### PR TITLE
Implement autoclose behavior for JSON input/output

### DIFF
--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -233,6 +233,7 @@ struct nmsg_json {
 #endif /* HAVE_YAJL */
 	pthread_mutex_t		lock;
 	FILE			*fp;
+	int			orig_fd;
 	bool			flush;
 };
 


### PR DESCRIPTION
This commit makes JSON input and output objects behave similarly to the
NMSG input/output objects, which automatically close() the original file
descriptor passed by the caller to the open function, *unless* the
libnmsg 'autoclose' global setting has been set to false, in which case
the caller's file descriptor should be left open. (See the documentation
for the nmsg_set_autoclose() function.)

This is implemented by unconditionally dup()'ing the caller's file
descriptor in nmsg_input_open_json() and nmsg_output_open_json(), and
then passing the dup()'d file descriptor to fdopen(). Since we have to
call fclose() on the FILE* object returned by fdopen(), this will always
close our dup()'d file descriptor.

Then we save a copy of the caller's original file descriptor when the
input or output object is opened, and, only if _nmsg_global_autoclose is
set to true, do we also close the caller's original file descriptor when
nmsg_input_close() or nmsg_output_close() is called.

This allows language bindings (e.g. pynmsg) to mutate their native file
object wrappers (backed by an underlying file descriptor) into libnmsg
NMSG or JSON input/output objects, without both the language's file
object destructor and libnmsg trying to close() the same file
descriptor.