### PR TITLE
Fix when building without YAJL support

### DIFF
--- a/nmsg/input.c
+++ b/nmsg/input.c
@@ -165,7 +165,7 @@ nmsg_input_open_json(int fd) {
 }
 #else /* HAVE_YAJL */
 nmsg_input_t
-nmsg_input_open_json(int fd, nmsg_msgmod_t msgmod) {
+nmsg_input_open_json(int fd) {
 	return (NULL);
 }
 #endif /* HAVE_YAJL */

--- a/nmsg/msgmod/message.c
+++ b/nmsg/msgmod/message.c
@@ -373,7 +373,7 @@ err:
 }
 #else /* HAVE_YAJL */
 nmsg_res
-nmsg_json_to_payload(const char *json, struct nmsg_msgmod **mod, uint8_t **pbuf, size_t *sz)
+nmsg_message_from_json(const char *json, nmsg_message_t *msg) {
 	return (nmsg_res_notimpl);
 }
 #endif /* HAVE_YAJL */


### PR DESCRIPTION
This commit fixes the build (#47) when configured with `--without-yajl`.

Without HAVE_YAJL, we build stub functions that return a failure, but
those stub functions aren't correct: `nmsg_input_open_json()` had the
wrong signature:

```
    nmsg/input.c:168:1: error: conflicting types for ‘nmsg_input_open_json’
     nmsg_input_open_json(int fd, nmsg_msgmod_t msgmod) {
     ^
    In file included from nmsg/nmsg.h:104:0,
                     from nmsg/private.h:67,
                     from nmsg/input.c:19:
    ./nmsg/input.h:173:1: note: previous declaration of ‘nmsg_input_open_json’ was here
     nmsg_input_open_json(int fd);
     ^
```

The YAJL-less alternative for `nmsg_message_from_json()` had the wrong
function name, wrong signature, and included a syntax error:

```
    nmsg/msgmod/message.c:376:1: warning: no previous prototype for ‘nmsg_json_to_payload’ [-Wmissing-prototypes]
     nmsg_json_to_payload(const char *json, struct nmsg_msgmod **mod, uint8_t **pbuf, size_t *sz)
     ^
    nmsg/msgmod/message.c: In function ‘nmsg_json_to_payload’:
    nmsg/msgmod/message.c:377:2: error: expected declaration specifiers before ‘return’
      return (nmsg_res_notimpl);
      ^
    nmsg/msgmod/message.c:378:1: error: expected declaration specifiers before ‘}’ token
     }
     ^
    [...a bunch more...]
```