### PR TITLE
Remove 'nmsg_modtype'

### DIFF
--- a/nmsg/msgmodset.c
+++ b/nmsg/msgmodset.c
@@ -115,7 +115,6 @@ _nmsg_msgmodset_init(const char *plugin_path) {
 				continue;
 			}
 
-			dlmod->type = nmsg_modtype_msgmod;
 			ISC_LIST_APPEND(msgmodset->dlmods, dlmod, link);
 
 			if (plugin != NULL) {

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -102,10 +102,6 @@ do { \
 /* Enums. */
 
 typedef enum {
-	nmsg_modtype_msgmod
-} nmsg_modtype;
-
-typedef enum {
 	nmsg_stream_type_file,
 	nmsg_stream_type_sock,
 	nmsg_stream_type_xs,
@@ -384,7 +380,6 @@ struct nmsg_message {
 
 struct nmsg_dlmod {
 	ISC_LINK(struct nmsg_dlmod)	link;
-	nmsg_modtype			type;
 	char				*path;
 	void				*handle;
 };


### PR DESCRIPTION
'nmsg_modtype' is an enum in the private API that we don't actually use;
we set it in _nmsg_msgmodset_init(), but we don't actually ever use it.
We were setting it just to set it.

We probably won't actually ever need it, so just delete it.