### PR TITLE
io: add interval randomization

### DIFF
--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -199,6 +199,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>-R</option></term>
+        <term><option>--randomize</option></term>
+        <listitem>
+          <para>Randomize the initial offset within the interval that the
+          process is stopped or outputs are reopened.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-k</option> <replaceable>cmd</replaceable></term>
         <term><option>--kicker</option> <replaceable>cmd</replaceable></term>
         <listitem>

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -387,6 +387,18 @@ void
 nmsg_io_set_interval(nmsg_io_t io, unsigned interval);
 
 /**
+ * Configure the nmsg_io_t object to randomize the initial second within the
+ * interval where it closes inputs, rather than on the zeroth second
+ * of the interval.
+ *
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] randomized Boolean flag.
+ */
+void
+nmsg_io_set_interval_randomized(nmsg_io_t io, bool randomized);
+
+/**
  * Set the output mode behavior for an nmsg_io_t object. Nmsg payloads received
  * from inputs may be striped across available outputs (the default), or
  * mirrored across all available outputs.

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -88,6 +88,12 @@ static argv_t args[] = {
 		"secs",
 		"stop or reopen after secs have elapsed" },
 
+	{ 'R', "randomize",
+		ARGV_BOOL,
+		&ctx.interval_randomized,
+		NULL,
+		"randomize beginning of -t interval" },
+
 	{ 'k',	"kicker",
 		ARGV_CHAR_P,
 		&ctx.kicker,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -47,7 +47,7 @@ typedef struct {
 	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
-	bool		help, mirror, unbuffered, zlibout, daemon, version;
+	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
 	char		*endline, *kicker, *mname, *vname, *bpfstr;
 	int		debug;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -116,6 +116,8 @@ process_args(nmsgtool_ctx *c) {
 		nmsg_io_set_count(c->io, c->count);
 	if (c->interval > 0)
 		nmsg_io_set_interval(c->io, c->interval);
+	if (c->interval_randomized == true)
+		nmsg_io_set_interval_randomized(c->io, true);
 	if (c->mirror == true)
 		nmsg_io_set_output_mode(c->io, nmsg_io_output_mode_mirror);
 


### PR DESCRIPTION
This lets the kicker run at a random second in the interval rather than on the zeroth second of the interval.