### PR TITLE
Make base.encode support all 5 types

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,8 @@ AM_CFLAGS = \
 	$(libxs_CFLAGS) \
 	$(jansson_CFLAGS) \
 	$(yaml_CFLAGS) \
-	$(msgpack_CFLAGS)
+	$(msgpack_CFLAGS) \
+	$(libxml2_CFLAGS)
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
@@ -186,7 +187,8 @@ nmsg_base_nmsg_msg8_base_la_LIBADD = \
 	$(libwdns_LIBS) \
 	$(jansson_LIBS) \
 	$(yaml_LIBS) \
-	$(msgpack_LIBS)
+	$(msgpack_LIBS) \
+	$(libxml2_LIBS)
 nmsg_base_nmsg_msg8_base_la_SOURCES = \
 	libmy/list.h \
 	libmy/lookup3.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,8 @@ AM_CFLAGS = \
 	$(libprotobuf_c_CFLAGS) \
 	$(libwdns_CFLAGS) \
 	$(libxs_CFLAGS) \
-	$(jansson_CFLAGS)
+	$(jansson_CFLAGS) \
+	$(yaml_CFLAGS)
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
@@ -182,7 +183,8 @@ nmsg_base_nmsg_msg8_base_la_LDFLAGS = \
 nmsg_base_nmsg_msg8_base_la_LIBADD = \
 	$(libpcap_LIBS) \
 	$(libwdns_LIBS) \
-	$(jansson_LIBS)
+	$(jansson_LIBS) \
+	$(yaml_LIBS)
 nmsg_base_nmsg_msg8_base_la_SOURCES = \
 	libmy/list.h \
 	libmy/lookup3.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,7 +18,8 @@ AM_CFLAGS = \
 	$(libwdns_CFLAGS) \
 	$(libxs_CFLAGS) \
 	$(jansson_CFLAGS) \
-	$(yaml_CFLAGS)
+	$(yaml_CFLAGS) \
+	$(msgpack_CFLAGS)
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
@@ -184,7 +185,8 @@ nmsg_base_nmsg_msg8_base_la_LIBADD = \
 	$(libpcap_LIBS) \
 	$(libwdns_LIBS) \
 	$(jansson_LIBS) \
-	$(yaml_LIBS)
+	$(yaml_LIBS) \
+	$(msgpack_LIBS)
 nmsg_base_nmsg_msg8_base_la_SOURCES = \
 	libmy/list.h \
 	libmy/lookup3.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ AM_CFLAGS = \
 	$(libpcap_CFLAGS) \
 	$(libprotobuf_c_CFLAGS) \
 	$(libwdns_CFLAGS) \
-	$(libxs_CFLAGS)
+	$(libxs_CFLAGS) \
+	$(jansson_CFLAGS)
 AM_LDFLAGS = \
 	-Wl,--as-needed
 
@@ -180,7 +181,8 @@ nmsg_base_nmsg_msg8_base_la_LDFLAGS = \
 	$(MSG_LIBTOOL_FLAGS)
 nmsg_base_nmsg_msg8_base_la_LIBADD = \
 	$(libpcap_LIBS) \
