### PR TITLE
Make base msgmod package replace isc

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -83,6 +83,9 @@ Package: nmsg-msg8-module-base
 Section: net
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
+Provides: nmsg-msg8-module-isc
+Conflicts: nmsg-msg8-module-isc
+Replaces: nmsg-msg8-module-isc
 Description: base message module plugin for libnmsg
  This package extends the libnmsg runtime to support the following
  message types:


### PR DESCRIPTION
This will remove the obsolete isc msgmod package at upgrade time.

dpkg output:

(Reading database ... 297342 files and directories currently installed.)
Preparing to replace libnmsg6 0.7.3-1 (using libnmsg6_0.8.0~rc2-1_amd64.deb) ...
Unpacking replacement libnmsg6 ...
Preparing to replace libnmsg-dev 0.7.3-1 (using libnmsg-dev_0.8.0~rc2-1_amd64.deb) ...
Unpacking replacement libnmsg-dev ...
Preparing to replace nmsg-doc 0.7.3-1 (using nmsg-doc_0.8.0~rc2-1_all.deb) ...
Unpacking replacement nmsg-doc ...
Selecting previously unselected package nmsg-msg8-module-base.
dpkg: considering removing nmsg-msg8-module-isc in favour of nmsg-msg8-module-base ...
dpkg: yes, will remove nmsg-msg8-module-isc in favour of nmsg-msg8-module-base
Unpacking nmsg-msg8-module-base (from nmsg-msg8-module-base_0.8.0~rc2-1_amd64.deb) ...
Preparing to replace nmsgtool 0.7.3-1 (using nmsgtool_0.8.0~rc2-1_amd64.deb) ...
Unpacking replacement nmsgtool ...
Setting up nmsg-doc (0.8.0~rc2-1) ...
Setting up nmsg-msg8-module-base (0.8.0~rc2-1) ...
Setting up libnmsg6 (0.8.0~rc2-1) ...
Setting up libnmsg-dev (0.8.0~rc2-1) ...
Setting up nmsgtool (0.8.0~rc2-1) ...
Processing triggers for man-db ...
Processing triggers for libc-bin ...
