### PR TITLE
Check for null aliases list in nmsg_chalias_free.

### DIFF
--- a/nmsg/chalias.c
+++ b/nmsg/chalias.c
@@ -69,6 +69,8 @@ nmsg_chalias_lookup(const char *ch, char ***alias) {
 
 void
 nmsg_chalias_free(char ***alias) {
+	if (*alias == NULL)
+		return;
 	for (char **a = *alias; *a != NULL; a++)
 		free(*a);
 	free(*alias);


### PR DESCRIPTION
Fixes segfault when no chalias file is present, or chalias file cannot be opened.