### PR TITLE
Header cleanups

### DIFF
--- a/nmsg/asprintf.h
+++ b/nmsg/asprintf.h
@@ -6,8 +6,6 @@
  * Portable replacements for the asprintf(3) and vasprintf(3) functions.
  */
 
-#include <stdarg.h>
-
 int nmsg_asprintf(char **strp, const char *fmt, ...);
 int nmsg_vasprintf(char **strp, const char *fmt, va_list args);
 

--- a/nmsg/input.h
+++ b/nmsg/input.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +46,6 @@
  *	\li An internal buffer will be allocated and used until an nmsg_input_t
  *	object is destroyed.
  */
-
-#include <nmsg.h>
 
 /** 
  * An enum identifying the underlying implementation of an nmsg_input_t object.

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,10 +37,6 @@
  *	is executing, with the exception of nmsg_io_breakloop() which may be
  *	called to abort the loop.
  */
-
-#include <nmsg/input.h>
-#include <nmsg/output.h>
-#include <nmsg.h>
 
 /**
  * Type of a close event notification.

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -17,6 +17,9 @@
 #ifndef NMSG_IO_H
 #define NMSG_IO_H
 
+#include <nmsg/input.h>
+#include <nmsg/output.h>
+
 /*! \file nmsg/io.h
  * \brief Multi-threaded nmsg I/O processing.
  *

--- a/nmsg/ipdg.h
+++ b/nmsg/ipdg.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 by Farsight Security, Inc.
+ * Copyright (c) 2009-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,9 +24,6 @@
  * IP datagrams, performing reassembly if requested.  Non-IP packets are
  * discarded.
  */
-
-#include <pcap.h>
-#include <nmsg.h>
 
 /**
  * Parsed IP datagram.

--- a/nmsg/message.h
+++ b/nmsg/message.h
@@ -17,6 +17,8 @@
 #ifndef NMSG_MESSAGE_H
 #define NMSG_MESSAGE_H
 
+#include <nmsg/msgmod.h>
+
 /*! \file nmsg/message.h
  * \brief Create, load, inspect, and manipulate message objects. Message
  * objects are proxy objects that bind together the in-memory and wire format

--- a/nmsg/message.h
+++ b/nmsg/message.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2011, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2009-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,8 +63,6 @@
  *
  * nmsg_message_enum_value_to_name() / nmsg_message_enum_value_to_name_by_idx()
  */
-
-#include <nmsg.h>
 
 /**
  * Initialize a new, empty message object of a particular type.

--- a/nmsg/msgmod.h
+++ b/nmsg/msgmod.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2012 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -60,8 +60,6 @@
  *	\li nmsg_msgmod_init() returns an opaque pointer which is used to
  *	differentiate threads if a message module is not stateless.
  */
-
-#include <nmsg.h>
 
 /**
  * Enum mapping protocol buffer schema types to nmsg-specific types for

--- a/nmsg/nmsg.h
+++ b/nmsg/nmsg.h
@@ -94,25 +94,24 @@ typedef nmsg_res (*nmsg_cb_message_read)(nmsg_message_t *msg, void *user);
 
 #include <nmsg/alias.h>
 #include <nmsg/asprintf.h>
+#include <nmsg/chalias.h>
 #include <nmsg/compat.h>
 #include <nmsg/constants.h>
 #include <nmsg/container.h>
-#include <nmsg/chalias.h>
 #include <nmsg/input.h>
+#include <nmsg/io.h>
 #include <nmsg/ipdg.h>
-#include <nmsg/msgmod.h>
 #include <nmsg/message.h>
+#include <nmsg/msgmod.h>
 #include <nmsg/output.h>
 #include <nmsg/pcap_input.h>
-#include <nmsg/rate.h>
 #include <nmsg/random.h>
+#include <nmsg/rate.h>
 #include <nmsg/sock.h>
 #include <nmsg/strbuf.h>
 #include <nmsg/timespec.h>
 #include <nmsg/vendors.h>
 #include <nmsg/zbuf.h>
-
-#include <nmsg/io.h>
 
 /**
  * Initialize the libnmsg library. This function MUST be called before

--- a/nmsg/nmsg.h
+++ b/nmsg/nmsg.h
@@ -28,10 +28,17 @@
 extern "C" {
 #endif
 
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/socket.h>
 #include <sys/types.h>
+#include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 #include <time.h>
+
+#include <pcap.h>
 
 #include <nmsg/res.h>
 typedef enum nmsg_res nmsg_res;
@@ -92,7 +99,6 @@ typedef nmsg_res (*nmsg_cb_message_read)(nmsg_message_t *msg, void *user);
 #include <nmsg/container.h>
 #include <nmsg/chalias.h>
 #include <nmsg/input.h>
-#include <nmsg/io.h>
 #include <nmsg/ipdg.h>
 #include <nmsg/msgmod.h>
 #include <nmsg/message.h>
@@ -105,6 +111,8 @@ typedef nmsg_res (*nmsg_cb_message_read)(nmsg_message_t *msg, void *user);
 #include <nmsg/timespec.h>
 #include <nmsg/vendors.h>
 #include <nmsg/zbuf.h>
+
+#include <nmsg/io.h>
 
 /**
  * Initialize the libnmsg library. This function MUST be called before

--- a/nmsg/nmsg.h
+++ b/nmsg/nmsg.h
@@ -2,7 +2,7 @@
 #define NMSG_H
 
 /*
- * Copyright (c) 2008-2012 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ extern "C" {
 #include <sys/types.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <time.h>
 
 #include <nmsg/res.h>
 typedef enum nmsg_res nmsg_res;

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2012, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,8 +30,6 @@
  * <b>Reliability:</b>
  *	\li Clients must not touch the underlying file descriptor.
  */
