### PR TITLE
Makefile.am: Link the base message module against libprotobuf-c

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,7 @@ nmsg_base_nmsg_msg9_base_la_LDFLAGS = \
 	$(MSG_LIBTOOL_FLAGS)
 nmsg_base_nmsg_msg9_base_la_LIBADD = \
 	$(libpcap_LIBS) \
+	$(libprotobuf_c_LIBS) \
 	$(libwdns_LIBS)
 nmsg_base_nmsg_msg9_base_la_SOURCES = \
 	libmy/list.h \


### PR DESCRIPTION
The base message module makes calls to the protobuf-c library (e.g.,
protobuf_c_message_pack_to_buffer() in dnsqr), so it needs to be linked
against libprotobuf-c.

Previously we were relying on libnmsg to be dynamically linked against
libprotobuf-c, which would incidentally satisfy the base message
module's dependency. But when libnmsg is statically linked against
libprotobuf-c, the base message module will fail to load, e.g.:

```
_nmsg_dlmod_init: /usr/lib64/sie-dns-sensor/nmsg/nmsg_msg9_base.so: undefined symbol: protobuf_c_buffer_simple_append
```