### PR TITLE
nmsg/private.h: add yajl/ prefix to yajl header include path

### DIFF
--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -60,8 +60,8 @@
 #endif /* HAVE_LIBXS */
 
 #ifdef HAVE_YAJL
-#include <yajl_gen.h>
-#include <yajl_tree.h>
+#include <yajl/yajl_gen.h>
+#include <yajl/yajl_tree.h>
 #endif /* HAVE_YAJL */
 
 #include "nmsg.h"


### PR DESCRIPTION
For OS X, possibly others.