-
-#include <nmsg.h>
 
 /**
  * An enum identifying the underlying implementation of an nmsg_output_t object.

--- a/nmsg/pcap_input.h
+++ b/nmsg/pcap_input.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2011 by Farsight Security, Inc.
+ * Copyright (c) 2009-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,9 +29,6 @@
  * reevaluation of the user-provided filter. nmsg_pcap_input_setfilter() and
  * nmsg_pcap_input_read() handle this transparently.
  */
-
-#include <nmsg.h>
-#include <pcap.h>
 
 typedef enum {
 	nmsg_pcap_type_file,

--- a/nmsg/rate.h
+++ b/nmsg/rate.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2009, 2013 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,8 +29,6 @@
  *	limit, provided that the scheduling frequency is smaller than the rate
  *	limit.
  */
-
-#include <nmsg.h>
 
 /**
  * Initialize a new nmsg_rate_t object.

--- a/nmsg/sock.h
+++ b/nmsg/sock.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2010 by Farsight Security, Inc.
+ * Copyright (c) 2010-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,12 +20,6 @@
 /*! \file nmsg/sock.h
  * \brief Socket utilities.
  */
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#include <sys/socket.h>
-
-#include <nmsg.h>
 
 /**
  * Parse an IP address and port number into a sockaddr.

--- a/nmsg/strbuf.h
+++ b/nmsg/strbuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 by Farsight Security, Inc.
+ * Copyright (c) 2009-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,11 +16,6 @@
 
 #ifndef NMSG_STRBUF_H
 #define NMSG_STRBUF_H
-
-#include <stdarg.h>
-#include <stddef.h>
-
-#include <nmsg.h>
 
 /*! \file nmsg/strbuf.h
  * \brief String buffers

--- a/nmsg/timespec.h
+++ b/nmsg/timespec.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008, 2011, 2012 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@
 /*! \file nmsg/timespec.h
  * \brief Sleeping and getting the current time.
  */
-
-#include <time.h>
 
 /**
  * Get the current time.

--- a/nmsg/zbuf.h
+++ b/nmsg/zbuf.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009 by Farsight Security, Inc.
+ * Copyright (c) 2009-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,8 +20,6 @@
 /*! \file nmsg/zbuf.h
  * \brief Compressed buffers.
  */
-
-#include <nmsg.h>
 
 /**
  * Initialize an nmsg_zbuf_t object for deflation.


### PR DESCRIPTION
This cleans up the includes in the public header files and makes a few things
more explicit.

In particular, this should properly fix the build failure on OS X (though I
can't test it) that @mschiffm hacked around in
https://github.com/mschiffm/nmsg/commit/8c51879f36f4a6464d30b8442927266d91cc5556#diff-c21e0fe5e25d0f5a90cd2feb9a992ec8.