### PR TITLE
Branches/filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ stamp-h1
 stamp-h2
 tags
 test
+test-suite.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ script:
     - ./autogen.sh
     - ./configure
     - make
+    - make clean
     - make distcheck

--- a/Makefile.am
+++ b/Makefile.am
@@ -233,6 +233,15 @@ EXTRA_DIST += \
 	nmsg/base/pkt.c \
 	nmsg/base/xml.c
 
+FLT_LIBTOOL_FLAGS = -module -avoid-version -shared -export-symbols-regex "^nmsg_fltmod_plugin_export$$"
+
+module_LTLIBRARIES += fltmod/nmsg_flt1_sample.la
+fltmod_nmsg_flt1_sample_la_LDFLAGS = \
+	$(AM_LDFLAGS) \
+	$(FLT_LIBTOOL_FLAGS)
+fltmod_nmsg_flt1_sample_la_SOURCES = \
+	fltmod/nmsg_flt_sample.c
+
 bin_PROGRAMS += src/nmsgtool
 src_nmsgtool_LDADD = \
 	nmsg/libnmsg.la \

--- a/Makefile.am
+++ b/Makefile.am
@@ -46,6 +46,8 @@ nobase_include_HEADERS = \
 	nmsg/constants.h \
 	nmsg/container.h \
 	nmsg/filter.h \
+	nmsg/fltmod.h \
+	nmsg/fltmod_plugin.h \
 	nmsg/input.h \
 	nmsg/io.h \
 	nmsg/ipdg.h \
@@ -93,6 +95,7 @@ nmsg_libnmsg_la_SOURCES = \
 	nmsg/chalias.c \
 	nmsg/container.c \
 	nmsg/dlmod.c \
+	nmsg/fltmod.c \
 	nmsg/input.c \
 	nmsg/input_callback.c \
 	nmsg/input_frag.c \

--- a/Makefile.am
+++ b/Makefile.am
@@ -45,6 +45,7 @@ nobase_include_HEADERS = \
 	nmsg/compat.h \
 	nmsg/constants.h \
 	nmsg/container.h \
+	nmsg/filter.h \
 	nmsg/input.h \
 	nmsg/io.h \
 	nmsg/ipdg.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -278,6 +278,12 @@ noinst_PROGRAMS += \
 	examples/nmsg-dnsqr2pcap \
 	examples/nmsg-packet2pcap
 
+TESTS += tests/nmsg.test
+
+TESTS += tests/test-layout-fltmod_plugin
+check_PROGRAMS += tests/test-layout-fltmod_plugin
+tests_test_layout_fltmod_plugin_SOURCES = tests/test-layout-fltmod_plugin.c
+
 examples_email_client_LDADD = nmsg/libnmsg.la
 examples_email_client_SOURCES = examples/email_client.c
 
@@ -324,5 +330,3 @@ clean-local:
 install-data-hook:
 	rm -rf $(DESTDIR)$(includedir)/nmsg/isc
 	$(LN_S) -f base $(DESTDIR)$(includedir)/nmsg/isc
-
-TESTS += tests/nmsg.test

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -240,6 +240,50 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>-F</option> <replaceable>dso</replaceable><optional>,<replaceable>param</replaceable></optional></term>
+        <term><option>--filter</option> <replaceable>dso</replaceable><optional>,<replaceable>param</replaceable></optional></term>
+        <listitem>
+          <para>Filter nmsg payloads with a module loaded from the given DSO
+          file. The <replaceable>dso</replaceable> specified may either be a
+          short, human friendly name (like <replaceable>sample</replaceable>)
+          which will be expanded into an absolute filename in the default
+          system-wide libnmsg module path, or it may be a name beginning with
+          <replaceable>/</replaceable> or <replaceable>.</replaceable> (like
+          <replaceable>/usr/lib/nmsg/nmsg_flt1_sample.so</replaceable>), in
+          which case the <replaceable>dso</replaceable> value will be treated as
+          an absolute or relative path name.</para>
+
+          <para>Filter modules may take a module-defined parameter string
+          <replaceable>param</replaceable>. The <replaceable>dso</replaceable>
+          value may be followed by a comma, in which case everything after the
+          comma is treated as the module parameter
+          <replaceable>param</replaceable> and passed to the module's
+          initialization function. Some modules may require a
+          <replaceable>param</replaceable> value or may perform additional
+          validation on the parameter. If the module fails to initialize,
+          <command>nmsgtool</command> will exit with an error message.</para>
+
+          <para>This option can be specified more than once, in which case the
+          filter modules will be loaded in the order they were specified in on
+          the command-line, and will form a linear filter chain.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--policy</option> <option>ACCEPT</option>|<option>DROP</option></term>
+        <listitem>
+          <para>If any filter modules have been loaded with <option>-F</option>,
+          <option>--policy</option> may be used to specify the policy action to
+          take if all filters in the filter chain decline to handle a given
+          message. The default policy action is <option>--policy ACCEPT</option>,
+          which causes messages that are declined by the filter chain to be
+          accepted into the output stream. If <option>--policy DROP</option> is
+          specified, any messages which are declined by the filter chain will be
+          silently discarded.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>-r</option> <replaceable>file</replaceable></term>
         <term><option>--readnmsg</option> <replaceable>file</replaceable></term>
         <listitem>

--- a/doc/doxygen/Doxyfile.in
+++ b/doc/doxygen/Doxyfile.in
@@ -582,7 +582,7 @@ INPUT_ENCODING         = UTF-8
 # *.c *.cc *.cxx *.cpp *.c++ *.java *.ii *.ixx *.ipp *.i++ *.inl *.h *.hh *.hxx 
 # *.hpp *.h++ *.idl *.odl *.cs *.php *.php3 *.inc *.m *.mm *.py *.f90
 
-FILE_PATTERNS          = 
+FILE_PATTERNS          = *.h
 
 # The RECURSIVE tag can be used to turn specify whether or not subdirectories 
 # should be searched for input files as well. Possible values are YES and NO. 

