### PR TITLE
Add json input and output support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -127,6 +127,7 @@ nmsg_libnmsg_la_SOURCES = \
 	nmsg/msgmod/msgmod.c \
 	nmsg/msgmod/transparent.c \
 	nmsg/msgmod/transparent.h \
+	nmsg/msgmod/transparent_json.c \
 	nmsg/msgmod/transparent_message.c \
 	nmsg/msgmod/transparent_module.c \
 	nmsg/msgmod/transparent_payload.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ AM_CFLAGS = \
 	$(libpcap_CFLAGS) \
 	$(libprotobuf_c_CFLAGS) \
 	$(libwdns_CFLAGS) \
-	$(libxs_CFLAGS)
+	$(libxs_CFLAGS) \
+	$(yajl_CFLAGS)
 AM_LDFLAGS =
 
 EXTRA_DIST += ChangeLog
@@ -74,7 +75,8 @@ nmsg_libnmsg_la_LDFLAGS = \
 nmsg_libnmsg_la_LIBADD = \
 	$(libpcap_LIBS) \
 	$(libprotobuf_c_LIBS) \
-	$(libxs_LIBS)
+	$(libxs_LIBS) \
+	$(yajl_LIBS)
 nmsg_libnmsg_la_SOURCES = \
 	libmy/crc32c.c libmy/crc32c.h libmy/crc32c-slicing.c libmy/crc32c-sse42.c \
 	libmy/list.h \
@@ -91,6 +93,7 @@ nmsg_libnmsg_la_SOURCES = \
 	nmsg/input.c \
 	nmsg/input_callback.c \
 	nmsg/input_frag.c \
+	nmsg/input_json.c \
 	nmsg/input_nmsg.c \
 	nmsg/input_nullnmsg.c \
 	nmsg/input_pcap.c \
@@ -105,6 +108,7 @@ nmsg_libnmsg_la_SOURCES = \
 	nmsg/nmsg_port_net.h \
 	nmsg/output.c \
 	nmsg/output_frag.c \
+	nmsg/output_json.c \
 	nmsg/output_nmsg.c \
 	nmsg/output_pres.c \
 	nmsg/payload.c \