-	$(libwdns_LIBS)
+	$(libwdns_LIBS) \
+	$(jansson_LIBS)
 nmsg_base_nmsg_msg8_base_la_SOURCES = \
 	libmy/list.h \
 	libmy/lookup3.c \

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AC_CHECK_MEMBER(
 
 ###
 ### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs,
-### libz, jansson, yaml-0.1, msgpack
+### libz, jansson, yaml-0.1, msgpack, libxml2
 ###
 
 MY_CHECK_LIBPCAP
@@ -138,6 +138,16 @@ if test "x$with_msgpack" != "xno"; then
     use_msgpack="true"
 else
     use_msgpack="false"
+fi
+
+AC_ARG_WITH([libxml2], AS_HELP_STRING([--without-libxml2], [Disable libxml2 support]))
+if test "x$with_libxml2" != "xno"; then
+    PKG_CHECK_MODULES([libxml2], [libxml-2.0 >= 2.8])
+    AC_DEFINE([HAVE_LIBXML2], [1], [Define to 1 if libxml2 support is enabled.])
+    dnl check for LIBXML_TREE_ENABLED LIBXML_OUTPUT_ENABLED
+    use_libxml2="true"
+else
+    use_libxml2="false"
 fi
 
 AC_CHECK_HEADER([zlib.h], [], [ AC_MSG_ERROR([required header file not found]) ])
@@ -206,6 +216,7 @@ AC_MSG_RESULT([
         jansson support:        ${use_jansson}
         yaml support:           ${use_yaml}
         msgpack support:        ${use_msgpack}
+	libxml2 support:        ${use_libxml2}
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}

--- a/configure.ac
+++ b/configure.ac
@@ -92,7 +92,7 @@ AC_CHECK_MEMBER(
 
 ###
 ### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs,
-### libz, jansson, yaml-0.1
+### libz, jansson, yaml-0.1, msgpack
 ###
 
 MY_CHECK_LIBPCAP
@@ -126,6 +126,18 @@ if test "x$with_yaml" != "xno"; then
     use_yaml="true"
 else
     use_yaml="false"
+fi
+
+AC_ARG_WITH([msgpack], AS_HELP_STRING([--without-msgpack], [Disable msgpack support]))
+if test "x$with_msgpack" != "xno"; then
+    dnl PKG_CHECK_MODULES([msgpack], [msgpack >= 0.5])
+    AC_CHECK_HEADERS([msgpack.h])
+    AC_DEFINE([HAVE_MSGPACK], [1], [Define to 1 if msgpack support is enabled.])
+    AC_SUBST([msgpack_CFLAGS], [])
+    AC_SUBST([msgpack_LIBS], [-lmsgpack])
+    use_msgpack="true"
+else
+    use_msgpack="false"
 fi
 
 AC_CHECK_HEADER([zlib.h], [], [ AC_MSG_ERROR([required header file not found]) ])
@@ -193,6 +205,7 @@ AC_MSG_RESULT([
         libxs support:          ${use_libxs}
         jansson support:        ${use_jansson}
         yaml support:           ${use_yaml}
+        msgpack support:        ${use_msgpack}
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,7 @@ AC_CHECK_MEMBER(
 )
 
 ###
-### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, libz
+### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, libz, jansson
 ###
 
 MY_CHECK_LIBPCAP
@@ -107,6 +107,15 @@ if test "x$with_libxs" != "xno"; then
     use_libxs="true"
 else
     use_libxs="false"
+fi
+
+AC_ARG_WITH([jansson], AS_HELP_STRING([--without-jansson], [Disable jansson support]))
+if test "x$with_jansson" != "xno"; then
+    PKG_CHECK_MODULES([jansson], [jansson >= 2.3])
+    AC_DEFINE([HAVE_JANSSON], [1], [Define to 1 if jansson support is enabled.])
+    use_jansson="true"
+else
+    use_jansson="false"
 fi
 
 AC_CHECK_HEADER([zlib.h], [], [ AC_MSG_ERROR([required header file not found]) ])
@@ -172,6 +181,7 @@ AC_MSG_RESULT([
 
         bigendian:              ${ac_cv_c_bigendian}
         libxs support:          ${use_libxs}
+	jansson support:	${use_jansson}
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}

--- a/configure.ac
+++ b/configure.ac
@@ -91,7 +91,8 @@ AC_CHECK_MEMBER(
 )
 
 ###
-### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, libz, jansson
+### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs,
+### libz, jansson, yaml-0.1
 ###
 
 MY_CHECK_LIBPCAP
@@ -116,6 +117,15 @@ if test "x$with_jansson" != "xno"; then
     use_jansson="true"
 else
     use_jansson="false"
+fi
+
+AC_ARG_WITH([yaml], AS_HELP_STRING([--without-yaml], [Disable yaml support]))
+if test "x$with_yaml" != "xno"; then
+    PKG_CHECK_MODULES([yaml], [yaml-0.1 >= 0.1.4])
+    AC_DEFINE([HAVE_YAML], [1], [Define to 1 if yaml support is enabled.])
+    use_yaml="true"
+else
+    use_yaml="false"
 fi
 
 AC_CHECK_HEADER([zlib.h], [], [ AC_MSG_ERROR([required header file not found]) ])
@@ -181,7 +191,8 @@ AC_MSG_RESULT([
 
         bigendian:              ${ac_cv_c_bigendian}
         libxs support:          ${use_libxs}
-	jansson support:	${use_jansson}
+        jansson support:        ${use_jansson}
+        yaml support:           ${use_yaml}
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}


### PR DESCRIPTION
TEXT is a bit weak as it does not render unprintable characters.  I would rather not reinvent the wheel there but I am not sure about what I can use that has already been written, preferably not by adding another  external dependency.

This PR does add four new optional dependencies (default=yes).  We could rewrite configure.ac to fall back on "not available" rather than emitting an error.

New dependencies: jansson, libyaml, msgpack-c, libxml2.