### PR TITLE
rewrite nmsg_res_lookup() to use a straight forward switch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ compiler:
 before_install:
     - sudo wget -O /etc/apt/trusted.gpg.d/debian-farsightsec.gpg https://dl.farsightsecurity.com/debian/archive.pubkey
     - sudo sh -c 'echo "deb [arch=amd64] http://dl.farsightsecurity.com/debian wheezy-farsightsec main" > /etc/apt/sources.list.d/debian-farsightsec.list'
+    - sudo sh -c 'echo "deb [arch=amd64] http://dl.farsightsecurity.com/debian wheezy-farsightsec-staging main" >> /etc/apt/sources.list.d/debian-farsightsec.list'
     - sudo apt-get -qq update
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
     - sudo apt-get -qq update
 
 install:
-    - sudo apt-get install -q libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libxs-dev zlib1g-dev docbook5-xml docbook-xsl-ns xsltproc libwdns-dev
+  - sudo apt-get install -q libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libxs-dev zlib1g-dev docbook5-xml docbook-xsl-ns xsltproc libyajl-dev libwdns-dev
 
 script:
     - ./autogen.sh

--- a/configure.ac
+++ b/configure.ac
@@ -108,7 +108,7 @@ fi
 
 AC_ARG_WITH([yajl], AS_HELP_STRING([--without-yajl], [Disable yajl support]))
 if test "x$with_yajl" != "xno"; then
-    PKG_CHECK_MODULES([yajl], [yajl >= 2])
+    PKG_CHECK_MODULES([yajl], [yajl >= 2.1.0])
     AC_DEFINE([HAVE_YAJL], [1], [Define to 1 if yajl support is enabled.])
     use_yajl="true"
 else

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -199,6 +199,15 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>-R</option></term>
+        <term><option>--randomize</option></term>
+        <listitem>
+          <para>Randomize the initial offset within the interval that the
+          process is stopped or outputs are reopened.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-k</option> <replaceable>cmd</replaceable></term>
         <term><option>--kicker</option> <replaceable>cmd</replaceable></term>
         <listitem>

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -211,7 +211,7 @@
         <term><option>-k</option> <replaceable>cmd</replaceable></term>
         <term><option>--kicker</option> <replaceable>cmd</replaceable></term>
         <listitem>
-          <para>Make <option>-c</option> and <option>-k</option>
+          <para>Make <option>-c</option> and <option>-t</option>
           continuous. In this mode output file names are suffixed with
           a timestamp and <command>nmsgtool</command> runs
           continuously, rotating output files as payload counts or

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -254,6 +254,14 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>-j</option> <replaceable>file</replaceable></term>
+        <term><option>--readjson</option> <replaceable>file</replaceable></term>
+        <listitem>
+          <para>Read JSON format data from a file.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-l</option> <replaceable>addr</replaceable>/<replaceable>port</replaceable></term>
         <term><option>--readsock</option> <replaceable>addr</replaceable>/<replaceable>port</replaceable></term>
         <listitem>
@@ -375,6 +383,14 @@
         <listitem>
           <para>Write presentation format payloads to a
           file. <option>-V</option> and <option>-T</option> are required.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-J</option> <replaceable>file</replaceable></term>
+        <term><option>--writejson</option> <replaceable>file</replaceable></term>
+        <listitem>
+          <para>Write JSON payloads to a file.</para>
         </listitem>
       </varlistentry>
 

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -550,7 +550,7 @@ init_timespec_intervals(nmsg_io_t io) {
 	} else {
 		nmsg_random_t r = nmsg_random_init();
 		io->interval_offset = nmsg_random_uniform(r, io->interval);
-		now.tv_sec = now.tv_sec - io->interval + io->interval_offset + 1;
+		now.tv_sec = now.tv_sec - (now.tv_sec % io->interval) + io->interval_offset;
 		nmsg_random_destroy(&r);
 	}
 

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -387,6 +387,18 @@ void
 nmsg_io_set_interval(nmsg_io_t io, unsigned interval);
 
 /**
+ * Configure the nmsg_io_t object to randomize the initial second within the
+ * interval where it closes inputs, rather than on the zeroth second
+ * of the interval.
+ *
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] randomized Boolean flag.
+ */
+void
+nmsg_io_set_interval_randomized(nmsg_io_t io, bool randomized);
+
+/**
  * Set the output mode behavior for an nmsg_io_t object. Nmsg payloads received
  * from inputs may be striped across available outputs (the default), or
  * mirrored across all available outputs.

--- a/nmsg/msgmodset.c
+++ b/nmsg/msgmodset.c
@@ -115,7 +115,6 @@ _nmsg_msgmodset_init(const char *plugin_path) {
 				continue;
 			}
 
-			dlmod->type = nmsg_modtype_msgmod;
 			ISC_LIST_APPEND(msgmodset->dlmods, dlmod, link);
 
 			if (plugin != NULL) {

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -102,10 +102,6 @@ do { \
 /* Enums. */
 
 typedef enum {
-	nmsg_modtype_msgmod
-} nmsg_modtype;
-
-typedef enum {
 	nmsg_stream_type_file,
 	nmsg_stream_type_sock,
 	nmsg_stream_type_xs,
@@ -384,7 +380,6 @@ struct nmsg_message {
 
 struct nmsg_dlmod {
 	ISC_LINK(struct nmsg_dlmod)	link;
-	nmsg_modtype			type;
 	char				*path;
 	void				*handle;
 };

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -88,6 +88,12 @@ static argv_t args[] = {
 		"secs",
 		"stop or reopen after secs have elapsed" },
 
+	{ 'R', "randomize",
+		ARGV_BOOL,
+		&ctx.interval_randomized,
+		NULL,
+		"randomize beginning of -t interval" },
+
 	{ 'k',	"kicker",
 		ARGV_CHAR_P,
 		&ctx.kicker,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -47,7 +47,7 @@ typedef struct {
 	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
-	bool		help, mirror, unbuffered, zlibout, daemon, version;
+	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
 	char		*endline, *kicker, *mname, *vname, *bpfstr;
 	int		debug;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -116,6 +116,8 @@ process_args(nmsgtool_ctx *c) {
 		nmsg_io_set_count(c->io, c->count);
 	if (c->interval > 0)
 		nmsg_io_set_interval(c->io, c->interval);
+	if (c->interval_randomized == true)
+		nmsg_io_set_interval_randomized(c->io, true);
 	if (c->mirror == true)
 		nmsg_io_set_output_mode(c->io, nmsg_io_output_mode_mirror);
 


### PR DESCRIPTION
nmsg/res.c triggers `-Wtautological-constant-out-of-range-compare` when compiled with clang. rewrite it to use a straight forward switch statement.

```
nmsg/res.c:43:10: warning: comparison of constant 16 with expression of type 'enum nmsg_res' is
      always true [-Wtautological-constant-out-of-range-compare]
            val <= sizeof(res_strings) / sizeof(char *) &&
            ~~~ ^  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```