### PR TITLE
debian/nmsgtool: use alternatives

### DIFF
--- a/debian/nmsgtool.install
+++ b/debian/nmsgtool.install
@@ -1,0 +1,2 @@
+src/nmsgtool usr/lib/nmsgtool
+usr/share/man/man1

--- a/debian/nmsgtool.postinst
+++ b/debian/nmsgtool.postinst
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+update-alternatives --install /usr/bin/nmsgtool nmsgtool /usr/lib/nmsgtool/nmsgtool 10
+
+#DEBHELPER#
+
+exit 0

--- a/debian/nmsgtool.prerm
+++ b/debian/nmsgtool.prerm
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+update-alternatives --remove nmsgtool /usr/lib/nmsgtool/nmsgtool
+
+#DEBHELPER#
+
+exit 0


### PR DESCRIPTION
install nmsgtool to /usr/lib/nmsgtool/nmsgtool, use alternatives to
symlink