--- a/README.md
+++ b/README.md
@@ -26,13 +26,15 @@ nmsg has the following external dependencies:
 
 * [wdns](https://github.com/farsightsec/wdns)
 
+* [yajl](http://lloyd.github.io/yajl/)
+
 * [libxs](http://www.crossroads.io/)
 
 * [zlib](http://www.zlib.net/)
 
 On Debian systems, the following packages should be installed, if available:
 
-    pkg-config libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libxs-dev zlib1g-dev
+    pkg-config libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libxs-dev libyajl-dev zlib1g-dev
 
 Note that on Debian systems, binary packages of nmsg and its dependencies are
 available from
@@ -43,6 +45,7 @@ Debian-based systems.
 On FreeBSD systems, the following ports should be installed, if available:
 
     devel/libxs
+    devel/yajl
     devel/pkgconf
     devel/protobuf
     devel/protobuf-c
@@ -56,6 +59,9 @@ After satisfying the prerequisites, `./configure && make && make install` should
 compile and install `libnmsg` and `nmsgtool` to `/usr/local`. If building from a
 git checkout, run the `./autogen.sh` command first to generate the `configure`
 script.
+
+Support for `yajl` can be disabled by passing the `--without-yajl`
+parameter to the `configure` script.
 
 Support for `libxs` can be disabled by passing the `--without-libxs` parameter
 to the `configure` script.

--- a/configure.ac
+++ b/configure.ac
@@ -81,7 +81,7 @@ AC_CHECK_MEMBER(
 )
 
 ###
-### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, libz
+### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, yajl, libz
 ###
 
 MY_CHECK_LIBPCAP
@@ -92,6 +92,14 @@ AS_IF([test -z "$PROTOC_C"],
       [AC_MSG_ERROR([The protoc-c program was not found. Please install the protobuf-c compiler!])])
 
 PKG_CHECK_MODULES([libwdns], [libwdns])
+AC_ARG_WITH([yajl], AS_HELP_STRING([--without-yajl], [Disable yajl support]))
+if test "x$with_yajl" != "xno"; then
+    PKG_CHECK_MODULES([yajl], [yajl >= 2])
+    AC_DEFINE([HAVE_YAJL], [1], [Define to 1 if yajl support is enabled.])
+    use_yajl="true"
+else
+    use_yajl="false"
+fi
 
 AC_ARG_WITH([libxs], AS_HELP_STRING([--without-libxs], [Disable libxs support]))
 if test "x$with_libxs" != "xno"; then
@@ -165,6 +173,7 @@ AC_MSG_RESULT([
 
         bigendian:              ${ac_cv_c_bigendian}
         libxs support:          ${use_libxs}
+        yajl support:        ${use_yajl}
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}

--- a/nmsg/input.c
+++ b/nmsg/input.c
@@ -151,8 +151,6 @@ nmsg_input_open_json(int fd) {
 		return (NULL);
 	}
 
-	/* TODO yajl? */
-
 	return (input);
 }
 #else /* HAVE_YAJL */
@@ -226,7 +224,6 @@ nmsg_input_close(nmsg_input_t *input) {
 	case nmsg_input_type_json:
 		fclose((*input)->json->fp);
 		free((*input)->json);
-		/* TODO yajl? */
 		break;
 	case nmsg_input_type_callback:
 		free((*input)->callback);

--- a/nmsg/input.h
+++ b/nmsg/input.h
@@ -57,6 +57,7 @@ typedef enum {
 	nmsg_input_type_stream,	/*%< NMSG payloads from file or socket */
 	nmsg_input_type_pcap,	/*%< pcap packets from file or interface */
 	nmsg_input_type_pres,	/*%< presentation form */
+	nmsg_input_type_json,	/*%< json form */
 	nmsg_input_type_callback
 } nmsg_input_type;
 
@@ -162,6 +163,16 @@ nmsg_input_open_null(void);
  */
 nmsg_input_t
 nmsg_input_open_pres(int fd, nmsg_msgmod_t msgmod);
+
+/**
+ * Initialize a new NMSG JSON form input from a file descriptor.
+ *
+ * \param[in] fd Readable file descriptor.
+ *
+ * \return Opaque pointer that is NULL on failure or non-NULL on success.
+ */
+nmsg_input_t
+nmsg_input_open_json(int fd);
 
 /**
  * Initialize a new NMSG pcap input from a pcap descriptor.

--- a/nmsg/input_json.c
+++ b/nmsg/input_json.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2009-2012 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Import. */
+
+#include "private.h"
+
+/* Internal functions. */
+
+#ifdef HAVE_YAJL
+nmsg_res
+_input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
+	return (nmsg_res_notimpl);
+}
+#else /* HAVE_YAJL */
+nmsg_res
+_input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
+	return (nmsg_res_notimpl);
+}
+#endif /* HAVE_YAJL */

--- a/nmsg/input_json.c
+++ b/nmsg/input_json.c
@@ -42,7 +42,7 @@ _input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
 			continue;
 		}
 
-		res = nmsg_message_from_json(line, msg);
+		res = nmsg_message_from_json(sb->data, msg);
 
 		nmsg_strbuf_destroy(&sb);
 

--- a/nmsg/input_json.c
+++ b/nmsg/input_json.c
@@ -44,6 +44,16 @@ _input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
 
 		res = nmsg_message_from_json(sb->data, msg);
 
+		/* skip failed messages */
+		if (res == nmsg_res_parse_error) {
+			if (nmsg_get_debug() >= 1) {
+				sb->pos[-1] = 0;
+				fprintf(stderr, "JSON parse error: \"%s\"\n", sb->data);
+			}
+			nmsg_strbuf_reset(sb);
+			continue;
+		}
+
 		nmsg_strbuf_destroy(&sb);
 
 		return (res);

--- a/nmsg/message.h
+++ b/nmsg/message.h
@@ -99,6 +99,34 @@ nmsg_message_from_raw_payload(unsigned vid, unsigned msgtype,
 			      const struct timespec *ts);
 
 /**
+ * Convert a json format line to an NMSG payload.
+ * Since the json format stream is line-delimited, not every line
+ * will necessarily result in a serialized message.
+ *
+ * This function will return the serialized payload. The caller is
+ * responsible for freeing the payload returned.
+ *
+ * Msgmods are not required to implement a function to convert json form
+ * data to payloads, in which case #nmsg_res_notimpl will be returned.
+ *
+ * \param[in] json Line of json form input of the type handled by 'mod'.
+ *
+ * \param[out] mod Message module.
+ *
+ * \param[out] pbuf Serialized payload.
+ *
+ * \param[out] sz Length of the serialized payload.
+ *
+ * \return #nmsg_res_success
+ * \return #nmsg_res_failure
+ * \return #nmsg_res_memfail
+ * \return #nmsg_res_notimpl
+ * \return #nmsg_res_parse_error
+ */
+nmsg_res
+nmsg_message_from_json(const char *json, nmsg_message_t *msg);
+
+/**
  * Destroy a message object and deallocate any resources associated with it.
  *
  * \param[in] msg Pointer to message object.

--- a/nmsg/message.h
+++ b/nmsg/message.h
@@ -121,6 +121,19 @@ nmsg_res
 nmsg_message_to_pres(nmsg_message_t msg, char **pres, const char *endline);
 
 /**
+ * Convert a message object to json format.
+ *
+ * \param[in] msg Message object.
+ * \param[out] pres Location to store malloc() allocated json format
+ *	string.
+ *
+ * \return #nmsg_res_success if presentation format string was successfully
+ *	rendered, non-success otherwise.
+ */
+nmsg_res
+nmsg_message_to_json(nmsg_message_t msg, char **json);
+
+/**
  * Return the message module object associated with a message object.
  */
 nmsg_msgmod_t

--- a/nmsg/msgmod.h
+++ b/nmsg/msgmod.h
@@ -209,6 +209,57 @@ nmsg_msgmod_pres_to_payload_finalize(nmsg_msgmod_t mod, void *clos, uint8_t **pb
 				     size_t *sz);
 
 /**
+ * Convert a json format line to an NMSG payload.
+ * Since the json format stream is line-delimited, not every line
+ * will necessarily result in a serialized message.
+ *
+ * When #nmsg_res_pbuf_ready is returned, the nmsg_msgmod_json_to_payload_finalize()
+ * function should be used to obtain the serialized payload.
+ *
+ * Msgmods are not required to implement a function to convert json form
+ * data to payloads, in which case #nmsg_res_notimpl will be returned.
+ *
+ * \param[in] mod Initialized msgmod.
+ *
+ * \param[in] clos Opaque pointer returned by the module initialization
+ *	function.
+ *
+ * \param[in] json Line of json form input of the type handled by 'mod'.
+ *
+ * \return #nmsg_res_success
+ * \return #nmsg_res_failure
+ * \return #nmsg_res_memfail
+ * \return #nmsg_res_notimpl
+ * \return #nmsg_res_parse_error
+ * \return #nmsg_res_pbuf_ready
+ */
+nmsg_res
+nmsg_msgmod_json_to_payload(nmsg_msgmod_t mod, void *clos, const char *json);
+
+/**
+ * After a call to nmsg_msgmod_json_to_payload() returns #nmsg_res_pbuf_ready, this
+ * function will return the serialized payload. The caller is responsible for
+ * freeing the payload returned.
+ *
+ * \param[in] mod Initialized msgmod.
+ *
+ * \param[in] clos Opaque pointer returned by the module initialization
+ *	function.
+ *
+ * \param[out] pbuf Serialized payload.
+ *
+ * \param[out] sz Length of the serialized payload.
+ *
+ * \return #nmsg_res_success
+ * \return #nmsg_res_failure
+ * \return #nmsg_res_memfail
+ * \return #nmsg_res_notimpl
+ */
+nmsg_res
+nmsg_msgmod_json_to_payload_finalize(nmsg_msgmod_t mod, void *clos, uint8_t **pbuf,
+				     size_t *sz);
+
+/**
  * Convert an IP datagram to an NMSG payload.
  *
  * Msgmods are not required to implement a function to convert IP datagrams to

--- a/nmsg/msgmod.h
+++ b/nmsg/msgmod.h
@@ -209,57 +209,6 @@ nmsg_msgmod_pres_to_payload_finalize(nmsg_msgmod_t mod, void *clos, uint8_t **pb
 				     size_t *sz);
 
 /**
- * Convert a json format line to an NMSG payload.
- * Since the json format stream is line-delimited, not every line
- * will necessarily result in a serialized message.
- *
- * When #nmsg_res_pbuf_ready is returned, the nmsg_msgmod_json_to_payload_finalize()
- * function should be used to obtain the serialized payload.
- *
- * Msgmods are not required to implement a function to convert json form
- * data to payloads, in which case #nmsg_res_notimpl will be returned.
- *
- * \param[in] mod Initialized msgmod.
- *
- * \param[in] clos Opaque pointer returned by the module initialization
- *	function.
- *
- * \param[in] json Line of json form input of the type handled by 'mod'.
- *
- * \return #nmsg_res_success
- * \return #nmsg_res_failure
- * \return #nmsg_res_memfail
- * \return #nmsg_res_notimpl
- * \return #nmsg_res_parse_error
- * \return #nmsg_res_pbuf_ready
- */
-nmsg_res
-nmsg_msgmod_json_to_payload(nmsg_msgmod_t mod, void *clos, const char *json);
-
-/**
- * After a call to nmsg_msgmod_json_to_payload() returns #nmsg_res_pbuf_ready, this
- * function will return the serialized payload. The caller is responsible for
- * freeing the payload returned.
- *
- * \param[in] mod Initialized msgmod.
- *
- * \param[in] clos Opaque pointer returned by the module initialization
- *	function.
- *
- * \param[out] pbuf Serialized payload.
- *
- * \param[out] sz Length of the serialized payload.
- *
- * \return #nmsg_res_success
- * \return #nmsg_res_failure
- * \return #nmsg_res_memfail
- * \return #nmsg_res_notimpl
- */
-nmsg_res
-nmsg_msgmod_json_to_payload_finalize(nmsg_msgmod_t mod, void *clos, uint8_t **pbuf,
-				     size_t *sz);
-
-/**
  * Convert an IP datagram to an NMSG payload.
  *
  * Msgmods are not required to implement a function to convert IP datagrams to

--- a/nmsg/msgmod/message.c
+++ b/nmsg/msgmod/message.c
@@ -329,6 +329,20 @@ nmsg_message_to_pres(struct nmsg_message *msg, char **pres, const char *endline)
 }
 
 nmsg_res
+nmsg_message_to_json(nmsg_message_t msg, char **json) {
+	if (msg->mod == NULL)
+		return (nmsg_res_failure);
+	switch (msg->mod->plugin->type) {
+	case nmsg_msgmod_type_transparent:
+		return (_nmsg_message_payload_to_json(msg, json));
+	case nmsg_msgmod_type_opaque:
+		return (nmsg_res_notimpl);
+	default:
+		return (nmsg_res_notimpl);
+	}
+}
+
+nmsg_res
 nmsg_message_add_allocation(struct nmsg_message *msg, void *ptr) {
 	void *tmp;
 

--- a/nmsg/msgmod/message.c
+++ b/nmsg/msgmod/message.c
@@ -207,6 +207,218 @@ nmsg_message_from_raw_payload(unsigned vid, unsigned msgtype,
 	return (msg);
 }
 
+#ifdef HAVE_YAJL
+nmsg_res
+nmsg_message_from_json(const char * json, nmsg_message_t *msg)
+{
+	nmsg_res res;
+	yajl_val node;
+
+	yajl_val msgtype_v;
+	const char *msgtype_path[] = { "msgtype", (const char*) 0 };
+	struct nmsg_msgmod *mod;
+
+	yajl_val source_v;
+	const char *source_path[] = { "source", (const char*) 0 };
+
+	yajl_val operator_v;
+	const char *operator_path[] = { "operator", (const char*) 0 };
+
+	yajl_val group_v;
+	const char *group_path[] = { "group", (const char*) 0 };
+
+	yajl_val time_v;
+	const char *time_path[] = { "time", (const char*) 0 };
+	struct timespec ts;
+
+	yajl_val message_v;
+	const char *message_path[] = { "message", (const char*) 0 };
+
+	*msg = NULL;
+
+	node = yajl_tree_parse(json, 0, 0);
+
+	if (node == NULL) {
+		return (nmsg_res_parse_error);
+	}
+
+	msgtype_v = yajl_tree_get(node, msgtype_path, yajl_t_string);
+	if (msgtype_v == NULL) {
+		res = (nmsg_res_parse_error);
+		goto err;
+	} else {
+		char *msgtype_orig, *msgtype_copy = NULL, *vname, *mname;
+
+		msgtype_orig = YAJL_GET_STRING(msgtype_v);
+		msgtype_copy = strdup(msgtype_orig);
+		if (msgtype_copy == NULL) {
+			res = (nmsg_res_memfail);
+			goto err;
+		}
+
+		vname = msgtype_copy;
+		mname = strchr(msgtype_copy, '.');
+		if (mname == NULL) {
+			res = (nmsg_res_parse_error);
+			free (msgtype_copy);
+			goto err;
+		}
+		*mname = 0;
+		mname++;
+
+		mod = nmsg_msgmod_lookup_byname(vname, mname);
+		if (mod == NULL) {
+			res = (nmsg_res_parse_error);
+			free (msgtype_copy);
+			goto err;
+		}
+
+		free (msgtype_copy);
+	}
+
+	/* TODO check if mod is transparent.  code should probably split off into transparent_json here. */
+
+	*msg = nmsg_message_init(mod);
+	if (*msg == NULL) {
+		res = (nmsg_res_failure);
+		goto err;
+	}
+
+	source_v = yajl_tree_get(node, source_path, yajl_t_any);
+	if (source_v) {
+		uint32_t source;
+
+		if (YAJL_IS_STRING(source_v)) {
+			sscanf(YAJL_GET_STRING(source_v), "%x", &source);
+		} else if (YAJL_IS_INTEGER(source_v)) {
+			source = YAJL_GET_INTEGER(source_v);
+		} else {
+			res = (nmsg_res_parse_error);
+			goto err;
+		}
+		nmsg_message_set_source(*msg, source);
+	}
+
+	operator_v = yajl_tree_get(node, operator_path, yajl_t_any);
+	if (operator_v) {
+		uint32_t operator;
+
+		if (YAJL_IS_STRING(operator_v)) {
+			operator = nmsg_alias_by_value(nmsg_alias_operator, YAJL_GET_STRING(operator_v));
+		} else if (YAJL_IS_INTEGER(operator_v)) {
+			operator = YAJL_GET_INTEGER(operator_v);
+		} else {
+			res = (nmsg_res_parse_error);
+			goto err;
+		}
+		nmsg_message_set_operator(*msg, operator);
+	}
+
+	group_v = yajl_tree_get(node, group_path, yajl_t_any);
+	if (group_v) {
+		uint32_t group;
+
+		if (YAJL_IS_STRING(group_v)) {
+			group = nmsg_alias_by_value(nmsg_alias_group, YAJL_GET_STRING(group_v));
+		} else if (YAJL_IS_INTEGER(group_v)) {
+			group = YAJL_GET_INTEGER(group_v);
+		} else {
+			res = (nmsg_res_parse_error);
+			goto err;
+		}
+		nmsg_message_set_group(*msg, group);
+	}
+
+	time_v = yajl_tree_get(node, time_path, yajl_t_any);
+	if (time_v) {
+		if (YAJL_IS_STRING(time_v)) {
+			struct tm tm;
+			char * remainder;
+
+			remainder = strptime(YAJL_GET_STRING(time_v), "%Y-%m-%d %T", &tm);
+			if (remainder == NULL) {
+				res = (nmsg_res_parse_error);
+				goto err;
+			}
+
+			ts.tv_sec = timegm(&tm);
+
+			if (sscanf(remainder, ".%ld", &ts.tv_nsec) == 0) {
+				ts.tv_nsec = 0;
+			}
+		} else if (YAJL_IS_INTEGER(time_v)) {
+			ts.tv_sec = YAJL_GET_INTEGER(time_v);
+			ts.tv_nsec = 0;
+		} else if (YAJL_IS_DOUBLE(time_v)) {
+			nmsg_timespec_from_double(YAJL_GET_DOUBLE(time_v), &ts);
+		} else {
+			res = (nmsg_res_parse_error);
+			goto err;
+		}
+	} else {
+		nmsg_timespec_get(&ts);
+	}
+	nmsg_message_set_time(*msg, &ts);
+
+	message_v = yajl_tree_get(node, message_path, yajl_t_object);
+	if (message_v) {
+		size_t n;
+		struct nmsg_msgmod_field *field = NULL;
+
+		for (n = 0; n < mod->n_fields; n++) {
+			const char* field_path[] = { (const char*) 0, (const char*)0 };
+			yajl_val field_v;
+
+			field = &mod->fields[n];
+
+			if (field->descr == NULL) {
+				continue;
+			}
+			field_path[0] = field->descr->name;
+
+			if (PBFIELD_REPEATED(field)) {
+				yajl_val array_v;
+				size_t v;
+
+				array_v = yajl_tree_get(message_v, field_path, yajl_t_array);
+				for (v = 0; v < YAJL_GET_ARRAY(array_v)->len; v++) {
+					field_v = YAJL_GET_ARRAY(array_v)->values[v];
+					//res = nmsg_message_set_field_by_idx(*msg, n, v, /* data */ 0, /* len */ 0);
+					if (res != nmsg_res_success) {
+						goto err;
+					}
+				}
+			} else {
+				field_v = yajl_tree_get(message_v, field_path, yajl_t_any);
+				//res = nmsg_message_set_field_by_idx(*msg, n, 0, /* data */ 0, /* len */ 0);
+				if (res != nmsg_res_success) {
+					goto err;
+				}
+			}
+		}
+	} else {
+		res = (nmsg_res_parse_error);
+		goto err;
+	}
+
+	yajl_tree_free(node);
+
+	return (nmsg_res_success);
+err:
+	if (*msg != NULL) {
+		nmsg_message_destroy(msg);
+	}
+
+	yajl_tree_free(node);
+	return (res);
+}
+#else /* HAVE_YAJL */
+nmsg_res
+nmsg_json_to_payload(const char * json, struct nmsg_msgmod **mod, uint8_t **pbuf, size_t *sz)
+	return (nmsg_res_notimpl);
+}
+#endif /* HAVE_YAJL */
+
 nmsg_res
 _nmsg_message_init_message(struct nmsg_message *msg) {
 	if (msg->mod->plugin->type == nmsg_msgmod_type_transparent &&

--- a/nmsg/msgmod/msgmod.c
+++ b/nmsg/msgmod/msgmod.c
@@ -77,6 +77,30 @@ nmsg_msgmod_pres_to_payload_finalize(struct nmsg_msgmod *mod, void *clos,
 }
 
 nmsg_res
+nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *clos, const char *json) {
+	switch (mod->plugin->type) {
+	case nmsg_msgmod_type_transparent:
+		return (_nmsg_msgmod_json_to_payload(mod, clos, json));
+	case nmsg_msgmod_type_opaque:
+	default:
+		return (nmsg_res_notimpl);
+	}
+}
+
+nmsg_res
+nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *clos,
+				     uint8_t **pbuf, size_t *sz)
+{
+	switch (mod->plugin->type) {
+	case nmsg_msgmod_type_transparent:
+		return (_nmsg_msgmod_json_to_payload_finalize(mod, clos, pbuf, sz));
+	case nmsg_msgmod_type_opaque:
+	default:
+		return (nmsg_res_notimpl);
+	}
+}
+
+nmsg_res
 nmsg_msgmod_ipdg_to_payload(struct nmsg_msgmod *mod, void *clos,
 			    const struct nmsg_ipdg *dg,
 			    uint8_t **pbuf, size_t *sz)

