### PR TITLE
dnsqr: Only set 'resolver_address_zeroed' if addresses are zeroed

### DIFF
--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -465,8 +465,10 @@ dnsqr_zero_resolver_address(Nmsg__Base__DnsQR *dnsqr) {
 	struct ip6_hdr *ip6;
 	size_t ip_len;
 
-	dnsqr->resolver_address_zeroed = true;
-	dnsqr->has_resolver_address_zeroed = true;
+	if (dnsqr->n_query_packet > 0 || dnsqr->n_response_packet > 0) {
+		dnsqr->resolver_address_zeroed = true;
+		dnsqr->has_resolver_address_zeroed = true;
+	}
 
 	/* zero the protobuf query_ip field */
 	memset(dnsqr->query_ip.data, 0, dnsqr->query_ip.len);


### PR DESCRIPTION
Resolver address zeroing only actually does something if the
'query_packet' and/or 'response_packet' fields are non-empty, which
isn't the case for TCP and ICMP, since those packets are stored in
separate fields.

Therefore, only set 'resolver_address_zeroed' if we actually end up
zeroing any addresses.