--- a/fltmod/nmsg_flt_sample.c
+++ b/fltmod/nmsg_flt_sample.c
@@ -1,0 +1,294 @@
+/*
+ * Copyright (c) 2016 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Import. */
+
+#include <sys/time.h>
+#include <inttypes.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include <nmsg/fltmod_plugin.h>
+
+#include "libmy/my_alloc.h"
+
+/* Macros. */
+
+#define _nmsg_dprintf(level, format, ...) \
+do { \
+	if (nmsg_get_debug() >= (level)) \
+		fprintf(stderr, format, ##__VA_ARGS__); \
+} while (0)
+
+/* Private declarations. */
+
+typedef enum {
+	/**
+	 * Systematic count-based sampling.
+	 * Every k-th message is selected.
+	 */
+	sample_type_count,
+
+	/**
+	 * Uniform probabilistic sampling.
+	 * The same selection probability is applied to all messages.
+	 */
+	sample_type_random,
+} sample_type;
+
+struct sample_options {
+	sample_type		type;
+	union {
+		/**
+		 * sample_type_count: select every k-th message.
+		 */
+		uintmax_t	k;
+
+		/**
+		 * sample_type_random: message selection probability.
+		 */
+		double		p;
+	};
+};
+
+struct sample_thread_state {
+	/**
+	 * 48-bit PRNG state for per-thread erand48() / nrand48().
+	 */
+	unsigned short		xsubi[3];
+
+	union {
+		/**
+		 * sample_type_count: per-thread message counter.
+		 */
+		uintmax_t	count;
+	};
+};
+
+/* Functions. */
+
+static nmsg_res
+sample_module_init(const void *param,
+		   const size_t len_param,
+		   void **mod_data)
+{
+	char *my_param = NULL;
+	struct sample_options *sopt = NULL;
+
+	/**
+	 * Validate module parameter.
+	 *
+	 * 'param' should be a \0 terminated C string containing 'len_param'
+	 * bytes of data, including the terminating \0.
+	 */
+	if (param == NULL) {
+		_nmsg_dprintf(1, "%s: module parameter is required but missing\n", __func__);
+		goto err;
+	}
+	if (len_param != strlen(param) + 1) {
+		_nmsg_dprintf(1, "%s: module parameter length mismatch\n", __func__);
+		goto err;
+	}
+
+	/* Make a copy of the caller's const parameter, for strtok_r() to clobber. */
+	my_param = my_strdup(param);
+
+	/**
+	 * Parse module parameter.
+	 *
+	 * The module parameter must be something like "count=<INTEGER>" or
+	 * "random=<DOUBLE>", where <INTEGER> is a number that can be parsed by
+	 * strtoumax() and <DOUBLE> is a number that can be parsed by strtod().
+	 * Then we apply range restrictions to those numbers.
+	 *
+	 * Specifying the "count=..." parameter selects systematic count-based
+	 * sampling (sample_type_count), while specifying the "random=..."
+	 * parameter selects uniform probabilistic sampling
+	 * (sample_type_random).
+	 *
+	 * If we add optional fields to the module parameter, we'll split them
+	 * on "," characters.
+	 */
+	char *saveptr = NULL;
+	char *tok1 = strtok_r(my_param, "=,", &saveptr);
+	char *tok2 = strtok_r(NULL, "=,", &saveptr);
+	char *tok3 = strtok_r(NULL, "=,", &saveptr);
+
+	if (tok1 == NULL ||
+	    tok2 == NULL ||
+	    tok3 != NULL)
+	{
+		/* Parse error. */
+		goto err;
+	}
+	
+	/* Allocate space for module-wide options. */
+	sopt = my_calloc(1, sizeof(*sopt));
+
+	/* Parse module option "count" or "random". */
+	if (strcasecmp(tok1, "count") == 0) {
+		sopt->type = sample_type_count;
+
+		/* Attempt numeric conversion. */
+		char *t = NULL;
+		uintmax_t val = strtoumax(tok2, &t, 0);
+		if (*t != '\0') {
+			/* Parse error. */
+			goto err;
+		}
+		if (val < 1) {
+			/* Parameter out of range. */
+			_nmsg_dprintf(1, "%s: 'count' value %" PRIuMAX
+				      " is out of range [1, %" PRIuMAX "]\n",
+				      __func__, val, UINTMAX_MAX);
+			goto err;
+		}
+		/* Store module-wide option "k". */
+		sopt->k = val;
+	} else if (strcasecmp(tok1, "random") == 0) {
+		sopt->type = sample_type_random;
+
+		/* Attempt numeric conversion. */
+		char *t = NULL;
+		double val = strtod(tok2, &t);
+		if (*t != '\0') {
+			/* Parse error. */
+			goto err;
+		}
+		if (val < 0.0 || val > 1.0) {
+			/* Parameter out of range. */
+			_nmsg_dprintf(1, "%s: 'random' value %s is out of range [0.0, 1.0]\n",
+				      __func__, tok2);
+			goto err;
+		}
+		/* Store module-wide option "p". */
+		sopt->p = val;
+	} else {
+		/* Parse error, unrecognized option. */
+		_nmsg_dprintf(1, "%s: unrecognized option '%s'\n", __func__, tok1);
+		goto err;
+	}
+
+	my_free(my_param);
+	*mod_data = sopt;
+	return nmsg_res_success;
+err:
+	my_free(sopt);
+	my_free(my_param);
+	return nmsg_res_failure;
+}
+
+static void
+sample_module_fini(void *mod_data)
+{
+	my_free(mod_data);
+}
+
+static nmsg_res
+sample_thread_init(void *mod_data, void **thr_data)
+{
+	if (!mod_data) {
+		return nmsg_res_failure;
+	}
+
+	struct sample_options *sopt = (struct sample_options *) mod_data;
+	struct sample_thread_state *state = my_calloc(1, sizeof(*state));
+
+	/* Initialize state->xsubi, seed for this thread's random generator. */
+	struct timeval tv = {0};
+	gettimeofday(&tv, NULL);
+	uint32_t seed = (unsigned) tv.tv_sec + (unsigned) tv.tv_usec + (unsigned) pthread_self();
+	memcpy(state->xsubi, &seed, sizeof(seed));
+
+	switch (sopt->type) {
+	case sample_type_count:
+		/**
+		 * Initialize state->count to a random value modulo k so that
+		 * threads don't "clump" their selections.
+		 */
+		state->count = nrand48(state->xsubi) % sopt->k;
+		break;
+	case sample_type_random:
+		break;
+	}
+
+	*thr_data = state;
+	return nmsg_res_success;
+}
+
+static nmsg_res
+sample_thread_fini(void *mod_data, void *thr_data)
+{
+	my_free(thr_data);
+	return nmsg_res_success;
+}
+
+static nmsg_res
+sample_filter_message(nmsg_message_t *msg,
+		      void *mod_data,
+		      void *thr_data,
+		      nmsg_filter_message_verdict *vres)
+{
+	if (!mod_data || !thr_data) {
+		return nmsg_res_failure;
+	}
+
+	struct sample_options *sopt = (struct sample_options *) mod_data;
+	struct sample_thread_state *state = (struct sample_thread_state *) thr_data;
+
+	*vres = nmsg_filter_message_verdict_DECLINED;
+
+	switch (sopt->type) {
+	case sample_type_count:
+		state->count += 1;
+		if (state->count >= sopt->k) {
+			/* Selected the k-th message. */
+			state->count = 0;
+			*vres = nmsg_filter_message_verdict_DECLINED;
+		} else {
+			/* Dropped message. */
+			*vres = nmsg_filter_message_verdict_DROP;
+		}
+		break;
+	case sample_type_random:
+		if (erand48(state->xsubi) < sopt->p) {
+			/* Message was selected with probability p. */
+			*vres = nmsg_filter_message_verdict_DECLINED;
+		} else {
+			/* Dropped message. */
+			*vres = nmsg_filter_message_verdict_DROP;
+		}
+		break;
+	}
+
+	return nmsg_res_success;
+}
+
+/* Export. */
+
+struct nmsg_fltmod_plugin nmsg_fltmod_plugin_export = {
+	NMSG_FLTMOD_REQUIRED_INIT,
+
+	.module_init		= sample_module_init,
+	.module_fini		= sample_module_fini,
+	.thread_init		= sample_thread_init,
+	.thread_fini		= sample_thread_fini,
+	.filter_message		= sample_filter_message,
+};

--- a/fltmod/nmsg_flt_sample.c
+++ b/fltmod/nmsg_flt_sample.c
@@ -136,6 +136,8 @@ sample_module_init(const void *param,
 	    tok3 != NULL)
 	{
 		/* Parse error. */
+		_nmsg_dprintf(1, "%s: error parsing module parameter '%s'\n",
+			      __func__, (char *) param);
 		goto err;
 	}
 	
@@ -151,6 +153,8 @@ sample_module_init(const void *param,
 		uintmax_t val = strtoumax(tok2, &t, 0);
 		if (*t != '\0') {
 			/* Parse error. */
+			_nmsg_dprintf(1, "%s: error converting string to integer: '%s'\n",
+				      __func__, tok2);
 			goto err;
 		}
 		if (val < 1) {
@@ -170,6 +174,8 @@ sample_module_init(const void *param,
 		double val = strtod(tok2, &t);
 		if (*t != '\0') {
 			/* Parse error. */
+			_nmsg_dprintf(1, "%s: error converting string to floating point value: '%s'\n",
+				      __func__, tok2);
 			goto err;
 		}
 		if (val < 0.0 || val > 1.0) {

--- a/nmsg/filter.h
+++ b/nmsg/filter.h
@@ -51,18 +51,23 @@ typedef enum {
  * in the 'vres' parameter-return variable.
  *
  * The filter function may alter the message object, or it may replace the
- * message object entirely with a new message. If the filter function replaces
+ * message object with an entirely new message. If the filter function replaces
  * the message object, it is responsible for disposing of the old message, for
  * instance by calling nmsg_message_destroy().
  *
- * \param[in,out] msg Pointer to message object.
- * \param[in] user NULL or a filter-specific user pointer.
- * \param[out] vres The filter verdict.
+ * \param[in,out] msg
+ *	Pointer to message object.
  *
- * \return #nmsg_res_success if a filter verdict was successfully determined,
- * or any non-success result code otherwise. A non-success result code
- * indicates to the caller that a fatal error has occurred and that processing
- * should immediately stop.
+ * \param[in] user
+ *	NULL or a filter-specific user pointer.
+ *
+ * \param[out] vres
+ *	The filter verdict.
+ *
+ * \return #nmsg_res_success
+ *      The filtering completed and returned a verdict in 'vres'.
+ * \return
+ *      Any other result to indicate a fatal error.
  */
 typedef nmsg_res (*nmsg_filter_message_fp)(nmsg_message_t *msg,
 					   void *user,

--- a/nmsg/filter.h
+++ b/nmsg/filter.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NMSG_FILTER_H
+#define NMSG_FILTER_H
+
+/*! \file nmsg/filter.h
+ * \brief Message filtering API.
+ */
+
+typedef enum {
+	/**
+	 * The filter declines to handle this message for an unspecified
+	 * reason, and processing should proceed as if the filter did not
+	 * exist. If part of a filter chain, filtering should proceed to the
+	 * next filter in the chain.
+	 */
+	nmsg_filter_message_verdict_DECLINED,
+
+	/**
+	 * The filter declares that this message should be accepted into the
+	 * output stream. If part of a filter chain, remaining filters should
+	 * be short-circuited and the message passed into the output stream.
+	 */
+	nmsg_filter_message_verdict_ACCEPT,
+
+	/**
+	 * The filter declares that this message should be dropped from the
+	 * output stream. If part of a filter chain, remaining filters should
+	 * be short-circuited.
+	 */
+	nmsg_filter_message_verdict_DROP,
+} nmsg_filter_message_verdict;
+
+/**
+ * Function pointer type for a function that performs message filtering. The
+ * filter function should read the message in 'msg' and return a filter verdict
+ * in the 'vres' parameter-return variable.
+ *
+ * \param[in] msg Message object.
+ * \param[in] user NULL or a filter-specific user pointer.
+ * \param[out] vres The filter verdict.
+ *
+ * \return #nmsg_res_success if a filter verdict was successfully determined,
+ * or any non-success result code otherwise. A non-success result code
+ * indicates to the caller that a fatal error has occurred and that processing
+ * should immediately stop.
+ */
+typedef nmsg_res (*nmsg_filter_message_fp)(nmsg_message_t msg,
+					   void *user,
+					   nmsg_filter_message_verdict *vres);
+
+#endif /* NMSG_FILTER_H */

--- a/nmsg/filter.h
+++ b/nmsg/filter.h
@@ -50,7 +50,12 @@ typedef enum {
  * filter function should read the message in 'msg' and return a filter verdict
  * in the 'vres' parameter-return variable.
  *
- * \param[in] msg Message object.
+ * The filter function may alter the message object, or it may replace the
+ * message object entirely with a new message. If the filter function replaces
+ * the message object, it is responsible for disposing of the old message, for
+ * instance by calling nmsg_message_destroy().
+ *
+ * \param[in,out] msg Pointer to message object.
  * \param[in] user NULL or a filter-specific user pointer.
  * \param[out] vres The filter verdict.
  *
@@ -59,7 +64,7 @@ typedef enum {
  * indicates to the caller that a fatal error has occurred and that processing
  * should immediately stop.
  */
-typedef nmsg_res (*nmsg_filter_message_fp)(nmsg_message_t msg,
+typedef nmsg_res (*nmsg_filter_message_fp)(nmsg_message_t *msg,
 					   void *user,
 					   nmsg_filter_message_verdict *vres);
 

--- a/nmsg/fltmod.c
+++ b/nmsg/fltmod.c
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) 2015 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Import. */
+
+#include <dlfcn.h>
+
+#include "private.h"
+
+/* Private declarations .*/
+
+/**
+ * The name of the symbol inside the dlopen()'d module that exports the
+ * plugin's struct nmsg_fltmod_plugin.
+ */
+#define NMSG_FLTMOD_ENTRY_POINT		"nmsg_fltmod_plugin_export"
+
+struct nmsg_fltmod {
+	struct nmsg_fltmod_plugin	*plugin;
+	char				*fname;
+	void				*dlhandle;
+	void				*mod_data;
+};
+
+/* Private functions. */
+
+static void *
+nmsg__fltmod_dlopen(const char *filename, int flag)
+{
+	void *ret = dlopen(filename, flag);
+	if (ret == NULL) {
+		_nmsg_dprintf(4, "%s: dlopen() failed: %s\n", __func__, dlerror());
+	}
+	return ret;
+}
+
+static void
+nmsg__fltmod_dlclose(void *handle)
+{
+	if (dlclose(handle) != 0) {
+		_nmsg_dprintf(4, "%s: dlclose() failed: %s\n", __func__, dlerror());
+	}
+}
+
+static void *
+nmsg__fltmod_dlsym(void *handle, const char *symbol)
+{
+	/* Clear any old error condition. */
+	dlerror();
+
+	/* Call dlsym(). */
+	void *ret = dlsym(handle, symbol);
+
+	/* Check for an error. */
+	char *err = dlerror();
+	if (err != NULL) {
+		_nmsg_dprintf(4, "%s: dlsym() failed: %s\n", __func__, err);
+	}
+
+	return ret;
+}
+
+/* Export. */
+
+nmsg_fltmod_t
+nmsg_fltmod_init(const char *name, const void *param, const size_t len_param)
+{
+	struct nmsg_fltmod *fltmod = my_calloc(1, sizeof(*fltmod));
+
+	/**
+	 * 'name' can be either an absolute or relative path (begins with "/"
+	 * or ".") to a particular plugin file, or it can be a shorter human
+	 * friendly name which we need to expand into a full file path.
+	 */
+	if (strlen(name) > 0 && name[0] != '/' && name[0] != '.') {
+		/* Expand the short name into a full path name. */
+		ubuf *u = ubuf_init(64);
+		ubuf_add_fmt(u, "%s/%s_%s%s",
+			     NMSG_LIBDIR,
+			     NMSG_FLT_MODULE_PREFIX,
+			     name,
+			     NMSG_MODULE_SUFFIX);
+		fltmod->fname = my_strdup(ubuf_cstr(u));
+		ubuf_destroy(&u);
+	} else {
+		/* Use 'name' as a full path name verbatim. */
+		fltmod->fname = my_strdup(name);
+	}
+
+	/* Open a handle to the dynamic library file. */
+	fltmod->dlhandle = nmsg__fltmod_dlopen(fltmod->fname, RTLD_LAZY);
+	if (fltmod->dlhandle == NULL) {
+		_nmsg_dprintf(1, "%s: ERROR: unable to open module file %s\n",
+			      __func__, fltmod->fname);
+		goto fail;
+	}
+
+	/* Check if the dynamic library file has our entry point. */
+	fltmod->plugin = (struct nmsg_fltmod_plugin *)
+		nmsg__fltmod_dlsym(fltmod->dlhandle, NMSG_FLTMOD_ENTRY_POINT);
+	if (fltmod->plugin == NULL) {
+		goto fail;
+	}
+
+	/* Check if we support the plugin's ABI version. */
+	if (fltmod->plugin->fltmod_version != NMSG_FLTMOD_VERSION) {
+		_nmsg_dprintf(1, "%s: WARNING: module '%s' version mismatch, not loading\n",
+			      __func__, fltmod->fname);
+		goto fail;
+	}
+
+	/* Call the module initialization function. */
+	if (fltmod->plugin->module_init != NULL) {
+		nmsg_res res = fltmod->plugin->module_init(param, len_param, &fltmod->mod_data);
+		if (res != nmsg_res_success) {
+			_nmsg_dprintf(1, "%s: WARNING: module '%s' init failed with res %d (%s), "
+				      "not loading\n",
+				      __func__, fltmod->fname, res, nmsg_res_lookup(res));
+			goto fail;
+		}
+	}
+
+	return fltmod;
+
+fail:
+	if (fltmod->dlhandle != NULL)
+		nmsg__fltmod_dlclose(fltmod->dlhandle);
+	free(fltmod->fname);
+	free(fltmod);
+	return NULL;
+}
+
+void
+nmsg_fltmod_destroy(nmsg_fltmod_t *fltmod)
+{
+	/* Call the module finalization function. */
+	if ((*fltmod)->plugin->module_fini != NULL) {
+		(*fltmod)->plugin->module_fini((*fltmod)->mod_data);
+	}
+	/* Close the handle to the dynamic library file. */
+	nmsg__fltmod_dlclose((*fltmod)->dlhandle);
+
+	my_free((*fltmod)->fname);
+	my_free(*fltmod);
+}
+
+nmsg_res
+nmsg_fltmod_thread_init(nmsg_fltmod_t fltmod, void **thr_data)
+{
+	if (fltmod->plugin->thread_init != NULL) {
+		nmsg_res res = fltmod->plugin->thread_init(fltmod->mod_data, thr_data);
+		if (res != nmsg_res_success) {
+			_nmsg_dprintf(2, "%s: WARNING: module '%s' thread_init failed with res %d (%s)\n",
+				      __func__, fltmod->fname, res, nmsg_res_lookup(res));
+		}
+		return res;
+	}
+	return nmsg_res_success;
+}
+
+nmsg_res
+nmsg_fltmod_thread_fini(nmsg_fltmod_t fltmod, void *thr_data)
+{
+	if (fltmod->plugin->thread_fini != NULL) {
+		nmsg_res res = fltmod->plugin->thread_fini(fltmod->mod_data, thr_data);
+		if (res != nmsg_res_success) {
+			_nmsg_dprintf(2, "%s: WARNING: module '%s' thread_fini failed with res %d (%s)\n",
+				      __func__, fltmod->fname, res, nmsg_res_lookup(res));
+		}
+		return res;
+	}
+	return nmsg_res_success;
+}
+
+nmsg_res
+nmsg_fltmod_filter_message(nmsg_fltmod_t fltmod,
+			   nmsg_message_t msg,
+			   void *thr_data,
+			   nmsg_filter_message_verdict *vres)
+{
+	if (fltmod->plugin->filter_message != NULL) {
+		return fltmod->plugin->filter_message(msg, fltmod->mod_data, thr_data, vres);
+	}
+	return nmsg_res_notimpl;
+}

--- a/nmsg/fltmod.c
+++ b/nmsg/fltmod.c
@@ -187,7 +187,7 @@ nmsg_fltmod_thread_fini(nmsg_fltmod_t fltmod, void *thr_data)
 
 nmsg_res
 nmsg_fltmod_filter_message(nmsg_fltmod_t fltmod,
-			   nmsg_message_t msg,
+			   nmsg_message_t *msg,
 			   void *thr_data,
 			   nmsg_filter_message_verdict *vres)
 {

--- a/nmsg/fltmod.c
+++ b/nmsg/fltmod.c
@@ -112,6 +112,8 @@ nmsg_fltmod_init(const char *name, const void *param, const size_t len_param)
 	fltmod->plugin = (struct nmsg_fltmod_plugin *)
 		nmsg__fltmod_dlsym(fltmod->dlhandle, NMSG_FLTMOD_ENTRY_POINT);
 	if (fltmod->plugin == NULL) {
+		_nmsg_dprintf(1, "%s: WARNING: module '%s' missing entry point '%s', not loading\n",
+			      __func__, fltmod->fname, NMSG_FLTMOD_ENTRY_POINT);
 		goto fail;
 	}
 

--- a/nmsg/fltmod.h
+++ b/nmsg/fltmod.h
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2015 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NMSG_FLTMOD_H
+#define NMSG_FLTMOD_H
+
+/*! \file nmsg/fltmod.h
+ * \brief Message filter modules.
+ *
+ * Message filter modules allow a message filtering function to be implemented
+ * externally in a dynamically loaded plugin.
+ *
+ * Filter modules are dynamically loaded shared objects that must export a
+ * symbol called <tt>nmsg_fltmod_plugin_export</tt>. This is a structure of type
+ * #nmsg_fltmod_plugin and is the sole entry point into the module.
+ *
+ * The first field of the nmsg_fltmod_plugin structure is the version of the
+ * API/ABI between libnmsg and the filter module. Module developers should
+ * assign this field the value #NMSG_FLTMOD_VERSION, or they can add
+ * <tt>NMSG_FLTMOD_REQUIRED_INIT,</tt> to the initializer, which is a
+ * convenience macro that initializes required fields.
+ *
+ * A filter module needs to provide at least one function, the core message
+ * filtering function <tt>message_filter</tt>. This function must be reentrant,
+ * since it may be called from multiple threads simultaneously.
+ *
+ * Optionally, up to four more functions may be provided: a global module
+ * initializer and finalizer (<tt>module_init</tt> and <tt>module_fini</tt>),
+ * and a per-thread initializer and finalizer (<tt>thread_init</tt> and
+ * <tt>thread_fini</tt>). These functions can be used to acquire and release
+ * resources, generate debug messages, etc. The module and thread initializers
+ * may provide opaque data pointers via a parameter-return value. These pointers
+ * will be provided as parameters to the message filtering function.
+ *
+ * The <tt>module_init</tt> function will only be called once, immediately after
+ * the plugin module has been loaded. It will be called before all other module
+ * functions. Therefore, it does not need to be reentrant.
+ *
+ * The <tt>module_fini</tt> function will only be called once, immediately
+ * before the plugin module will be unloaded from the process. It will be called
+ * after all other module functions. Therefore, it does not need to be
+ * reentrant.
+ *
+ * The <tt>thread_init</tt> and <tt>thread_fini</tt> may be called by a
+ * processing thread after the thread has started and before the thread exits.
+ * They need to be reentrant, since they be called by independently executing
+ * threads. A thread may not call a module's <tt>message_filter</tt> function
+ * before it has called <tt>thread_init</tt>, and it may not call
+ * <tt>message_filter</tt> after it has called <tt>thread_fini</tt>.
+ *
+ * For an example of a simple message filtering module, see the "sample" filter
+ * module in the fltmod/ directory of the nmsg distribution. The "sample" filter
+ * performs either systematic count-based or uniform probabilistic sampling of
+ * the message stream.
+ */
+
+#include <nmsg/filter.h>
+
+/**
+ * Initialize a filter module with the given parameters. Calls the module's
+ * 'module_init' function.
+ *
+ * \param name
+ *	The name of the filter module, which is used to construct the filesystem
+ *	path to the shared object containing the filter module. This may either
+ *	be a real, complete filesystem path (absolute or relative) that begins
+ *	with "/" or "./", or it may be a short "convenience" name that will be
+ *	expanded to a real filesystem path. For example, the short name "sample"
+ *	might be expanded to a long name like
+ *	"/usr/lib/nmsg/nmsg_flt1_sample.so".
+ *
+ * \param param
+ *	Pointer to a value that will be passed to the 'module_init' function.
+ *	Specifies module-specific configuration.
+ *
+ * \param len_param
+ *	Length of the 'param' value. Passed to the 'module_init' function.
+ */
+nmsg_fltmod_t
+nmsg_fltmod_init(const char *name, const void *param, const size_t len_param);
+
+/**
+ * Destroy a filter module. Calls the module's 'module_fini' function.
+ *
+ * \param[in] fltmod
+ *	Initialized fltmod.
+ */
+void
+nmsg_fltmod_destroy(nmsg_fltmod_t *fltmod);
+
+/**
+ * Initialize thread-specific data for the filter module. Must be called by a
+ * processing thread before calling #nmsg_fltmod_filter_message(). Calls the
+ * module's 'thread_init' function.
+ *
+ * \param fltmod
+ *	Initialized fltmod.
+ *
+ * \param[out] thr_data
+ *	Opaque data pointer specific to the calling thread. This pointer must be
+ *	supplied in subsequent calls to #nmsg_fltmod_filter_message() or
+ *	#nmsg_fltmod_thread_fini(). The caller must provide space to store this
+ *	value.
+ *
+ * \return #nmsg_res_success
+ *	If the thread data was successfully initialized.
+ * \return
+ *	Any other result may be returned by the module's 'thread_init' function
+ *	to indicate an error.
+ */
+nmsg_res
+nmsg_fltmod_thread_init(nmsg_fltmod_t fltmod, void **thr_data);
+
+/**
+ * Release any thread-specific resources acquired by #nmsg_fltmod_thread_init().
+ * Calls the module's 'thread_fini' function.
+ *
+ * \param fltmod
+ *	Initialized fltmod.
+ *
+ * \param thr_data
+ *	Opaque data pointer originally returned by #nmsg_fltmod_thread_init().
+ *
+ * \return #nmsg_res_success
+ *	If the thread data was successfully released.
+ * \return
+ *	Any other result may be returned by the module's 'thread_fini' function
+ *	to indicate an error.
+ */
+nmsg_res
+nmsg_fltmod_thread_fini(nmsg_fltmod_t fltmod, void *thr_data);
+
+/**
+ * Filter a message payload and return the filter verdict. Calls the module's
+ * 'filter_message' function.
+ *
+ * \param fltmod
+ *	Initialized fltmod.
+ *
+ * \param msg
+ *	The NMSG message payload to be filtered.
+ *
+ * \param thr_data
+ *	Opaque data pointer originally returned by #nmsg_fltmod_thread_init().
+ *
+ * \param[out] vres
+ *	The filter verdict. \see #nmsg_filter_message_verdict for the possible
+ *	verdict results and meanings.
+ *
+ * \return #nmsg_res_success
+ *	The filtering completed and returned a verdict in 'vres'.
+ * \return
+ *	Any other result may be returned to indicate a fatal error.
+ */
+nmsg_res
+nmsg_fltmod_filter_message(nmsg_fltmod_t fltmod,
+			   nmsg_message_t msg,
+			   void *thr_data,
+			   nmsg_filter_message_verdict *vres);
+
+#endif /* NMSG_FLTMOD_H */

--- a/nmsg/fltmod.h
+++ b/nmsg/fltmod.h
@@ -150,7 +150,7 @@ nmsg_fltmod_thread_fini(nmsg_fltmod_t fltmod, void *thr_data);
  * \param fltmod
  *	Initialized fltmod.
  *
- * \param msg
+ * \param[in,out] msg
  *	The NMSG message payload to be filtered.
  *
  * \param thr_data
@@ -167,7 +167,7 @@ nmsg_fltmod_thread_fini(nmsg_fltmod_t fltmod, void *thr_data);
  */
 nmsg_res
 nmsg_fltmod_filter_message(nmsg_fltmod_t fltmod,
-			   nmsg_message_t msg,
+			   nmsg_message_t *msg,
 			   void *thr_data,
 			   nmsg_filter_message_verdict *vres);
 

--- a/nmsg/fltmod.h
+++ b/nmsg/fltmod.h
@@ -34,8 +34,8 @@
  * convenience macro that initializes required fields.
  *
  * A filter module needs to provide at least one function, the core message
- * filtering function <tt>message_filter</tt>. This function must be reentrant,
- * since it may be called from multiple threads simultaneously.
+ * filtering function <tt>message_filter</tt>. This function must be
+ * thread-safe, since it may be called simultaneously from multiple threads.
  *
  * Optionally, up to four more functions may be provided: a global module
  * initializer and finalizer (<tt>module_init</tt> and <tt>module_fini</tt>),
@@ -47,16 +47,16 @@
  *
  * The <tt>module_init</tt> function will only be called once, immediately after
  * the plugin module has been loaded. It will be called before all other module
- * functions. Therefore, it does not need to be reentrant.
+ * functions. Therefore, it does not need to be thread-safe.
  *
  * The <tt>module_fini</tt> function will only be called once, immediately
  * before the plugin module will be unloaded from the process. It will be called
  * after all other module functions. Therefore, it does not need to be
- * reentrant.
+ * thread-safe, either.
  *
  * The <tt>thread_init</tt> and <tt>thread_fini</tt> may be called by a
  * processing thread after the thread has started and before the thread exits.
- * They need to be reentrant, since they be called by independently executing
+ * They need to be thread-safe, since they be called by independently executing
  * threads. A thread may not call a module's <tt>message_filter</tt> function
  * before it has called <tt>thread_init</tt>, and it may not call
  * <tt>message_filter</tt> after it has called <tt>thread_fini</tt>.

--- a/nmsg/fltmod_plugin.h
+++ b/nmsg/fltmod_plugin.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2015 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NMSG_FLTMOD_PLUGIN_H
+#define NMSG_FLTMOD_PLUGIN_H
+
+#include <nmsg.h>
+
+/** Version number of the nmsg fltmod ABI. */
+#define NMSG_FLTMOD_VERSION	1
+
+/** \see nmsg_fltmod_init() */
+typedef nmsg_res
+(*nmsg_fltmod_module_init_fp)(const void *param,
+			      const size_t len_param,
+			      void **mod_data);
+
+/** \see nmsg_fltmod_destroy() */
+typedef void
+(*nmsg_fltmod_module_fini_fp)(void *mod_data);
+
+/** \see nmsg_fltmod_thread_init() */
+typedef nmsg_res
+(*nmsg_fltmod_thread_init_fp)(void *mod_data, void **thr_data);
+
+/** \see nmsg_fltmod_thread_fini() */
+typedef nmsg_res
+(*nmsg_fltmod_thread_fini_fp)(void *mod_data, void *thr_data);
+
+/** \see nmsg_fltmod_filter_message() */
+typedef nmsg_res
+(*nmsg_fltmod_filter_message_fp)(nmsg_message_t msg,
+				 void *mod_data,
+				 void *thr_data,
+				 nmsg_filter_message_verdict *vres);
+
+/** Convenience macro. */
+#define NMSG_FLTMOD_REQUIRED_INIT \
+	.fltmod_version = NMSG_FLTMOD_VERSION
+
+/**
+ * Structure exported by filter modules.
+ */
+struct nmsg_fltmod_plugin {
+	/**
+	 * Module interface version.
+	 * Must be set to #NMSG_FLTMOD_VERSION or the module will be rejected
+	 * at load time.
+	 */
+	long					fltmod_version;
+
+	/**
+	 * Module-wide initialization function. Optional, may be NULL. If this
+	 * function exists, it will be called once at module startup by
+	 * nmsg_fltmod_init().
+	 */
+	nmsg_fltmod_module_init_fp		module_init;
+
+	/**
+	 * Module-wide finalization function. Optional, may be NULL. If this
+	 * function exists, it will be called once at module shutdown by
+	 * nmsg_fltmod_destroy(). This function should clean up any resources
+	 * acquired by 'module_init'.
+	 */
+	nmsg_fltmod_module_fini_fp		module_fini;
+
+	/**
+	 * Per-thread initialization function. Optional, may be NULL. If this
+	 * function exists, it will be called by each thread that wants to
+	 * perform message filtering via nmsg_fltmod_thread_init().
+	 */
+	nmsg_fltmod_thread_init_fp		thread_init;
+
+	/**
+	 * Per-thread finalization function. Optional, may be NULL. If this
+	 * function exists, it will be called by each thread that has called
+	 * 'thread_init' before the thread exits by nmsg_fltmod_thread_fini().
+	 * This function should clean up any resources acquired by
+	 * 'thread_init'.
+	 */
+	nmsg_fltmod_thread_fini_fp		thread_fini;
+
+	/**
+	 * Message filter function. Required, must not be NULL. This function
+	 * is called by nmsg_fltmod_filter_message().
+	 */
+	nmsg_fltmod_filter_message_fp		filter_message;
+
+	/**
+	 * \private Reserved fields.
+	 */
+	void					*_reserved15;
+	void					*_reserved14;
+	void					*_reserved13;
+	void					*_reserved12;
+	void					*_reserved11;
+	void					*_reserved10;
+	void					*_reserved9;
+	void					*_reserved8;
+	void					*_reserved7;
+	void					*_reserved6;
+	void					*_reserved5;
+	void					*_reserved4;
+	void					*_reserved3;
+	void					*_reserved2;
+	void					*_reserved1;
+	void					*_reserved0;
+};
+
+#endif /* NMSG_FLTMOD_PLUGIN_H */

--- a/nmsg/fltmod_plugin.h
+++ b/nmsg/fltmod_plugin.h
@@ -17,30 +17,163 @@
 #ifndef NMSG_FLTMOD_PLUGIN_H
 #define NMSG_FLTMOD_PLUGIN_H
 
+/*! \file nmsg/fltmod_plugin.h
+ * \brief Implementing message filter modules.
+ *
+ * This file defines the interface that developers of message filter modules
+ * must implement. For the interface for loading and calling filter modules,
+ * see nmsg/fltmod.h.
+ *
+ * Filter modules are dynamically loaded shared objects that must export a
+ * symbol called <tt>nmsg_fltmod_plugin_export</tt>. This is a structure of
+ * type #nmsg_fltmod_plugin and is the sole entry point into the module.
+ *
+ * The first field of the nmsg_fltmod_plugin structure is the version of the
+ * API/ABI between libnmsg and the filter module. Module developers should
+ * assign this field the value #NMSG_FLTMOD_VERSION, or they can add
+ * <tt>NMSG_FLTMOD_REQUIRED_INIT,</tt> to the initializer, which is a
+ * convenience macro that initializes required fields.
+ *
+ * A filter module needs to provide at least one function, the core message
+ * filtering function <tt>filter_message</tt>. This function must be
+ * thread-safe, since it may be called simultaneously from multiple threads.
+ *
+ * Optionally, up to four more functions may be provided: a global module
+ * initializer and finalizer (<tt>module_init</tt> and <tt>module_fini</tt>),
+ * and a per-thread initializer and finalizer (<tt>thread_init</tt> and
+ * <tt>thread_fini</tt>). These functions can be used to acquire and release
+ * resources, generate debug messages, etc. The module and thread initializers
+ * may provide opaque data pointers. These pointers will be provided as
+ * parameters to the message filtering function.
+ *
+ * The <tt>module_init</tt> function will only be called once, immediately
+ * after the plugin module has been loaded. It will be called before all other
+ * module functions. Therefore, it does not need to be thread-safe.
+ *
+ * The <tt>module_fini</tt> function will only be called once, immediately
+ * before the plugin module will be unloaded from the process. It will be
+ * called after all other module functions. Therefore, it does not need to be
+ * thread-safe, either.
+ *
+ * The <tt>thread_init</tt> and <tt>thread_fini</tt> functions may be called by
+ * a processing thread after the thread has started and before the thread
+ * exits. They need to be thread-safe, since they be called by independently
+ * executing threads. A thread may not call a module's <tt>filter_message</tt>
+ * function before it has called <tt>thread_init</tt>, and it may not call
+ * <tt>filter_message</tt> after it has called <tt>thread_fini</tt>.
+ *
+ * For an example of a simple message filtering module, see the "sample" filter
+ * module in the fltmod/ directory of the nmsg distribution. The "sample"
+ * filter performs either systematic count-based or uniform probabilistic
+ * sampling of the message stream.
+ */
+
 #include <nmsg.h>
 
 /** Version number of the nmsg fltmod ABI. */
 #define NMSG_FLTMOD_VERSION	1
 
-/** \see nmsg_fltmod_init() */
+/**
+ * Initialize the filter module.
+ *
+ * Data with module-defined meaning may be passed in via the 'param' and
+ * 'len_param' parameters. This can be used to, for example, configure
+ * module-specific filtering parameters.
+ *
+ * \param[in] param
+ *	Module-defined data needed for the initialization of the module.
+ *
+ * \param[in] len_param
+ *	Length of 'param'.
+ *
+ * \param[out] mod_data
+ *	Module-defined, module-wide state, passed to other module functions
+ *	that take a 'mod_data' parameter.
+ *
+ * \return #nmsg_res_success
+ *	If the module was successfully initialized.
+ * \return
+ *	Any other result to indicate a fatal error.
+ */
 typedef nmsg_res
 (*nmsg_fltmod_module_init_fp)(const void *param,
 			      const size_t len_param,
 			      void **mod_data);
 
-/** \see nmsg_fltmod_destroy() */
+/**
+ * Destroy the filter module. Any module-wide resources acquired by the module
+ * must be released.
+ *
+ * \param[in] mod_data
+ *	Module-defined, module-wide state.
+ */
 typedef void
 (*nmsg_fltmod_module_fini_fp)(void *mod_data);
 
-/** \see nmsg_fltmod_thread_init() */
+/**
+ * Initialize module-defined, thread-wide state.
+ *
+ * \param[in] mod_data
+ *	Module-defined, module-wide state.
+ *
+ * \param[out] thr_data
+ *	Module-defined, thread-wide state.
+ *
+ * \return #nmsg_res_success
+ *	If the thread-wide state was successfully initialized.
+ * \return
+ *	Any other result to indicate a fatal error.
+ */
 typedef nmsg_res
 (*nmsg_fltmod_thread_init_fp)(void *mod_data, void **thr_data);
 
-/** \see nmsg_fltmod_thread_fini() */
+/**
+ * Destroy thread-wide state. Any thread-wide resources corresponding to the
+ * passed in 'thr_data' value that have been acquired by the module must be
+ * released.
+ *
+ * \param[in] mod_data
+ *	Module-defined, module-wide state.
+ *
+ * \param[in] thr_data
+ *	Module-defined, thread-wide state.
+ *
+ * \return #nmsg_res_success
+ *	If the thread-wide state was successfully destroyed.
+ * \return
+ *	Any other result to indicate a fatal error.
+ */
 typedef nmsg_res
 (*nmsg_fltmod_thread_fini_fp)(void *mod_data, void *thr_data);
 
-/** \see nmsg_fltmod_filter_message() */
+/**
+ * Filter a message object and return the filter verdict.
+ *
+ * The filter function may alter the message object, or it may replace the
+ * message object with an entirely new message. If the filter function replaces
+ * the message object, it is responsible for disposing of the old message, for
+ * instance by calling nmsg_message_destroy().
+ *
+ * \param[in,out] msg
+ *	Pointer to the message object to be filtered. The message object may
+ *	optionally be altered, or it may be replaced with an entirely new
+ *	message object.
+ *
+ * \param[in] mod_data
+ *	Module-defined, module-wide state.
+ *
+ * \param[in] thr_data
+ *	Module-defined, thread-wide state.
+ *
+ * \param[out] vres
+ *	The filter verdict. \see #nmsg_filter_message_verdict for the possible
+ *	verdict results and meanings.
+ *
+ * \return #nmsg_res_success
+ *      The filtering completed and returned a verdict in 'vres'.
+ * \return
+ *	Any other result to indicate a fatal error.
+ */
 typedef nmsg_res
 (*nmsg_fltmod_filter_message_fp)(nmsg_message_t *msg,
 				 void *mod_data,

--- a/nmsg/fltmod_plugin.h
+++ b/nmsg/fltmod_plugin.h
@@ -42,7 +42,7 @@ typedef nmsg_res
 
 /** \see nmsg_fltmod_filter_message() */
 typedef nmsg_res
-(*nmsg_fltmod_filter_message_fp)(nmsg_message_t msg,
+(*nmsg_fltmod_filter_message_fp)(nmsg_message_t *msg,
 				 void *mod_data,
 				 void *thr_data,
 				 nmsg_filter_message_verdict *vres);

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -788,7 +788,7 @@ io_write_mirrored(struct nmsg_io_thr *iothr, nmsg_message_t msg) {
 static nmsg_res
 io_run_filters(nmsg_io_t io,
 	       nmsg_io_filter_vec *filters,
-	       nmsg_message_t msg,
+	       nmsg_message_t *msg,
 	       nmsg_filter_message_verdict *vres)
 {
 	for (size_t i = 0; i < nmsg_io_filter_vec_size(filters); i++) {
@@ -909,7 +909,7 @@ io_thr_input(void *user) {
 		io_input->count_nmsg_payload_in += 1;
 
 		if (iothr->filters != NULL) {
-			res = io_run_filters(io, iothr->filters, msg, &vres);
+			res = io_run_filters(io, iothr->filters, &msg, &vres);
 			if (res != nmsg_res_success) {
 				nmsg_message_destroy(&msg);
 				iothr->res = res;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -26,9 +26,18 @@ struct nmsg_io_input;
 struct nmsg_io_output;
 struct nmsg_io_thr;
 
+typedef enum {
+	nmsg_io_filter_type_function,
+	nmsg_io_filter_type_module,
+} nmsg_io_filter_type;
+
 struct nmsg_io_filter {
-	nmsg_filter_message_fp		fp;
-	void				*user;
+	nmsg_io_filter_type		type;
+	union {
+		nmsg_filter_message_fp	fp;
+		nmsg_fltmod_t		mod;
+	};
+	void				*data;
 };
 VECTOR_GENERATE(nmsg_io_filter_vec, struct nmsg_io_filter *);
 
@@ -78,6 +87,7 @@ struct nmsg_io_thr {
 	nmsg_res			res;
 	struct timespec			now;
 	struct nmsg_io_input		*io_input;
+	nmsg_io_filter_vec		*filters;
 };
 
 /* Forward. */
@@ -109,6 +119,7 @@ nmsg_io_init(void) {
 	io->output_mode = nmsg_io_output_mode_stripe;
 	pthread_mutex_init(&io->lock, NULL);
 	ISC_LIST_INIT(io->threads);
+	io->filters = nmsg_io_filter_vec_init(1);
 
 	return (io);
 }
@@ -237,7 +248,17 @@ nmsg_io_destroy(nmsg_io_t *io) {
 
 	/* destroy filters */
 	for (size_t i = 0; i < nmsg_io_filter_vec_size((*io)->filters); i++) {
-		struct nmsg_io_filter *filter = nmsg_io_filter_vec_value((*io)->filters, i);
+		struct nmsg_io_filter *filter =
+			nmsg_io_filter_vec_value((*io)->filters, i);
+
+		switch (filter->type) {
+		case nmsg_io_filter_type_function:
+			break;
+		case nmsg_io_filter_type_module:
+			nmsg_fltmod_destroy(&filter->mod);
+			break;
+		}
+
 		my_free(filter);
 	}
 	nmsg_io_filter_vec_destroy(&(*io)->filters);
@@ -253,17 +274,36 @@ nmsg_io_destroy(nmsg_io_t *io) {
 }
 
 nmsg_res
-nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *user) {
-	struct nmsg_io_filter *filter;
-
-	filter = my_calloc(1, sizeof(*filter));
+nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *data) {
+	/* Wrap the callback in an io_filter. */
+	struct nmsg_io_filter *filter = my_calloc(1, sizeof(*filter));
+	filter->type = nmsg_io_filter_type_function;
 	filter->fp = *fp;
-	filter->user = user;
+	filter->data = data;
 
-	if (io->filters == NULL) {
-		io->filters = nmsg_io_filter_vec_init(1);
+	/* Add to the global filter vector. */
+	nmsg_io_filter_vec_add(io->filters, filter);
+
+	return nmsg_res_success;
+}
+
+nmsg_res
+nmsg_io_add_filter_module(nmsg_io_t io, const char *name,
+			  const void *param, const size_t len_param)
+{
+	/* Initialize the filter module. */
+	nmsg_fltmod_t fltmod = nmsg_fltmod_init(name, param, len_param);
+	if (fltmod == NULL) {
+		_nmsg_dprintf(4, "%s: nmsg_fltmod_init() failed\n", __func__);
+		return nmsg_res_failure;
 	}
 
+	/* Wrap the fltmod in an io_filter. */
+	struct nmsg_io_filter *filter = my_calloc(1, sizeof(*filter));
+	filter->type = nmsg_io_filter_type_module;
+	filter->mod = fltmod;
+
+	/* Add to the global filter vector. */
 	nmsg_io_filter_vec_add(io->filters, filter);
 
 	return nmsg_res_success;
@@ -640,7 +680,7 @@ check_close_event(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output) {
 
 	if (io->close_fp != NULL)
 		pthread_mutex_lock(&io_output->lock);
-	
+
 	if (io_output->output == NULL) {
 		res = nmsg_res_stop;
 		goto out;
@@ -735,13 +775,22 @@ io_write_mirrored(struct nmsg_io_thr *iothr, nmsg_message_t msg) {
 }
 
 static nmsg_res
-io_run_filters(struct nmsg_io *io, nmsg_message_t msg, nmsg_filter_message_verdict *vres) {
-	for (size_t i = 0; i < nmsg_io_filter_vec_size(io->filters); i++) {
-		struct nmsg_io_filter *filter;
+io_run_filters(nmsg_io_filter_vec *filters,
+	       nmsg_message_t msg,
+	       nmsg_filter_message_verdict *vres)
+{
+	for (size_t i = 0; i < nmsg_io_filter_vec_size(filters); i++) {
+		struct nmsg_io_filter *filter = nmsg_io_filter_vec_value(filters, i);
 		nmsg_res res;
 
-		filter = nmsg_io_filter_vec_value(io->filters, i);
-		res = filter->fp(msg, filter->user, vres);
+		switch (filter->type) {
+		case nmsg_io_filter_type_function:
+			res = filter->fp(msg, filter->data, vres);
+			break;
+		case nmsg_io_filter_type_module:
+			res = nmsg_fltmod_filter_message(filter->mod, msg, filter->data, vres);
+			break;
+		}
 		if (res != nmsg_res_success)
 			return res;
 
@@ -786,6 +835,39 @@ io_thr_input(void *user) {
 	if (io->atstart_fp != NULL)
 		io->atstart_fp(iothr->threadno, io->atstart_user);
 
+	/* Setup thread-local filter chain. */
+	if (nmsg_io_filter_vec_size(io->filters) > 0) {
+		/* Allocate thread-local filter vector. */
+		iothr->filters = nmsg_io_filter_vec_init(nmsg_io_filter_vec_size(io->filters));
+
+		/**
+		 * Copy the io-wide filter vector into the thread-local filter
+		 * vector. For module filters, call nmsg_fltmod_thread_init().
+		 */
+		for (size_t i = 0; i < nmsg_io_filter_vec_size(io->filters); i++) {
+			struct nmsg_io_filter *filter = nmsg_io_filter_vec_value(io->filters, i);
+
+			/* Make a thread-local copy. */
+			struct nmsg_io_filter *thr_filter = my_calloc(1, sizeof(*thr_filter));
+			memcpy(thr_filter, filter, sizeof(*thr_filter));
+
+			/* Initialize thread-local data. */
+			if (thr_filter->type == nmsg_io_filter_type_module) {
+				res = nmsg_fltmod_thread_init(thr_filter->mod, &thr_filter->data);
+				if (res != nmsg_res_success) {
+					my_free(thr_filter);
+					_nmsg_dprintfv(io->debug, 1,
+						"nmsg_iothr: failed to initialize filter module\n");
+					iothr->res = res;
+					return (NULL);
+				}
+			}
+
+			/* Append to the thread-local filter vector. */
+			nmsg_io_filter_vec_add(iothr->filters, thr_filter);
+		}
+	}
+
 	/* loop over input */
 	for (;;) {
 		nmsg_timespec_get(&iothr->now);
@@ -811,8 +893,8 @@ io_thr_input(void *user) {
 
 		io_input->count_nmsg_payload_in += 1;
 
-		if (io->filters != NULL) {
-			res = io_run_filters(io, msg, &vres);
+		if (iothr->filters != NULL) {
+			res = io_run_filters(iothr->filters, msg, &vres);
 			if (res != nmsg_res_success) {
 				nmsg_message_destroy(&msg);
 				iothr->res = res;
@@ -845,6 +927,29 @@ io_thr_input(void *user) {
 
 		if (io->stop == true)
 			break;
+	}
+
+	/* Clean up thread-local filters. */
+	if (iothr->filters != NULL) {
+		/* Iterate over each filter. */
+		for (size_t i = 0; i < nmsg_io_filter_vec_size(iothr->filters); i++) {
+			struct nmsg_io_filter *filter = nmsg_io_filter_vec_value(iothr->filters, i);
+
+			/* Free any resources associated with the filter. */
+			if (filter->type == nmsg_io_filter_type_module) {
+				res = nmsg_fltmod_thread_fini(filter->mod, filter->data);
+				if (res != nmsg_res_success) {
+					_nmsg_dprintfv(io->debug, 4,
+						"nmsg_iothr: filter module @ %p finalizer failed: "
+						"%s (%d)\n",
+						filter->mod, nmsg_res_lookup(res), res);
+				}
+			}
+			my_free(filter);
+		}
+
+		/* Delete the filter vector. */
+		nmsg_io_filter_vec_destroy(&iothr->filters);
 	}
 
 	/* call user function */

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -430,6 +430,23 @@ void
 nmsg_io_set_debug(nmsg_io_t io, int debug);
 
 /**
+ * Set the filter policy for the nmsg_io_t object's filter chain. If all
+ * filters in the filter chain return #nmsg_filter_message_verdict_DECLINED for
+ * a particular message, the filter policy determines the default policy action
+ * to be applied to the message.
+ *
+ * If not explicitly set, the default is #nmsg_filter_message_verdict_ACCEPT.
+ *
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] policy The filter policy to apply by default. Must be either
+ *	#nmsg_filter_message_verdict_ACCEPT or
+ *	#nmsg_filter_message_verdict_DROP.
+ */
+void
+nmsg_io_set_filter_policy(nmsg_io_t io, const nmsg_filter_message_verdict policy);
+
+/**
  * Configure the nmsg_io_t object to close inputs after processing for a set
  * amount of time.
  *

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -141,20 +141,21 @@ nmsg_io_init(void);
  * documentation for #nmsg_filter_message_fp for further details about the
  * semantics of the filter function itself.
  *
- * This function appends the specified filter function callback to the
- * end of an nmsg_io_t object's list of filters.
+ * This function appends the specified filter to the end of an nmsg_io_t
+ * object's list of filters.
  *
  * When an nmsg_io_t runs its processing loop, each message read from an input
- * stream is sequentially passed to each filter function. If a filter function
- * returns the verdict #nmsg_filter_message_verdict_DROP, the message will be
- * immediately destroyed with no further processing. The verdict
+ * stream is sequentially passed to each filter. If a filter returns the
+ * verdict #nmsg_filter_message_verdict_DROP, the message will be immediately
+ * destroyed with no further processing. The verdict
  * #nmsg_filter_message_verdict_ACCEPT causes the message to be accepted into
  * the output stream, bypassing any remaining filters in the filter chain, if
  * any. The verdict #nmsg_filter_message_verdict_DECLINED causes the message to
  * be passed to the next filter in the filter chain, if any.
  *
- * Filter functions in the filter chain are executed in the order that they
- * were added to the nmsg_io_t object with nmsg_io_add_filter().
+ * Filters in the filter chain are executed in the order that they were added
+ * to the nmsg_io_t object with nmsg_io_add_filter() and
+ * nmsg_io_add_filter_module().
  *
  * All filters must be added to the nmsg_io_t object before calling
  * nmsg_io_loop(). It is an unchecked runtime error for a caller to attempt to
@@ -165,12 +166,34 @@ nmsg_io_init(void);
  *
  * \param[in] fp User-specified function.
  *
- * \param[in] user User pointer to be passed to user function.
+ * \param[in] data User pointer to be passed to user function.
  *
  * \return #nmsg_res_success
  */
 nmsg_res
-nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *user);
+nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *data);
+
+/**
+ * Add a filter module to the filter chain. This function instantiates an
+ * nmsg_fltmod_t object with the specified 'name', 'param', and 'len_param'
+ * values and appends the filter to the end of an nmsg_io_t object's list of
+ * filters.
+ *
+ * \see nmsg_io_add_filter()
+ * \see nmsg_fltmod_init()
+ *
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] name Passed to nmsg_fltmod_init().
+ * \param[in] param Passed to nmsg_fltmod_init().
+ * \param[in] len_param Passed to nmsg_fltmod_init().
+ *
+ * \return #nmsg_res_success
+ * \return #nmsg_res_failure If creating the nmsg_fltmod_t object failed.
+ */
+nmsg_res
+nmsg_io_add_filter_module(nmsg_io_t io, const char *name,
+			  const void *param, const size_t len_param);
 
 /**
  * Add an nmsg input to an nmsg_io_t object. When nmsg_io_loop() is called, one

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -137,6 +137,42 @@ nmsg_io_t
 nmsg_io_init(void);
 
 /**
+ * Add a user-specified filter function to the filter chain. See the
+ * documentation for #nmsg_filter_message_fp for further details about the
+ * semantics of the filter function itself.
+ *
+ * This function appends the specified filter function callback to the
+ * end of an nmsg_io_t object's list of filters.
+ *
+ * When an nmsg_io_t runs its processing loop, each message read from an input
+ * stream is sequentially passed to each filter function. If a filter function
+ * returns the verdict #nmsg_filter_message_verdict_DROP, the message will be
+ * immediately destroyed with no further processing. The verdict
+ * #nmsg_filter_message_verdict_ACCEPT causes the message to be accepted into
+ * the output stream, bypassing any remaining filters in the filter chain, if
+ * any. The verdict #nmsg_filter_message_verdict_DECLINED causes the message to
+ * be passed to the next filter in the filter chain, if any.
+ *
+ * Filter functions in the filter chain are executed in the order that they
+ * were added to the nmsg_io_t object with nmsg_io_add_filter().
+ *
+ * All filters must be added to the nmsg_io_t object before calling
+ * nmsg_io_loop(). It is an unchecked runtime error for a caller to attempt to
+ * modify the filter chain on an nmsg_io_t that is currently executing its
+ * processing loop.
+ *
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] fp User-specified function.
+ *
+ * \param[in] user User pointer to be passed to user function.
+ *
+ * \return #nmsg_res_success
+ */
+nmsg_res
+nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *user);
+
+/**
  * Add an nmsg input to an nmsg_io_t object. When nmsg_io_loop() is called, one
  * thread will be created for each input to process input payloads.
  *

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -157,6 +157,12 @@ nmsg_io_init(void);
  * to the nmsg_io_t object with nmsg_io_add_filter() and
  * nmsg_io_add_filter_module().
  *
+ * If the entire filter chain has been executed and all filters have returned
+ * the verdict #nmsg_filter_message_verdict_DECLINED, the default action to
+ * take is determined by the nmsg_io_t's filter policy, which can be set with
+ * nmsg_io_set_filter_policy(). The default filter policy is
+ * #nmsg_filter_message_verdict_ACCEPT.
+ *
  * All filters must be added to the nmsg_io_t object before calling
  * nmsg_io_loop(). It is an unchecked runtime error for a caller to attempt to
  * modify the filter chain on an nmsg_io_t that is currently executing its
@@ -178,6 +184,10 @@ nmsg_io_add_filter(nmsg_io_t io, nmsg_filter_message_fp fp, void *data);
  * nmsg_fltmod_t object with the specified 'name', 'param', and 'len_param'
  * values and appends the filter to the end of an nmsg_io_t object's list of
  * filters.
+ *
+ * Filter modules allow filter functions to be wrapped in external shared
+ * objects, but they otherwise participate in the filter chain in the same way
+ * that a filter function added with nmsg_io_add_filter() does.
  *
  * \see nmsg_io_add_filter()
  * \see nmsg_fltmod_init()

--- a/nmsg/nmsg.h
+++ b/nmsg/nmsg.h
@@ -98,6 +98,7 @@ typedef nmsg_res (*nmsg_cb_message_read)(nmsg_message_t *msg, void *user);
 #include <nmsg/compat.h>
 #include <nmsg/constants.h>
 #include <nmsg/container.h>
+#include <nmsg/filter.h>
 #include <nmsg/input.h>
 #include <nmsg/io.h>
 #include <nmsg/ipdg.h>

--- a/nmsg/nmsg.h
+++ b/nmsg/nmsg.h
@@ -44,6 +44,7 @@ extern "C" {
 typedef enum nmsg_res nmsg_res;
 
 typedef struct nmsg_container *	nmsg_container_t;
+typedef struct nmsg_fltmod *	nmsg_fltmod_t;
 typedef struct nmsg_input *	nmsg_input_t;
 typedef struct nmsg_io *	nmsg_io_t;
 typedef struct nmsg_message *	nmsg_message_t;
@@ -99,6 +100,7 @@ typedef nmsg_res (*nmsg_cb_message_read)(nmsg_message_t *msg, void *user);
 #include <nmsg/constants.h>
 #include <nmsg/container.h>
 #include <nmsg/filter.h>
+#include <nmsg/fltmod.h>
 #include <nmsg/input.h>
 #include <nmsg/io.h>
 #include <nmsg/ipdg.h>

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -67,6 +67,7 @@
 #include "nmsg.h"
 #include "nmsg.pb-c.h"
 
+#include "fltmod_plugin.h"
 #include "msgmod_plugin.h"
 #include "ipreasm.h"
 
@@ -85,8 +86,12 @@
 
 #define NMSG_SEQSRC_GC_INTERVAL	120
 #define NMSG_FRAG_GC_INTERVAL	30
-#define NMSG_MSG_MODULE_PREFIX	"nmsg_msg" XSTR(NMSG_MSGMOD_VERSION)
 #define NMSG_NSEC_PER_SEC	1000000000
+
+#define NMSG_FLT_MODULE_PREFIX	"nmsg_flt" XSTR(NMSG_FLTMOD_VERSION)
+#define NMSG_MSG_MODULE_PREFIX	"nmsg_msg" XSTR(NMSG_MSGMOD_VERSION)
+
+#define NMSG_MODULE_SUFFIX	".so"
 
 #define _nmsg_dprintf(level, format, ...) \
 do { \

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -76,6 +76,7 @@
 #include "libmy/ubuf.h"
 #include "libmy/b64_decode.h"
 #include "libmy/b64_encode.h"
+#include "libmy/vector.h"
 
 /* Macros. */
 

--- a/src/io.c
+++ b/src/io.c
@@ -638,7 +638,7 @@ add_filter_module(nmsgtool_ctx *c, const char *args) {
 
 	/* Load the filter module. */
 	if (c->debug >= 2)
-		fprintf(stderr, "%s: adding filter module %s,%s\n", argv_program, mod_name, mod_param);
+		fprintf(stderr, "%s: adding filter module %s\n", argv_program, args);
 	res = nmsg_io_add_filter_module(c->io, mod_name, mod_param, len_mod_param);
 	if (res != nmsg_res_success) {
 		if (c->debug >= 2)

--- a/src/io.c
+++ b/src/io.c
@@ -631,7 +631,7 @@ add_filter_module(nmsgtool_ctx *c, const char *args) {
 	/* Parse the arguments. */
 	tmp = my_strdup(args);
 	mod_name = strtok_r(tmp, ",", &saveptr);
-	mod_param = strtok_r(NULL, ",", &saveptr);
+	mod_param = strtok_r(NULL, "", &saveptr);
 	if (mod_param != NULL) {
 		len_mod_param = strlen(mod_param) + 1;
 	}

--- a/src/io.c
+++ b/src/io.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,8 @@
 
 #include "kickfile.h"
 #include "nmsgtool.h"
+
+#include "libmy/my_alloc.h"
 
 static const int on = 1;
 
@@ -616,3 +618,34 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 	exit(EXIT_FAILURE);
 }
 #endif /* HAVE_YAJL */
+
+void
+add_filter_module(nmsgtool_ctx *c, const char *args) {
+	nmsg_res res;
+	char *tmp = NULL;
+	char *saveptr = NULL;
+	char *mod_name = NULL;
+	char *mod_param = NULL;
+	size_t len_mod_param = 0;
+
+	/* Parse the arguments. */
+	tmp = my_strdup(args);
+	mod_name = strtok_r(tmp, ",", &saveptr);
+	mod_param = strtok_r(NULL, ",", &saveptr);
+	if (mod_param != NULL) {
+		len_mod_param = strlen(mod_param) + 1;
+	}
+
+	/* Load the filter module. */
+	if (c->debug >= 2)
+		fprintf(stderr, "%s: adding module %s,%s\n", argv_program, mod_name, mod_param);
+	res = nmsg_io_add_filter_module(c->io, mod_name, mod_param, len_mod_param);
+	if (res != nmsg_res_success) {
+		if (c->debug >= 2)
+			fprintf(stderr, "%s: nmsg_io_add_filter_module() failed for %s,%s: %s (%d)\n",
+				argv_program, mod_name, mod_param, nmsg_res_lookup(res), res);
+		exit(EXIT_FAILURE);
+	}
+
+	my_free(tmp);
+}

--- a/src/io.c
+++ b/src/io.c
@@ -638,7 +638,7 @@ add_filter_module(nmsgtool_ctx *c, const char *args) {
 
 	/* Load the filter module. */
 	if (c->debug >= 2)
-		fprintf(stderr, "%s: adding module %s,%s\n", argv_program, mod_name, mod_param);
+		fprintf(stderr, "%s: adding filter module %s,%s\n", argv_program, mod_name, mod_param);
 	res = nmsg_io_add_filter_module(c->io, mod_name, mod_param, len_mod_param);
 	if (res != nmsg_res_success) {
 		if (c->debug >= 2)

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,6 +105,12 @@ static argv_t args[] = {
 		&ctx.bpfstr,
 		"filter",
 		"filter pcap inputs with this bpf" },
+
+	{ 'F',	"filter",
+		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
+		&ctx.filters,
+		"dso[,param]",
+		"filter nmsg payloads with module" },
 
 	{ 'r', "readnmsg",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -254,6 +254,12 @@ static argv_t args[] = {
 		NULL,
 		"don't buffer writes to outputs" },
 
+	{ '\0', "policy",
+		ARGV_CHAR_P,
+		&ctx.filter_policy,
+		"ACCEPT|DROP",
+		"default filter chain policy" },
+
 	{ '\0',	"setsource",
 		ARGV_CHAR_P,
 		&ctx.set_source_str,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -49,7 +49,7 @@ typedef struct {
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
-	char		*endline, *kicker, *mname, *vname, *bpfstr;
+	char		*endline, *kicker, *mname, *vname, *bpfstr, *filter_policy;
 	int		debug;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;
 	char		*set_source_str, *set_operator_str, *set_group_str;

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ typedef union nmsgtool_sockaddr nmsgtool_sockaddr;
 
 typedef struct {
 	/* parameters */
+	argv_array_t	filters;
 	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
@@ -108,6 +109,7 @@ void add_sock_input(nmsgtool_ctx *, const char *);
 void add_sock_output(nmsgtool_ctx *, const char *);
 void add_xsock_input(nmsgtool_ctx *, const char *);
 void add_xsock_output(nmsgtool_ctx *, const char *);
+void add_filter_module(nmsgtool_ctx *, const char *);
 void pidfile_write(FILE *);
 void process_args(nmsgtool_ctx *);
 void setup_nmsg_input(nmsgtool_ctx *, nmsg_input_t);

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -318,6 +318,25 @@ process_args(nmsgtool_ctx *c) {
 	/* filter modules */
 	process_args_loop(c->filters, add_filter_module);
 
+	/* filter policy */
+	if (ARGV_ARRAY_COUNT(c->filters) > 0 && c->filter_policy != NULL) {
+		if (strcasecmp(c->filter_policy, "ACCEPT") == 0) {
+			if (c->debug >= 2)
+				fprintf(stderr, "%s: setting default filter policy to ACCEPT\n",
+					argv_program);
+			nmsg_io_set_filter_policy(c->io, nmsg_filter_message_verdict_ACCEPT);
+		} else if (strcasecmp(c->filter_policy, "DROP") == 0) {
+			if (c->debug >= 2)
+				fprintf(stderr, "%s: setting default filter policy to DROP\n",
+					argv_program);
+			nmsg_io_set_filter_policy(c->io, nmsg_filter_message_verdict_DROP);
+		} else {
+			fprintf(stderr, "%s: unknown filter policy '%s'\n",
+				argv_program, c->filter_policy);
+			exit(EXIT_FAILURE);
+		}
+	}
+
 #undef process_args_loop
 #undef process_args_loop_mod
 

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2015 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -314,6 +314,9 @@ process_args(nmsgtool_ctx *c) {
 	/* json inputs and outputs */
 	process_args_loop(c->r_json, add_json_input);
 	process_args_loop(c->w_json, add_json_output);
+
+	/* filter modules */
+	process_args_loop(c->filters, add_filter_module);
 
 #undef process_args_loop
 #undef process_args_loop_mod

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,3 @@
+test-layout-fltmod_plugin
+*.log
+*.trs

--- a/tests/test-layout-fltmod_plugin.c
+++ b/tests/test-layout-fltmod_plugin.c
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2016 by Farsight Security, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "nmsg/fltmod_plugin.h"
+
+#define NAME	"test-layout_fltmod_plugin"
+
+/**
+ * These tests are inherently compiler and architecture specific, but hopefully
+ * will catch inadvertent ABI-breaking changes to 'struct fltmod_plugin'.
+ */
+
+static int
+test_sizeof(void)
+{
+	int ret = 0;
+
+	struct nmsg_fltmod_plugin p = {0};
+
+	/* 's': sum up sizeof() for all the fields. */
+	size_t s = 0;
+	s += sizeof(p.fltmod_version);
+	s += sizeof(p.module_init);
+	s += sizeof(p.module_fini);
+	s += sizeof(p.thread_init);
+	s += sizeof(p.thread_fini);
+	s += sizeof(p.filter_message);
+	s += sizeof(p._reserved15);
+	s += sizeof(p._reserved14);
+	s += sizeof(p._reserved13);
+	s += sizeof(p._reserved12);
+	s += sizeof(p._reserved11);
+	s += sizeof(p._reserved10);
+	s += sizeof(p._reserved9);
+	s += sizeof(p._reserved8);
+	s += sizeof(p._reserved7);
+	s += sizeof(p._reserved6);
+	s += sizeof(p._reserved5);
+	s += sizeof(p._reserved4);
+	s += sizeof(p._reserved3);
+	s += sizeof(p._reserved2);
+	s += sizeof(p._reserved1);
+	s += sizeof(p._reserved0);
+
+	/* 't': sum up the sizes of what we think the fields are. */
+	size_t t = 0;
+	t += sizeof(long);
+	t += 21 * sizeof(void *);
+
+	/* Hopefully there are no holes in the struct. */
+	if (s != t || s != sizeof(struct nmsg_fltmod_plugin)) {
+		ret |= 1;
+	}
+
+	return ret;
+}
+
+static int
+check(int ret, const char *s)
+{
+	if (ret == 0) {
+		fprintf(stderr, NAME ": PASS: %s\n", s);
+	} else {
+		fprintf(stderr, NAME ": FAIL: %s\n", s);
+	}
+	return ret;
+}
+
+int
+main(void)
+{
+	int ret = 0;
+
+	ret |= check(test_sizeof(), "test-sizeof");
+
+	if (ret)
+		return EXIT_FAILURE;
+	return EXIT_SUCCESS;
+}

--- a/tests/test-layout-fltmod_plugin.c
+++ b/tests/test-layout-fltmod_plugin.c
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
+#include <assert.h>
 #include <stdio.h>
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "nmsg/fltmod_plugin.h"
@@ -31,42 +33,46 @@ test_sizeof(void)
 {
 	int ret = 0;
 
-	struct nmsg_fltmod_plugin p = {0};
-
-	/* 's': sum up sizeof() for all the fields. */
-	size_t s = 0;
-	s += sizeof(p.fltmod_version);
-	s += sizeof(p.module_init);
-	s += sizeof(p.module_fini);
-	s += sizeof(p.thread_init);
-	s += sizeof(p.thread_fini);
-	s += sizeof(p.filter_message);
-	s += sizeof(p._reserved15);
-	s += sizeof(p._reserved14);
-	s += sizeof(p._reserved13);
-	s += sizeof(p._reserved12);
-	s += sizeof(p._reserved11);
-	s += sizeof(p._reserved10);
-	s += sizeof(p._reserved9);
-	s += sizeof(p._reserved8);
-	s += sizeof(p._reserved7);
-	s += sizeof(p._reserved6);
-	s += sizeof(p._reserved5);
-	s += sizeof(p._reserved4);
-	s += sizeof(p._reserved3);
-	s += sizeof(p._reserved2);
-	s += sizeof(p._reserved1);
-	s += sizeof(p._reserved0);
-
-	/* 't': sum up the sizes of what we think the fields are. */
+	/* This tests that the overall size of the structure hasn't changed. */
 	size_t t = 0;
 	t += sizeof(long);
 	t += 21 * sizeof(void *);
-
-	/* Hopefully there are no holes in the struct. */
-	if (s != t || s != sizeof(struct nmsg_fltmod_plugin)) {
+	if (t != sizeof(struct nmsg_fltmod_plugin)) {
 		ret |= 1;
 	}
+
+	return ret;
+}
+
+static int
+test_offsetof(void)
+{
+	int ret = 0;
+
+	/**
+	 * These assert()'s test for both the existence of the non-reserved
+	 * fields in the structure, as well as their ordering within the
+	 * structure.
+	 */
+	size_t offset = 0;
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, fltmod_version));
+	offset += sizeof(long);
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, module_init));
+	offset += sizeof(void *);
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, module_fini));
+	offset += sizeof(void *);
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, thread_init));
+	offset += sizeof(void *);
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, thread_fini));
+	offset += sizeof(void *);
+
+	assert(offset == offsetof(struct nmsg_fltmod_plugin, filter_message));
+	offset += sizeof(void *);
 
 	return ret;
 }
@@ -88,6 +94,7 @@ main(void)
 	int ret = 0;
 
 	ret |= check(test_sizeof(), "test-sizeof");
+	ret |= check(test_offsetof(), "test-offsetof");
 
 	if (ret)
 		return EXIT_FAILURE;


### PR DESCRIPTION
This branch adds a message filtering capability to the `libnmsg` I/O loop.

Message filters are callbacks which can decide to accept a message into the output stream, silently drop it, or pass it to the next filter in the chain. Filters hook into the `nmsg_io` processing loop and can alter or replace messages. See [nmsg/filter.h](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/filter.h) for the documentation on filter semantics.

A message filter callback can either be provided as a function pointer + data pointer via [`nmsg_io_add_filter()`](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/io.h#L139-L180), or it can be contained in an external shared object (a "module" or "plugin") which can be loaded and initialized via [`nmsg_io_add_filter_module()`](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/io.h#L182-L206). See [nmsg/fltmod_plugin.h](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/fltmod_plugin.h) for the interface that filter plugin providers must implement, and see [nmsg/fltmod.h](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/fltmod.h) for the interface used by filter plugin consumers, like `nmsg_io`.

`nmsg_io_add_filter()` and `nmsg_io_add_filter_module()` can be called repeatedly to build up a linear filter chain. The order of filters in the chain is the same as the order of calls to `nmsg_io_add_filter()` or `nmsg_io_add_filter_module()`. Each input message processed by the `nmsg_io` loop is passed to each filter in sequence, until a filter returns a terminal verdict (`ACCEPT` or `DROP`). If a filter returns a non-terminal verdict (`DECLINED`), the message is passed to the next filter in the chain. If the end of the filter chain is reached, the `nmsg_io` loop's filter policy is applied. (The default is `ACCEPT`, but it can be changed to `DROP` with [`nmsg_io_set_filter_policy()`](https://github.com/farsightsec/nmsg/blob/branches/filtering/nmsg/io.h#L442-L457).

Two new command-line options have been added to `nmsgtool`. `-F` or `--filter` loads a filter module, and `--policy` sets the default filter chain policy. These are relatively thin wrappers around `nmsg_io_add_filter_module()` and `nmsg_io_set_filter_policy()`.

A [sample filter module](https://github.com/farsightsec/nmsg/blob/branches/filtering/fltmod/nmsg_flt_sample.c) is provided, which functions as both a code sample of how to provide a filter plugin using the `nmsg/fltmod_plugin.h` interface, as well as providing message sampling functionality. It can perform either systematic count-based sampling or uniform probabilistic sampling. E.g., try `nmsgtool --filter sample,count=10 [...]` to systematically sample every 1-in-10 messages in the input stream, or `nmsgtool --filter sample,random=0.10 [...]` to probabilistically sample every message in the input stream with probability 10%.