--- a/nmsg/msgmod/msgmod.c
+++ b/nmsg/msgmod/msgmod.c
@@ -77,30 +77,6 @@ nmsg_msgmod_pres_to_payload_finalize(struct nmsg_msgmod *mod, void *clos,
 }
 
 nmsg_res
-nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *clos, const char *json) {
-	switch (mod->plugin->type) {
-	case nmsg_msgmod_type_transparent:
-		return (_nmsg_msgmod_json_to_payload(mod, clos, json));
-	case nmsg_msgmod_type_opaque:
-	default:
-		return (nmsg_res_notimpl);
-	}
-}
-
-nmsg_res
-nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *clos,
-				     uint8_t **pbuf, size_t *sz)
-{
-	switch (mod->plugin->type) {
-	case nmsg_msgmod_type_transparent:
-		return (_nmsg_msgmod_json_to_payload_finalize(mod, clos, pbuf, sz));
-	case nmsg_msgmod_type_opaque:
-	default:
-		return (nmsg_res_notimpl);
-	}
-}
-
-nmsg_res
 nmsg_msgmod_ipdg_to_payload(struct nmsg_msgmod *mod, void *clos,
 			    const struct nmsg_ipdg *dg,
 			    uint8_t **pbuf, size_t *sz)

--- a/nmsg/msgmod/msgmod.c
+++ b/nmsg/msgmod/msgmod.c
@@ -152,6 +152,7 @@ err:
 void
 _nmsg_msgmod_stop(struct nmsg_msgmod **mod) {
 	free((*mod)->fields);
+	free((*mod)->fields_idx);
 	free(*mod);
 	*mod = NULL;
 }

--- a/nmsg/msgmod/transparent.c
+++ b/nmsg/msgmod/transparent.c
@@ -21,26 +21,31 @@
 static int
 _nmsg_msgmod_field_cmp(const void *v1, const void *v2)
 {
-	const struct nmsg_msgmod_field *f1 = (const struct nmsg_msgmod_field *) v1;
-	const struct nmsg_msgmod_field *f2 = (const struct nmsg_msgmod_field *) v2;
+	const struct nmsg_msgmod_field **f1 = (const struct nmsg_msgmod_field **) v1;
+	const struct nmsg_msgmod_field **f2 = (const struct nmsg_msgmod_field **) v2;
 
-	return (strcmp(f1->name, f2->name));
+	return (strcmp((*f1)->name, (*f2)->name));
 }
 
 struct nmsg_msgmod_field *
 _nmsg_msgmod_lookup_field(struct nmsg_msgmod *mod, const char *name) {
-	struct nmsg_msgmod_field *res;
-	struct nmsg_msgmod_field key;
+	struct nmsg_msgmod_field **res;
+	struct nmsg_msgmod_field key, *key_ptr;
 
 	key.name = name;
+	key_ptr = &key;
 
-	res = bsearch(&key,
-		      &mod->fields[0],
+	res = bsearch(&key_ptr,
+		      &mod->fields_idx[0],
 		      mod->n_fields,
-		      sizeof(struct nmsg_msgmod_field),
+		      sizeof(struct nmsg_msgmod_field*),
 		      _nmsg_msgmod_field_cmp);
 
-	return (res);
+	if (res) {
+		return (*res);
+	} else {
+		return NULL;
+	}
 }
 
 nmsg_res
@@ -93,9 +98,18 @@ _nmsg_msgmod_load_field_descriptors(struct nmsg_msgmod *mod) {
 	}
 
 	/* sort field descriptors by name */
-	qsort(&mod->fields[0],
+	mod->fields_idx = calloc(1, sizeof(struct nmsg_msgmod_field*) * (mod->n_fields + 1));
+	if (mod->fields_idx == NULL) {
+		free(mod->fields);
+		return (nmsg_res_memfail);
+	}
+
+	for(i = 0; i < mod->n_fields; i++) {
+		mod->fields_idx[i] = &mod->fields[i];
+	}
+	qsort(&mod->fields_idx[0],
 	      mod->n_fields,
-	      sizeof(struct nmsg_msgmod_field),
+	      sizeof(struct nmsg_msgmod_field*),
 	      _nmsg_msgmod_field_cmp);
 
 	return (nmsg_res_success);

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -76,9 +76,10 @@ _nmsg_msgmod_json_to_message(void * /* yajl_val */ val,
 			     struct nmsg_message *msg);
 
 nmsg_res
-_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
-				  struct nmsg_msgmod_clos *clos,
-				  const char *value, void *ptr, int *qptr);
+_nmsg_msgmod_json_to_payload_load(struct nmsg_message *msg,
+				  struct nmsg_msgmod_field *field,
+				  unsigned field_idx, unsigned val_idx,
+				  void * /* yajl_val */ val);
 
 nmsg_res
 _nmsg_msgmod_load_field_descriptors(struct nmsg_msgmod *mod);

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -67,6 +67,19 @@ nmsg_res
 _nmsg_message_payload_to_json(struct nmsg_message *msg, char **json);
 
 nmsg_res
+_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *pres);
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
+				  struct nmsg_msgmod_clos *clos,
+				  const char *value, void *ptr, int *qptr);
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
+				      uint8_t **pbuf, size_t *sz);
+
+
+nmsg_res
 _nmsg_message_payload_to_json_load(struct nmsg_message *msg,
 				   struct nmsg_msgmod_field *field, void *ptr,
 				   void * /* yajl_gen */ gen);

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -67,6 +67,11 @@ nmsg_res
 _nmsg_message_payload_to_json(struct nmsg_message *msg, char **json);
 
 nmsg_res
+_nmsg_message_payload_to_json_load(struct nmsg_message *msg,
+				   struct nmsg_msgmod_field *field, void *ptr,
+				   void * /* yajl_gen */ gen);
+
+nmsg_res
 _nmsg_msgmod_load_field_descriptors(struct nmsg_msgmod *mod);
 
 struct nmsg_msgmod_field *

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -64,6 +64,9 @@ _nmsg_msgmod_pres_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
 				      uint8_t **pbuf, size_t *sz);
 
 nmsg_res
+_nmsg_message_payload_to_json(struct nmsg_message *msg, char **json);
+
+nmsg_res
 _nmsg_msgmod_load_field_descriptors(struct nmsg_msgmod *mod);
 
 struct nmsg_msgmod_field *

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -67,22 +67,14 @@ nmsg_res
 _nmsg_message_payload_to_json(struct nmsg_message *msg, char **json);
 
 nmsg_res
-_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *pres);
+_nmsg_message_payload_to_json_load(struct nmsg_message *msg,
+				   struct nmsg_msgmod_field *field, void *ptr,
+				   void * /* yajl_gen */ gen);
 
 nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,
 				  const char *value, void *ptr, int *qptr);
-
-nmsg_res
-_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
-				      uint8_t **pbuf, size_t *sz);
-
-
-nmsg_res
-_nmsg_message_payload_to_json_load(struct nmsg_message *msg,
-				   struct nmsg_msgmod_field *field, void *ptr,
-				   void * /* yajl_gen */ gen);
 
 nmsg_res
 _nmsg_msgmod_load_field_descriptors(struct nmsg_msgmod *mod);

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -72,6 +72,10 @@ _nmsg_message_payload_to_json_load(struct nmsg_message *msg,
 				   void * /* yajl_gen */ gen);
 
 nmsg_res
+_nmsg_msgmod_json_to_message(void * /* yajl_val */ val,
+			     struct nmsg_message *msg);
+
+nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,
 				  const char *value, void *ptr, int *qptr);

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -100,8 +100,7 @@ _nmsg_msgmod_json_to_payload_load(struct nmsg_message *msg,
 
 	/* fields with custom printers and no parsers cannot be processed */
 	if (field->print != NULL) {
-		/* TODO switch to parse error */
-		return (nmsg_res_success);
+		return (nmsg_res_failure);
 	}
 
 	switch (field->type) {

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -74,12 +74,30 @@ _nmsg_msgmod_json_to_payload_load(struct nmsg_message *msg,
 		return (nmsg_res_success);
 	}
 
-	/* TODO msgmod field parser */
+	if (field->parse != NULL) {
+		if (YAJL_IS_STRING(field_v)) {
+			char * str = YAJL_GET_STRING(field_v);
+			uint8_t * ptr = NULL;
+			size_t len = 0;
+
+			res = field->parse(msg, field, str, (void*)&ptr, &len, "");
+			if (res != nmsg_res_success) {
+				return (res);
+			}
+
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, ptr, len);
+			free (ptr);
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+	}
+
+	/* fields with custom printers and no parsers cannot be processed */
 	if (field->print != NULL) {
+		/* TODO switch to parse error */
 		return (nmsg_res_success);
 	}
 
-	//res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, /* data */ 0, /* len */ 0);
 	switch (field->type) {
 	case nmsg_msgmod_ft_bool: {
 		protobuf_c_boolean b;

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -41,12 +41,18 @@ _nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
 			yajl_val array_v;
 			size_t v;
 
-			array_v = yajl_tree_get(message_v, field_path, yajl_t_array);
-			for (v = 0; v < YAJL_GET_ARRAY(array_v)->len; v++) {
-				field_v = YAJL_GET_ARRAY(array_v)->values[v];
-				res = _nmsg_msgmod_json_to_payload_load(msg, field, n, v, field_v);
-				if (res != nmsg_res_success) {
-					return (res);
+			array_v = yajl_tree_get(message_v, field_path, yajl_t_any);
+			if (array_v) {
+				if (! YAJL_IS_ARRAY(array_v)) {
+					return (nmsg_res_parse_error);
+				}
+
+				for (v = 0; v < YAJL_GET_ARRAY(array_v)->len; v++) {
+					field_v = YAJL_GET_ARRAY(array_v)->values[v];
+					res = _nmsg_msgmod_json_to_payload_load(msg, field, n, v, field_v);
+					if (res != nmsg_res_success) {
+						return (res);
+					}
 				}
 			}
 		} else {

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2009-2012 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "private.h"
+
+#include "transparent.h"
+
+#ifdef HAVE_YAJL
+nmsg_res
+_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *json) {
+	return (nmsg_res_notimpl);
+}
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
+				  struct nmsg_msgmod_clos *clos,
+				  const char *value, void *ptr, int *qptr)
+{
+	return (nmsg_res_notimpl);
+}
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
+				      uint8_t **pbuf, size_t *sz)
+{
+	return (nmsg_res_notimpl);
+}
+#else /* HAVE_YAJL */
+nmsg_res
+_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *json) {
+	return (nmsg_res_notimpl);
+}
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
+				  struct nmsg_msgmod_clos *clos,
+				  const char *value, void *ptr, int *qptr)
+{
+	return (nmsg_res_notimpl);
+}
+
+nmsg_res
+_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
+				      uint8_t **pbuf, size_t *sz)
+{
+	return (nmsg_res_notimpl);
+}
+#endif /* HAVE_YAJL */

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -20,6 +20,48 @@
 
 #ifdef HAVE_YAJL
 nmsg_res
+_nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
+	yajl_val message_v = (yajl_val) val;
+	nmsg_res res;
+	size_t n;
+	struct nmsg_msgmod_field *field = NULL;
+
+	for (n = 0; n < msg->mod->n_fields; n++) {
+		const char* field_path[] = { (const char*) 0, (const char*)0 };
+		yajl_val field_v;
+
+		field = &msg->mod->fields[n];
+
+		if (field->descr == NULL) {
+			continue;
+		}
+		field_path[0] = field->descr->name;
+
+		if (PBFIELD_REPEATED(field)) {
+			yajl_val array_v;
+			size_t v;
+
+			array_v = yajl_tree_get(message_v, field_path, yajl_t_array);
+			for (v = 0; v < YAJL_GET_ARRAY(array_v)->len; v++) {
+				field_v = YAJL_GET_ARRAY(array_v)->values[v];
+				//res = nmsg_message_set_field_by_idx(*msg, n, v, /* data */ 0, /* len */ 0);
+				if (res != nmsg_res_success) {
+					return (res);
+				}
+			}
+		} else {
+			field_v = yajl_tree_get(message_v, field_path, yajl_t_any);
+			//res = nmsg_message_set_field_by_idx(*msg, n, 0, /* data */ 0, /* len */ 0);
+			if (res != nmsg_res_success) {
+				return (res);
+			}
+		}
+	}
+
+	return (nmsg_res_success);
+}
+
+nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,
 				  const char *value, void *ptr, int *qptr)
@@ -28,6 +70,11 @@ _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 }
 
 #else /* HAVE_YAJL */
+nmsg_res
+_nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
+	return (nmsg_res_notimpl);
+}
+
 nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -20,11 +20,6 @@
 
 #ifdef HAVE_YAJL
 nmsg_res
-_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *json) {
-	return (nmsg_res_notimpl);
-}
-
-nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,
 				  const char *value, void *ptr, int *qptr)
@@ -32,29 +27,11 @@ _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 	return (nmsg_res_notimpl);
 }
 
-nmsg_res
-_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
-				      uint8_t **pbuf, size_t *sz)
-{
-	return (nmsg_res_notimpl);
-}
 #else /* HAVE_YAJL */
 nmsg_res
-_nmsg_msgmod_json_to_payload(struct nmsg_msgmod *mod, void *cl, const char *json) {
-	return (nmsg_res_notimpl);
-}
-
-nmsg_res
 _nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
 				  struct nmsg_msgmod_clos *clos,
 				  const char *value, void *ptr, int *qptr)
-{
-	return (nmsg_res_notimpl);
-}
-
-nmsg_res
-_nmsg_msgmod_json_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
-				      uint8_t **pbuf, size_t *sz)
 {
 	return (nmsg_res_notimpl);
 }

--- a/nmsg/msgmod/transparent_json.c
+++ b/nmsg/msgmod/transparent_json.c
@@ -44,14 +44,14 @@ _nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
 			array_v = yajl_tree_get(message_v, field_path, yajl_t_array);
 			for (v = 0; v < YAJL_GET_ARRAY(array_v)->len; v++) {
 				field_v = YAJL_GET_ARRAY(array_v)->values[v];
-				//res = nmsg_message_set_field_by_idx(*msg, n, v, /* data */ 0, /* len */ 0);
+				res = _nmsg_msgmod_json_to_payload_load(msg, field, n, v, field_v);
 				if (res != nmsg_res_success) {
 					return (res);
 				}
 			}
 		} else {
 			field_v = yajl_tree_get(message_v, field_path, yajl_t_any);
-			//res = nmsg_message_set_field_by_idx(*msg, n, 0, /* data */ 0, /* len */ 0);
+			res = _nmsg_msgmod_json_to_payload_load(msg, field, n, 0, field_v);
 			if (res != nmsg_res_success) {
 				return (res);
 			}
@@ -62,11 +62,206 @@ _nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
 }
 
 nmsg_res
-_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
-				  struct nmsg_msgmod_clos *clos,
-				  const char *value, void *ptr, int *qptr)
+_nmsg_msgmod_json_to_payload_load(struct nmsg_message *msg,
+				  struct nmsg_msgmod_field *field,
+                                  unsigned field_idx, unsigned val_idx,
+                                  void * val)
 {
-	return (nmsg_res_notimpl);
+	yajl_val field_v = (yajl_val) val;
+	nmsg_res res;
+
+	if (field_v == NULL) {
+		return (nmsg_res_success);
+	}
+
+	/* TODO msgmod field parser */
+	if (field->print != NULL) {
+		return (nmsg_res_success);
+	}
+
+	//res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, /* data */ 0, /* len */ 0);
+	switch (field->type) {
+	case nmsg_msgmod_ft_bool: {
+		protobuf_c_boolean b;
+
+		if (YAJL_IS_TRUE(field_v)) {
+			b = true;
+		} else if (YAJL_IS_FALSE(field_v)) {
+			b = false;
+		} else if (YAJL_IS_INTEGER(field_v)) {
+			b = YAJL_GET_INTEGER(field_v) != 0;
+		} else if (YAJL_IS_STRING(field_v)) {
+			char * str = YAJL_GET_STRING(field_v);
+			if (strcasecmp("true", str)) {
+				b = true;
+			} else if (strcasecmp("false", str)) {
+				b = false;
+			} else {
+				return (nmsg_res_parse_error);
+			}
+		}
+
+		res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &b, sizeof(b));
+		return (res);
+		break;
+	}
+	case nmsg_msgmod_ft_bytes: {
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_enum: {
+		ProtobufCEnumDescriptor *enum_descr;
+		unsigned enum_value;
+
+		enum_descr = (ProtobufCEnumDescriptor *) field->descr->descriptor;
+
+		if (YAJL_IS_STRING(field_v)) {
+			char * str = YAJL_GET_STRING(field_v);
+			size_t i;
+
+			for (i = 0; i < enum_descr->n_values; i++) {
+				if (strcasecmp(enum_descr->values[i].name, str) == 0) {
+					enum_value = enum_descr->values[i].value;
+					break;
+				}
+			}
+			if (i >= enum_descr->n_values) {
+				return (nmsg_res_parse_error);
+			}
+		} else if (YAJL_IS_INTEGER(field_v)) {
+			enum_value = YAJL_GET_INTEGER(field_v);
+			if (enum_value < 0 || enum_value >= enum_descr->n_values) {
+				return (nmsg_res_parse_error);
+			}
+		} else {
+			return (nmsg_res_parse_error);
+		}
+		res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &enum_value, sizeof(enum_value));
+		return (res);
+		break;
+	}
+	case nmsg_msgmod_ft_string:
+	case nmsg_msgmod_ft_mlstring: {
+		if (! YAJL_IS_STRING(field_v)) {
+			return (nmsg_res_parse_error);
+		}
+		char * str = YAJL_GET_STRING(field_v);
+		size_t len = strlen(str) + 1; /* \0 terminated */
+		res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) str, len);
+		return (res);
+		break;
+	}
+	case nmsg_msgmod_ft_ip: {
+		char addr[16];
+
+		if (YAJL_IS_STRING(field_v)) {
+			char * str = YAJL_GET_STRING(field_v);
+
+			if (inet_pton(AF_INET, str, addr) == 1) {
+				res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) addr, 4);
+				return (res);
+			} else if (inet_pton(AF_INET6, str, addr) == 1) {
+				res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) addr, 16);
+				return (res);
+			}
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_uint16: {
+		uint32_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			if (YAJL_GET_INTEGER(field_v)> UINT16_MAX)
+				return (nmsg_res_parse_error);
+			intval = (uint32_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_uint32: {
+		uint32_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			if (YAJL_GET_INTEGER(field_v)> UINT32_MAX)
+				return (nmsg_res_parse_error);
+			intval = (uint32_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_uint64: {
+		uint64_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			intval = (uint64_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		} else if (YAJL_IS_NUMBER(field_v)) {
+			char * str = YAJL_GET_NUMBER(field_v);
+			if (sscanf(str, "%" PRIu64, &intval)) {
+				res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+				return (res);
+			}
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_int16: {
+		int32_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			if (YAJL_GET_INTEGER(field_v) > INT16_MAX || YAJL_GET_INTEGER(field_v) < INT16_MIN)
+				return (nmsg_res_parse_error);
+			intval = (int32_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_int32: {
+		int32_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			if (YAJL_GET_INTEGER(field_v) > INT32_MAX || YAJL_GET_INTEGER(field_v) < INT32_MIN)
+				return (nmsg_res_parse_error);
+			intval = (int32_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_int64: {
+		int64_t intval;
+
+		if (YAJL_IS_INTEGER(field_v)) {
+			intval = (int64_t) YAJL_GET_INTEGER(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &intval, sizeof(intval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	case nmsg_msgmod_ft_double: {
+		double dval;
+
+		if (YAJL_IS_DOUBLE(field_v)) {
+			dval = YAJL_GET_DOUBLE(field_v);
+			res = nmsg_message_set_field_by_idx(msg, field_idx, val_idx, (const uint8_t*) &dval, sizeof(dval));
+			return (res);
+		}
+		return (nmsg_res_parse_error);
+		break;
+	}
+	} /* switch */
+
+	return (nmsg_res_failure);
 }
 
 #else /* HAVE_YAJL */
@@ -76,9 +271,10 @@ _nmsg_msgmod_json_to_message(void * val, struct nmsg_message *msg) {
 }
 
 nmsg_res
-_nmsg_msgmod_json_to_payload_load(struct nmsg_msgmod_field *field,
-				  struct nmsg_msgmod_clos *clos,
-				  const char *value, void *ptr, int *qptr)
+_nmsg_msgmod_json_to_payload_load(struct nmsg_message *msg,
+				  struct nmsg_msgmod_field *field,
+                                  unsigned field_idx, unsigned val_idx,
+                                  void * val)
 {
 	return (nmsg_res_notimpl);
 }

--- a/nmsg/msgmod/transparent_payload.c
+++ b/nmsg/msgmod/transparent_payload.c
@@ -553,6 +553,9 @@ _nmsg_message_payload_to_json_load(struct nmsg_message *msg,
 
 	switch(field->type) {
 	case nmsg_msgmod_ft_bytes:
+		status = yajl_gen_null(g);
+		assert(status == yajl_gen_status_ok);
+		break;
 	case nmsg_msgmod_ft_string:
 	case nmsg_msgmod_ft_mlstring: {
 		bdata = (ProtobufCBinaryData *) ptr;

--- a/nmsg/msgmod/transparent_payload.c
+++ b/nmsg/msgmod/transparent_payload.c
@@ -608,7 +608,7 @@ _nmsg_message_payload_to_json_load(struct nmsg_message *msg,
 			status = yajl_gen_string(g, (const unsigned char*)sip, strlen(sip));
 			assert(status == yajl_gen_status_ok);
 		} else {
-			status = yajl_gen_number(g, (const char*)bdata->data, bdata->len);
+			status = yajl_gen_null(g);
 			assert(status == yajl_gen_status_ok);
 		}
 		break;

--- a/nmsg/msgmod/transparent_payload.c
+++ b/nmsg/msgmod/transparent_payload.c
@@ -628,8 +628,21 @@ _nmsg_message_payload_to_json_load(struct nmsg_message *msg,
 		break;
 	}
 	case nmsg_msgmod_ft_uint64: {
-		status = yajl_gen_number(g, ptr, sizeof(uint64_t));
+		uint64_t val;
+		struct nmsg_strbuf *sb = NULL;
+
+		sb = nmsg_strbuf_init();
+		if (sb == NULL)
+			return (nmsg_res_memfail);
+
+		memcpy(&val, ptr, sizeof(uint64_t));
+		nmsg_strbuf_append(sb, "%" PRIu64, val);
+
+		status = yajl_gen_number(g, (const char*) sb->data, strlen(sb->data));
 		assert(status == yajl_gen_status_ok);
+
+		nmsg_strbuf_destroy(&sb);
+
 		break;
 	}
 	case nmsg_msgmod_ft_int16: {

--- a/nmsg/msgmod/transparent_payload.c
+++ b/nmsg/msgmod/transparent_payload.c
@@ -248,3 +248,278 @@ _nmsg_message_payload_to_pres_load(struct nmsg_message *msg,
 
 	return (nmsg_res_success);
 }
+
+#ifdef HAVE_YAJL
+
+#define add_yajl_string(g, s) do {                                              \
+	yajl_gen_status g_status;                                               \
+	g_status = yajl_gen_string(g, (const unsigned  char *) s, strlen(s));   \
+	assert(g_status == yajl_gen_status_ok);                                 \
+} while (0)
+
+static void
+callback_print_yajl_ubuf(void *ctx, const char *str, size_t len)
+{
+        ubuf *u = (ubuf *) ctx;
+        ubuf_append(u, (const uint8_t *) str, len);
+}
+
+nmsg_res
+_nmsg_message_payload_to_json(struct nmsg_message *msg, char **json) {
+	Nmsg__NmsgPayload *np;
+	nmsg_res res;
+	yajl_gen g;
+	yajl_gen_status status;
+	int yajl_rc;
+	ubuf *u;
+	uint8_t *s;
+	size_t u_len;
+	const char * ntop_status;
+
+	size_t field_idx, n_fields;
+	const char *field_name;
+	nmsg_msgmod_field_type field_type;
+	unsigned field_flags;
+
+	size_t val_idx;
+        unsigned val_enum;
+        const char *str_enum;
+        int val_bool;
+	char str_ip[INET_ADDRSTRLEN];
+	char str_ip6[INET6_ADDRSTRLEN];
+        uint32_t val_uint32;
+        uint64_t val_uint64;
+        int32_t val_int32;
+        int64_t val_int64;
+        double val_double;
+        const uint8_t *data;
+        size_t data_len;
+
+	u = ubuf_init(256);
+
+	np = msg->np;
+
+	g = yajl_gen_alloc(NULL);
+	assert (g != NULL);
+
+	yajl_rc = yajl_gen_config(g, yajl_gen_print_callback, callback_print_yajl_ubuf, u);
+	assert (yajl_rc != 0);
+
+	status = yajl_gen_map_open(g);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "time_sec");
+	status = yajl_gen_integer(g, np->time_sec);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "time_nsec");
+	status = yajl_gen_integer(g, np->time_nsec);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "vid");
+	status = yajl_gen_integer(g, np->vid);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "msgtype");
+	status = yajl_gen_integer(g, np->msgtype);
+	assert(status == yajl_gen_status_ok);
+
+	if (np->has_source) {
+		add_yajl_string(g, "source");
+		status = yajl_gen_integer(g, np->source);
+		assert(status == yajl_gen_status_ok);
+	}
+
+	if (np->has_operator_) {
+		add_yajl_string(g, "operator");
+		status = yajl_gen_integer(g, np->operator_);
+		assert(status == yajl_gen_status_ok);
+	}
+
+	if (np->has_group) {
+		add_yajl_string(g, "group");
+		status = yajl_gen_integer(g, np->group);
+		assert(status == yajl_gen_status_ok);
+	}
+
+	add_yajl_string(g, "message");
+
+	status = yajl_gen_map_open(g);
+	assert(status == yajl_gen_status_ok);
+
+	res = nmsg_message_get_num_fields(msg, &n_fields);
+	if (res != nmsg_res_success) {
+		// raise Exception, 'nmsg_message_get_num_fields() failed'
+	}
+
+	for (field_idx = 0; field_idx < n_fields; field_idx++) {
+		res = nmsg_message_get_field_name(msg, field_idx, &field_name);
+		if (res != nmsg_res_success) {
+			continue;
+		}
+
+		/* Ensure that there is at least one value */
+		res = nmsg_message_get_field_by_idx(msg, field_idx, 0, (void **) &data, &data_len);
+		if (res == nmsg_res_success) {
+			status = yajl_gen_string(g, (unsigned char *) field_name, strlen(field_name));
+			assert(status == yajl_gen_status_ok);
+		} else {
+			continue;
+		}
+
+		res = nmsg_message_get_field_flags_by_idx(msg, field_idx, &field_flags);
+		if (res != nmsg_res_success) {
+			status = yajl_gen_null(g);
+			assert(status == yajl_gen_status_ok);
+			continue;
+		}
+
+		res = nmsg_message_get_field_type_by_idx(msg, field_idx, &field_type);
+		if (res != nmsg_res_success) {
+			status = yajl_gen_null(g);
+			assert(status == yajl_gen_status_ok);
+			continue;
+		}
+
+		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
+			status = yajl_gen_array_open(g);
+			assert(status == yajl_gen_status_ok);
+		}
+
+		val_idx = 0;
+
+		while (1) {
+			res = nmsg_message_get_field_by_idx(msg, field_idx, val_idx, (void **) &data, &data_len);
+			if (res != nmsg_res_success) {
+				break;
+			}
+			val_idx++;
+
+			switch(field_type) {
+				case nmsg_msgmod_ft_enum: {
+					val_enum = data[0];
+					res = nmsg_message_enum_value_to_name_by_idx(msg, field_idx, val_enum, &str_enum);
+					if (res == nmsg_res_success) {
+						status = yajl_gen_string(g, (const unsigned char*) str_enum, strlen(str_enum));
+						assert(status == yajl_gen_status_ok);
+					} else {
+						status = yajl_gen_integer(g, val_enum);
+						assert(status == yajl_gen_status_ok);
+					}
+					break;
+				}
+				case nmsg_msgmod_ft_bytes: {
+					status = yajl_gen_string(g, (const unsigned char*) data, data_len);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_string:
+				case nmsg_msgmod_ft_mlstring: {
+					if (data_len > 0 && data[data_len-1]) {
+						data_len--;
+					}
+					status = yajl_gen_string(g, (const unsigned char*)data, data_len);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_ip: {
+					if (data_len == 4) {
+						ntop_status = inet_ntop(AF_INET, data, str_ip, sizeof(str_ip));
+						assert(ntop_status != NULL);
+						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
+						assert(status == yajl_gen_status_ok);
+					} else if (data_len == 16) {
+						ntop_status = inet_ntop(AF_INET6, data, str_ip6, sizeof(str_ip6));
+						assert(ntop_status != NULL);
+						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
+						assert(status == yajl_gen_status_ok);
+					} else {
+						status = yajl_gen_number(g, (const char*)data, data_len);
+						assert(status == yajl_gen_status_ok);
+					}
+					break;
+				}
+				case nmsg_msgmod_ft_uint16:
+				case nmsg_msgmod_ft_uint32: {
+					val_uint32 = ((uint32_t *)data)[0];
+					status = yajl_gen_integer(g, val_uint32);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_uint64: {
+					val_uint64 = ((uint64_t *)data)[0];
+					status = yajl_gen_integer(g, val_uint64);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_int16:
+				case nmsg_msgmod_ft_int32: {
+					val_int32 = ((int32_t *)data)[0];
+					status = yajl_gen_integer(g, val_int32);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_int64: {
+					val_int64 = ((int64_t *)data)[0];
+					status = yajl_gen_integer(g, val_int64);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_double: {
+					val_double = ((double *)data)[0];
+					status = yajl_gen_double(g, val_double);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				case nmsg_msgmod_ft_bool: {
+					val_bool = ((int *)data)[0];
+					status = yajl_gen_bool(g, val_bool);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+				default: {
+					status = yajl_gen_null(g);
+					assert(status == yajl_gen_status_ok);
+					break;
+				}
+
+			}
+
+			if (! (field_flags & NMSG_MSGMOD_FIELD_REPEATED)) {
+				break;
+			}
+		}
+
+		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
+			status = yajl_gen_array_close(g);
+			assert(status == yajl_gen_status_ok);
+		}
+
+	}
+
+	status = yajl_gen_map_close(g);
+	assert(status == yajl_gen_status_ok);
+
+	status = yajl_gen_map_close(g);
+	assert(status == yajl_gen_status_ok);
+
+	yajl_gen_reset(g, "");
+
+	ubuf_cterm(u);
+	ubuf_detach(u, &s, &u_len);
+	ubuf_destroy(&u);
+
+	if (g != NULL) {
+		yajl_gen_free(g);
+	}
+
+	*json = (char*)s;
+
+	return (nmsg_res_success);
+}
+#else /* HAVE_YAJL */
+nmsg_res
+_nmsg_message_payload_to_json(struct nmsg_message *msg, char **pres) {
+	return (nmsg_res_notimpl);
+}
+#endif /* HAVE_YAJL */

--- a/nmsg/msgmod/transparent_payload.c
+++ b/nmsg/msgmod/transparent_payload.c
@@ -295,6 +295,7 @@ _nmsg_message_payload_to_json(struct nmsg_message *msg, char **json) {
 
 	sb_tmp = nmsg_strbuf_init();
 	if (sb_tmp == NULL) {
+		nmsg_strbuf_destroy(&sb);
 		res = nmsg_res_memfail;
 		goto err;
 	}
@@ -451,6 +452,8 @@ _nmsg_message_payload_to_json(struct nmsg_message *msg, char **json) {
 	*json = sb->data;
 	free(sb);
 
+	nmsg_strbuf_destroy(&sb_tmp);
+
 	return (nmsg_res_success);
 
 err:
@@ -458,9 +461,8 @@ err:
 		yajl_gen_free(g);
 	}
 
-	if (sb != NULL) {
-		nmsg_strbuf_destroy(&sb);
-	}
+	nmsg_strbuf_destroy(&sb);
+	nmsg_strbuf_destroy(&sb_tmp);
 
 	return (res);
 }

--- a/nmsg/msgmod_plugin.h
+++ b/nmsg/msgmod_plugin.h
@@ -77,6 +77,14 @@ typedef nmsg_res (*nmsg_msgmod_field_format_fp)(nmsg_message_t m,
 					        struct nmsg_strbuf *sb,
 					        const char *endline);
 
+/** Custom field parser function. */
+typedef nmsg_res (*nmsg_msgmod_field_parse_fp)(nmsg_message_t m,
+					       struct nmsg_msgmod_field *field,
+					       const char *value,
+					       void **ptr,
+					       size_t *len,
+					       const char *endline);
+
 /** Convenience macro. */
 #define NMSG_MSGMOD_FIELD_PRINTER(funcname) \
 	nmsg_res funcname(nmsg_message_t m, \
@@ -129,8 +137,10 @@ struct nmsg_msgmod_field {
 	/* Optional custom field formatter function. */
 	nmsg_msgmod_field_format_fp             format;
 
+	/* Optional custom field parser function. */
+	nmsg_msgmod_field_parse_fp              parse;
+
 	/** \private Reserved fields. */
-	void					*_reserved2;
 	void					*_reserved1;
 	void					*_reserved0;
 };

--- a/nmsg/msgmod_plugin.h
+++ b/nmsg/msgmod_plugin.h
@@ -70,6 +70,13 @@ typedef nmsg_res (*nmsg_msgmod_field_get_fp)(nmsg_message_t m,
 					     size_t *len,
 					     void *msg_clos);
 
+/** Custom field formatter function. */
+typedef nmsg_res (*nmsg_msgmod_field_format_fp)(nmsg_message_t m,
+					        struct nmsg_msgmod_field *field,
+					        void *ptr,
+					        struct nmsg_strbuf *sb,
+					        const char *endline);
+
 /** Convenience macro. */
 #define NMSG_MSGMOD_FIELD_PRINTER(funcname) \
 	nmsg_res funcname(nmsg_message_t m, \
@@ -119,8 +126,10 @@ struct nmsg_msgmod_field {
 	/** \private, must be initialized to NULL. */
 	const ProtobufCFieldDescriptor		*descr;
 
+	/* Optional custom field formatter function. */
+	nmsg_msgmod_field_format_fp             format;
+
 	/** \private Reserved fields. */
-	void					*_reserved3;
 	void					*_reserved2;
 	void					*_reserved1;
 	void					*_reserved0;

--- a/nmsg/msgmod_plugin.h
+++ b/nmsg/msgmod_plugin.h
@@ -103,6 +103,23 @@ typedef nmsg_res (*nmsg_msgmod_field_parse_fp)(nmsg_message_t m,
 			  void *msg_clos)
 
 /** Convenience macro. */
+#define NMSG_MSGMOD_FIELD_FORMATTER(funcname) \
+	nmsg_res funcname(nmsg_message_t m, \
+			  struct nmsg_msgmod_field *field, \
+			  void *ptr, \
+			  struct nmsg_strbuf *sb, \
+			  const char *endline)
+
+/** Convenience macro. */
+#define NMSG_MSGMOD_FIELD_PARSER(funcname) \
+	nmsg_res funcname(nmsg_message_t m, \
+			  struct nmsg_msgmod_field *field, \
+			  const char *value, \
+			  void **ptr, \
+			  size_t *len, \
+			  const char *endline)
+
+/** Convenience macro. */
 #define NMSG_MSGMOD_REQUIRED_INIT \
 	.msgver = NMSG_MSGMOD_VERSION, \
 	.protobuf_c_version_number = PROTOBUF_C_VERSION_NUMBER

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -40,6 +40,7 @@
 typedef enum {
 	nmsg_output_type_stream,
 	nmsg_output_type_pres,
+	nmsg_output_type_json,
 	nmsg_output_type_callback
 } nmsg_output_type;
 
@@ -127,6 +128,16 @@ nmsg_output_open_xs_endpoint(void *xs_ctx, const char *ep, size_t bufsz);
  */
 nmsg_output_t
 nmsg_output_open_pres(int fd);
+
+/**
+ * Initialize a new JSON format nmsg output.
+ *
+ * \param[in] fd Writable file descriptor.
+ *
+ * \return Opaque pointer that is NULL on failure or non-NULL on success.
+ */
+nmsg_output_t
+nmsg_output_open_json(int fd);
 
 /**
  * Initialize a new nmsg output closure. This allows a user-provided callback to

--- a/nmsg/output_json.c
+++ b/nmsg/output_json.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (c) 2008-2012 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Import. */
+
+#include "private.h"
+#include <arpa/inet.h>
+
+/* Internal functions. */
+
+#ifdef HAVE_YAJL
+
+#define add_yajl_string(g, s) do {                                              \
+	yajl_gen_status g_status;                                               \
+	g_status = yajl_gen_string(g, (const unsigned  char *) s, strlen(s));   \
+	assert(g_status == yajl_gen_status_ok);                                 \
+} while (0)
+
+static void
+callback_print_yajl_ubuf(void *ctx, const char *str, size_t len)
+{
+        ubuf *u = (ubuf *) ctx;
+        ubuf_append(u, (const uint8_t *) str, len);
+}
+
+nmsg_res
+_output_json_write(nmsg_output_t output, nmsg_message_t msg) {
+	Nmsg__NmsgPayload *np;
+	nmsg_res res;
+	yajl_gen g;
+	yajl_gen_status status;
+	int yajl_rc;
+	ubuf *u;
+	uint8_t *s = NULL;
+	size_t u_len;
+	const char * ntop_status;
+
+	size_t field_idx, n_fields;
+	const char *field_name;
+	nmsg_msgmod_field_type field_type;
+	unsigned field_flags;
+
+	size_t val_idx;
+        unsigned val_enum;
+        const char *str_enum;
+        int val_bool;
+	char str_ip[INET_ADDRSTRLEN];
+	char str_ip6[INET6_ADDRSTRLEN];
+        uint32_t val_uint32;
+        uint64_t val_uint64;
+        int32_t val_int32;
+        int64_t val_int64;
+        double val_double;
+        const uint8_t *data;
+        size_t data_len;
+
+	u = ubuf_init(256);
+
+	np = msg->np;
+
+	/* lock output */
+	pthread_mutex_lock(&output->json->lock);
+
+	g = yajl_gen_alloc(NULL);
+	assert (g != NULL);
+
+	yajl_rc = yajl_gen_config(g, yajl_gen_print_callback, callback_print_yajl_ubuf, u);
+	assert (yajl_rc != 0);
+
+	status = yajl_gen_map_open(g);
+	assert(status == yajl_gen_status_ok);
+	
+	add_yajl_string(g, "time_sec");
+	status = yajl_gen_integer(g, np->time_sec);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "time_nsec");
+	status = yajl_gen_integer(g, np->time_nsec);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "vid");
+	status = yajl_gen_integer(g, np->vid);
+	assert(status == yajl_gen_status_ok);
+
+	add_yajl_string(g, "msgtype");
+	status = yajl_gen_integer(g, np->msgtype);
+	assert(status == yajl_gen_status_ok);
+
+	if (np->has_source) {
+		add_yajl_string(g, "source");
+		status = yajl_gen_integer(g, np->source);
+		assert(status == yajl_gen_status_ok);
+	}
+	
+	if (np->has_operator_) {
+		add_yajl_string(g, "operator");
+		status = yajl_gen_integer(g, np->operator_);
+		assert(status == yajl_gen_status_ok);
+	}
+	
+	if (np->has_group) {
+		add_yajl_string(g, "group");
+		status = yajl_gen_integer(g, np->group);
+		assert(status == yajl_gen_status_ok);
+	}
+
+	add_yajl_string(g, "message");
+
+	status = yajl_gen_map_open(g);
+	assert(status == yajl_gen_status_ok);
+
+	res = nmsg_message_get_num_fields(msg, &n_fields);
+	if (res != nmsg_res_success) {
+		// raise Exception, 'nmsg_message_get_num_fields() failed'
+	}
+
+	for (field_idx = 0; field_idx < n_fields; field_idx++) {
+		res = nmsg_message_get_field_name(msg, field_idx, &field_name);
+		if (res != nmsg_res_success) {
+			continue;
+		}
+
+		/* Ensure that there is at least one value */
+		res = nmsg_message_get_field_by_idx(msg, field_idx, 0, (void **) &data, &data_len);
+		if (res == nmsg_res_success) {
+			status = yajl_gen_string(g, (unsigned char *) field_name, strlen(field_name));
+			assert(status == yajl_gen_status_ok);
+		} else {
+			continue;
+		}
+
+		res = nmsg_message_get_field_flags_by_idx(msg, field_idx, &field_flags);
+		if (res != nmsg_res_success) {
+			status = yajl_gen_null(g);
+			assert(status == yajl_gen_status_ok);
+			continue;
+		}
+
+		res = nmsg_message_get_field_type_by_idx(msg, field_idx, &field_type);
+		if (res != nmsg_res_success) {
+			status = yajl_gen_null(g);
+			assert(status == yajl_gen_status_ok);
+			continue;
+		}
+
+		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
+			status = yajl_gen_array_open(g);
+			assert(status == yajl_gen_status_ok);
+		}
+
+		val_idx = 0;
+
+		while (1) {
+			res = nmsg_message_get_field_by_idx(msg, field_idx, val_idx, (void **) &data, &data_len);
+			if (res != nmsg_res_success) {
+				break;
+			}
+			val_idx++;
+
+			switch(field_type) {
+				case nmsg_msgmod_ft_enum:
+					val_enum = data[0]; // TODO bounds check?
+					res = nmsg_message_enum_value_to_name_by_idx(msg, field_idx, val_enum, &str_enum);
+					if (res == nmsg_res_success) {
+						status = yajl_gen_string(g, (const unsigned char*) str_enum, strlen(str_enum));
+						assert(status == yajl_gen_status_ok);
+					} else {
+						status = yajl_gen_integer(g, val_enum);
+						assert(status == yajl_gen_status_ok);
+					}
+					break;
+				case nmsg_msgmod_ft_bytes:
+					status = yajl_gen_string(g, (const unsigned char*) data, data_len);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_string:
+				case nmsg_msgmod_ft_mlstring:
+					if (data_len > 0 && data[data_len-1]) {
+						data_len--;
+					}
+					status = yajl_gen_string(g, (const unsigned char*)data, data_len);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_ip:
+					if (data_len == 4) {
+						ntop_status = inet_ntop(AF_INET, data, str_ip, sizeof(str_ip));
+						assert(ntop_status != NULL);
+						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
+						assert(status == yajl_gen_status_ok);
+					} else if (data_len == 16) {
+						ntop_status = inet_ntop(AF_INET6, data, str_ip6, sizeof(str_ip6));
+						assert(ntop_status != NULL);
+						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
+						assert(status == yajl_gen_status_ok);
+					} else {
+						status = yajl_gen_number(g, (const char*)data, data_len);
+						assert(status == yajl_gen_status_ok);
+					}
+					break;
+				case nmsg_msgmod_ft_uint16:
+				case nmsg_msgmod_ft_uint32:
+					val_uint32 = ((uint32_t *)data)[0];
+					status = yajl_gen_integer(g, val_uint32);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_uint64:
+					val_uint64 = ((uint64_t *)data)[0];
+					status = yajl_gen_integer(g, val_uint64);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_int16:
+				case nmsg_msgmod_ft_int32:
+					val_int32 = ((int32_t *)data)[0];
+					status = yajl_gen_integer(g, val_int32);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_int64:
+					val_int64 = ((int64_t *)data)[0];
+					status = yajl_gen_integer(g, val_int64);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_double:
+					val_double = ((double *)data)[0];
+					status = yajl_gen_double(g, val_double);
+					assert(status == yajl_gen_status_ok);
+					break;
+				case nmsg_msgmod_ft_bool:
+					val_bool = ((int *)data)[0];
+					status = yajl_gen_bool(g, val_bool);
+					assert(status == yajl_gen_status_ok);
+					break;
+				default:
+					status = yajl_gen_null(g);
+					assert(status == yajl_gen_status_ok);
+					break;
+
+			}
+
+			if (! (field_flags & NMSG_MSGMOD_FIELD_REPEATED)) {
+				break;
+			}
+		}
+
+		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
+			status = yajl_gen_array_close(g);
+			assert(status == yajl_gen_status_ok);
+		}
+
+	}
+
+	status = yajl_gen_map_close(g);
+	assert(status == yajl_gen_status_ok);
+
+	status = yajl_gen_map_close(g);
+	assert(status == yajl_gen_status_ok);
+
+	yajl_gen_reset(g, "\n");
+
+	ubuf_cterm(u);
+	ubuf_detach(u, &s, &u_len);
+	ubuf_destroy(&u);
+
+	fwrite(s, sizeof(uint8_t), u_len, output->pres->fp);
+	free(s);
+        if (output->pres->flush)
+                fflush(output->pres->fp);
+
+	if (g != NULL) {
+		yajl_gen_free(g);
+	}
+
+	/* unlock output */
+	pthread_mutex_unlock(&output->json->lock);
+
+	return (nmsg_res_success);
+}
+#else /* HAVE_YAJL */
+nmsg_res
+_output_json_write(nmsg_output_t output, nmsg_message_t msg) {
+	return (nmsg_res_notimpl);
+}
+#endif /* HAVE_YAJL */

--- a/nmsg/output_json.c
+++ b/nmsg/output_json.c
@@ -17,279 +17,30 @@
 /* Import. */
 
 #include "private.h"
-#include <arpa/inet.h>
 
 /* Internal functions. */
 
-#ifdef HAVE_YAJL
-
-#define add_yajl_string(g, s) do {                                              \
-	yajl_gen_status g_status;                                               \
-	g_status = yajl_gen_string(g, (const unsigned  char *) s, strlen(s));   \
-	assert(g_status == yajl_gen_status_ok);                                 \
-} while (0)
-
-static void
-callback_print_yajl_ubuf(void *ctx, const char *str, size_t len)
-{
-        ubuf *u = (ubuf *) ctx;
-        ubuf_append(u, (const uint8_t *) str, len);
-}
-
 nmsg_res
 _output_json_write(nmsg_output_t output, nmsg_message_t msg) {
-	Nmsg__NmsgPayload *np;
 	nmsg_res res;
-	yajl_gen g;
-	yajl_gen_status status;
-	int yajl_rc;
-	ubuf *u;
-	uint8_t *s = NULL;
-	size_t u_len;
-	const char * ntop_status;
-
-	size_t field_idx, n_fields;
-	const char *field_name;
-	nmsg_msgmod_field_type field_type;
-	unsigned field_flags;
-
-	size_t val_idx;
-        unsigned val_enum;
-        const char *str_enum;
-        int val_bool;
-	char str_ip[INET_ADDRSTRLEN];
-	char str_ip6[INET6_ADDRSTRLEN];
-        uint32_t val_uint32;
-        uint64_t val_uint64;
-        int32_t val_int32;
-        int64_t val_int64;
-        double val_double;
-        const uint8_t *data;
-        size_t data_len;
-
-	u = ubuf_init(256);
-
-	np = msg->np;
+	char *json_data;
 
 	/* lock output */
 	pthread_mutex_lock(&output->json->lock);
 
-	g = yajl_gen_alloc(NULL);
-	assert (g != NULL);
-
-	yajl_rc = yajl_gen_config(g, yajl_gen_print_callback, callback_print_yajl_ubuf, u);
-	assert (yajl_rc != 0);
-
-	status = yajl_gen_map_open(g);
-	assert(status == yajl_gen_status_ok);
-	
-	add_yajl_string(g, "time_sec");
-	status = yajl_gen_integer(g, np->time_sec);
-	assert(status == yajl_gen_status_ok);
-
-	add_yajl_string(g, "time_nsec");
-	status = yajl_gen_integer(g, np->time_nsec);
-	assert(status == yajl_gen_status_ok);
-
-	add_yajl_string(g, "vid");
-	status = yajl_gen_integer(g, np->vid);
-	assert(status == yajl_gen_status_ok);
-
-	add_yajl_string(g, "msgtype");
-	status = yajl_gen_integer(g, np->msgtype);
-	assert(status == yajl_gen_status_ok);
-
-	if (np->has_source) {
-		add_yajl_string(g, "source");
-		status = yajl_gen_integer(g, np->source);
-		assert(status == yajl_gen_status_ok);
-	}
-	
-	if (np->has_operator_) {
-		add_yajl_string(g, "operator");
-		status = yajl_gen_integer(g, np->operator_);
-		assert(status == yajl_gen_status_ok);
-	}
-	
-	if (np->has_group) {
-		add_yajl_string(g, "group");
-		status = yajl_gen_integer(g, np->group);
-		assert(status == yajl_gen_status_ok);
-	}
-
-	add_yajl_string(g, "message");
-
-	status = yajl_gen_map_open(g);
-	assert(status == yajl_gen_status_ok);
-
-	res = nmsg_message_get_num_fields(msg, &n_fields);
+	res = nmsg_message_to_json(msg, &json_data);
 	if (res != nmsg_res_success) {
-		// raise Exception, 'nmsg_message_get_num_fields() failed'
+		goto out;
 	}
 
-	for (field_idx = 0; field_idx < n_fields; field_idx++) {
-		res = nmsg_message_get_field_name(msg, field_idx, &field_name);
-		if (res != nmsg_res_success) {
-			continue;
-		}
-
-		/* Ensure that there is at least one value */
-		res = nmsg_message_get_field_by_idx(msg, field_idx, 0, (void **) &data, &data_len);
-		if (res == nmsg_res_success) {
-			status = yajl_gen_string(g, (unsigned char *) field_name, strlen(field_name));
-			assert(status == yajl_gen_status_ok);
-		} else {
-			continue;
-		}
-
-		res = nmsg_message_get_field_flags_by_idx(msg, field_idx, &field_flags);
-		if (res != nmsg_res_success) {
-			status = yajl_gen_null(g);
-			assert(status == yajl_gen_status_ok);
-			continue;
-		}
-
-		res = nmsg_message_get_field_type_by_idx(msg, field_idx, &field_type);
-		if (res != nmsg_res_success) {
-			status = yajl_gen_null(g);
-			assert(status == yajl_gen_status_ok);
-			continue;
-		}
-
-		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
-			status = yajl_gen_array_open(g);
-			assert(status == yajl_gen_status_ok);
-		}
-
-		val_idx = 0;
-
-		while (1) {
-			res = nmsg_message_get_field_by_idx(msg, field_idx, val_idx, (void **) &data, &data_len);
-			if (res != nmsg_res_success) {
-				break;
-			}
-			val_idx++;
-
-			switch(field_type) {
-				case nmsg_msgmod_ft_enum:
-					val_enum = data[0]; // TODO bounds check?
-					res = nmsg_message_enum_value_to_name_by_idx(msg, field_idx, val_enum, &str_enum);
-					if (res == nmsg_res_success) {
-						status = yajl_gen_string(g, (const unsigned char*) str_enum, strlen(str_enum));
-						assert(status == yajl_gen_status_ok);
-					} else {
-						status = yajl_gen_integer(g, val_enum);
-						assert(status == yajl_gen_status_ok);
-					}
-					break;
-				case nmsg_msgmod_ft_bytes:
-					status = yajl_gen_string(g, (const unsigned char*) data, data_len);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_string:
-				case nmsg_msgmod_ft_mlstring:
-					if (data_len > 0 && data[data_len-1]) {
-						data_len--;
-					}
-					status = yajl_gen_string(g, (const unsigned char*)data, data_len);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_ip:
-					if (data_len == 4) {
-						ntop_status = inet_ntop(AF_INET, data, str_ip, sizeof(str_ip));
-						assert(ntop_status != NULL);
-						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
-						assert(status == yajl_gen_status_ok);
-					} else if (data_len == 16) {
-						ntop_status = inet_ntop(AF_INET6, data, str_ip6, sizeof(str_ip6));
-						assert(ntop_status != NULL);
-						status = yajl_gen_string(g, (const unsigned char*)str_ip, strlen(str_ip));
-						assert(status == yajl_gen_status_ok);
-					} else {
-						status = yajl_gen_number(g, (const char*)data, data_len);
-						assert(status == yajl_gen_status_ok);
-					}
-					break;
-				case nmsg_msgmod_ft_uint16:
-				case nmsg_msgmod_ft_uint32:
-					val_uint32 = ((uint32_t *)data)[0];
-					status = yajl_gen_integer(g, val_uint32);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_uint64:
-					val_uint64 = ((uint64_t *)data)[0];
-					status = yajl_gen_integer(g, val_uint64);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_int16:
-				case nmsg_msgmod_ft_int32:
-					val_int32 = ((int32_t *)data)[0];
-					status = yajl_gen_integer(g, val_int32);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_int64:
-					val_int64 = ((int64_t *)data)[0];
-					status = yajl_gen_integer(g, val_int64);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_double:
-					val_double = ((double *)data)[0];
-					status = yajl_gen_double(g, val_double);
-					assert(status == yajl_gen_status_ok);
-					break;
-				case nmsg_msgmod_ft_bool:
-					val_bool = ((int *)data)[0];
-					status = yajl_gen_bool(g, val_bool);
-					assert(status == yajl_gen_status_ok);
-					break;
-				default:
-					status = yajl_gen_null(g);
-					assert(status == yajl_gen_status_ok);
-					break;
-
-			}
-
-			if (! (field_flags & NMSG_MSGMOD_FIELD_REPEATED)) {
-				break;
-			}
-		}
-
-		if (field_flags & NMSG_MSGMOD_FIELD_REPEATED) {
-			status = yajl_gen_array_close(g);
-			assert(status == yajl_gen_status_ok);
-		}
-
-	}
-
-	status = yajl_gen_map_close(g);
-	assert(status == yajl_gen_status_ok);
-
-	status = yajl_gen_map_close(g);
-	assert(status == yajl_gen_status_ok);
-
-	yajl_gen_reset(g, "\n");
-
-	ubuf_cterm(u);
-	ubuf_detach(u, &s, &u_len);
-	ubuf_destroy(&u);
-
-	fwrite(s, sizeof(uint8_t), u_len, output->pres->fp);
-	free(s);
+	fprintf(output->pres->fp, "%s\n", json_data);
         if (output->pres->flush)
                 fflush(output->pres->fp);
+	free(json_data);
 
-	if (g != NULL) {
-		yajl_gen_free(g);
-	}
-
+out:
 	/* unlock output */
 	pthread_mutex_unlock(&output->json->lock);
 
 	return (nmsg_res_success);
 }
-#else /* HAVE_YAJL */
-nmsg_res
-_output_json_write(nmsg_output_t output, nmsg_message_t msg) {
-	return (nmsg_res_notimpl);
-}
-#endif /* HAVE_YAJL */

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -409,6 +409,7 @@ struct nmsg_msgvendor {
 struct nmsg_msgmod {
 	struct nmsg_msgmod_plugin	*plugin;
 	struct nmsg_msgmod_field	*fields;
+	struct nmsg_msgmod_field	**fields_idx;
 	size_t				n_fields;
 };
 

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -57,6 +57,7 @@
 
 #ifdef HAVE_YAJL
 #include <yajl_gen.h>
+#include <yajl_tree.h>
 #endif /* HAVE_YAJL */
 
 #ifdef HAVE_LIBXS

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -55,6 +55,10 @@
 
 #include <protobuf-c/protobuf-c.h>
 
+#ifdef HAVE_YAJL
+#include <yajl_gen.h>
+#endif /* HAVE_YAJL */
+
 #ifdef HAVE_LIBXS
 # include <xs/xs.h>
 #endif /* HAVE_LIBXS */
@@ -115,6 +119,7 @@ struct nmsg_frag;
 struct nmsg_frag_key;
 struct nmsg_frag_tree;
 struct nmsg_input;
+struct nmsg_json;
 struct nmsg_output;
 struct nmsg_msgmod;
 struct nmsg_msgmod_field;
@@ -219,6 +224,15 @@ struct nmsg_pres {
 	char			*endline;
 };
 
+/* nmsg_json: used by nmsg_input and nmsg_output */
+struct nmsg_json {
+#ifdef HAVE_YAJL
+#endif /* HAVE_YAJL */
+	pthread_mutex_t		lock;
+	FILE			*fp;
+	bool			flush;
+};
+
 /* nmsg_stream_input: used by nmsg_input */
 struct nmsg_stream_input {
 	nmsg_stream_type	type;
@@ -294,6 +308,7 @@ struct nmsg_input {
 		struct nmsg_stream_input	*stream;
 		struct nmsg_pcap		*pcap;
 		struct nmsg_pres		*pres;
+		struct nmsg_json		*json;
 		struct nmsg_callback_input	*callback;
 	};
 	nmsg_input_read_fp	read_fp;
@@ -311,6 +326,7 @@ struct nmsg_output {
 	union {
 		struct nmsg_stream_output	*stream;
 		struct nmsg_pres		*pres;
+		struct nmsg_json		*json;
 		struct nmsg_callback_output	*callback;
 	};
 	nmsg_output_write_fp	write_fp;
@@ -479,6 +495,9 @@ nmsg_res		_input_pcap_read_raw(nmsg_input_t, nmsg_message_t *);
 /* from input_pres.c */
 nmsg_res		_input_pres_read(nmsg_input_t, nmsg_message_t *);
 
+/* from input_json.c */
+nmsg_res		_input_json_read(nmsg_input_t, nmsg_message_t *);
+
 /* from input_seqsrc.c */
 struct nmsg_seqsrc *	_input_seqsrc_get(nmsg_input_t, Nmsg__Nmsg *);
 void			_input_seqsrc_destroy(nmsg_input_t);
@@ -502,6 +521,9 @@ nmsg_res		_output_nmsg_write_xs(nmsg_output_t, uint8_t *buf, size_t len);
 
 /* from output_pres.c */
 nmsg_res		_output_pres_write(nmsg_output_t, nmsg_message_t);
+
+/* from output_json.c */
+nmsg_res		_output_json_write(nmsg_output_t, nmsg_message_t);
 
 /* from brate.c */
 struct nmsg_brate *	_nmsg_brate_init(size_t target_byte_rate);

--- a/src/io.c
+++ b/src/io.c
@@ -547,3 +547,72 @@ add_pres_output(nmsgtool_ctx *c, const char *fname) {
 			fname);
 	c->n_outputs += 1;
 }
+
+#ifdef HAVE_YAJL
+void
+add_json_input(nmsgtool_ctx *c, const char *fname) {
+	nmsg_input_t input;
+	nmsg_res res;
+
+	input = nmsg_input_open_json(open_rfile(fname));
+	res = nmsg_io_add_input(c->io, input, NULL);
+	if (res != nmsg_res_success) {
+		fprintf(stderr, "%s: nmsg_io_add_input() failed\n",
+			argv_program);
+		exit(1);
+	}
+	if (c->debug >= 2)
+		fprintf(stderr, "%s: nmsg json input: %s\n", argv_program,
+			fname);
+	c->n_inputs += 1;
+}
+#else /* HAVE_YAJL */
+void
+add_json_input(nmsgtool_ctx *c, const char *fname) {
+	fprintf(stderr, "%s: Error: compiled without yajl support\n",
+		argv_program);
+	exit(EXIT_FAILURE);
+}
+#endif /* HAVE_YAJL */
+
+#ifdef HAVE_YAJL
+void
+add_json_output(nmsgtool_ctx *c, const char *fname) {
+	nmsg_output_t output;
+	nmsg_res res;
+
+	if (c->kicker != NULL) {
+		struct kickfile *kf;
+		kf = calloc(1, sizeof(*kf));
+		assert(kf != NULL);
+
+		kf->cmd = c->kicker;
+		kf->basename = strdup(fname);
+		kickfile_rotate(kf);
+
+		output = nmsg_output_open_json(open_wfile(kf->tmpname));
+		setup_nmsg_output(c, output);
+		res = nmsg_io_add_output(c->io, output, (void *) kf);
+	} else {
+		output = nmsg_output_open_json(open_wfile(fname));
+		setup_nmsg_output(c, output);
+		res = nmsg_io_add_output(c->io, output, NULL);
+	}
+	if (res != nmsg_res_success) {
+		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
+			argv_program);
+		exit(1);
+	}
+	if (c->debug >= 2)
+		fprintf(stderr, "%s: nmsg json output: %s\n", argv_program,
+			fname);
+	c->n_outputs += 1;
+}
+#else /* HAVE_YAJL */
+void
+add_json_output(nmsgtool_ctx *c, const char *fname) {
+	fprintf(stderr, "%s: Error: compiled without yajl support\n",
+		argv_program);
+	exit(EXIT_FAILURE);
+}
+#endif /* HAVE_YAJL */

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -112,6 +112,16 @@ static argv_t args[] = {
 		"file",
 		"read pres format data from file" },
 
+	{ 'j', "readjson",
+		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
+		&ctx.r_json,
+		"file",
+#ifdef HAVE_YAJL
+		"read json format data from file" },
+#else /* HAVE_YAJL */
+		"read json format data from file (no support)" },
+#endif /* HAVE_YAJL */
+
 	{ 'l', "readsock",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
 		&ctx.r_sock,
@@ -163,6 +173,16 @@ static argv_t args[] = {
 		&ctx.w_pres,
 		"file",
 		"write pres format data to file" },
+
+	{ 'J', "writejson",
+		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
+		&ctx.w_json,
+		"file",
+#ifdef HAVE_YAJL
+		"write json format data to file" },
+#else /* HAVE_YAJL */
+		"write json format data to file (no support)" },
+#endif /* HAVE_YAJL */
 
 	{ 's', "writesock",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -44,9 +44,9 @@ typedef union nmsgtool_sockaddr nmsgtool_sockaddr;
 
 typedef struct {
 	/* parameters */
-	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel;
+	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
-	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock;
+	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version;
 	char		*endline, *kicker, *mname, *vname, *bpfstr;
 	int		debug;
@@ -102,6 +102,8 @@ void add_pcapfile_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
 void add_pcapif_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
 void add_pres_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
 void add_pres_output(nmsgtool_ctx *, const char *);
+void add_json_input(nmsgtool_ctx *, const char *);
+void add_json_output(nmsgtool_ctx *, const char *);
 void add_sock_input(nmsgtool_ctx *, const char *);
 void add_sock_output(nmsgtool_ctx *, const char *);
 void add_xsock_input(nmsgtool_ctx *, const char *);

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -309,6 +309,10 @@ process_args(nmsgtool_ctx *c) {
 	process_args_loop_mod(c->r_pres, add_pres_input, mod);
 	process_args_loop(c->w_pres, add_pres_output);
 
+	/* json inputs and outputs */
+	process_args_loop(c->r_json, add_json_input);
+	process_args_loop(c->w_json, add_json_output);
+
 #undef process_args_loop
 #undef process_args_loop_mod
 


### PR DESCRIPTION
This adds several features to nmsg.  Message modules now have a format and parse function for fields.  Support for this should be added to pynmsg.

You can output messages in json format with the -J option to nmsgtool.  You can input messages in json format with the -j option.  JSON blobs with parse errors are ignored (and reported with debug >= 1).

This is blocked on https://github.com/lloyd/yajl/pull/168 being accepted, unless you don't mind memory leakage on parse errors (or you merge my commits into your own build).