### PR TITLE
Fix erroneous NULL result checks.

### DIFF
--- a/nmsg/input_frag.c
+++ b/nmsg/input_frag.c
@@ -224,7 +224,7 @@ reassemble_frags(nmsg_input_t input, Nmsg__Nmsg **nmsg, struct nmsg_frag *fent) 
 
 	/* unpack the defragmented payload */
 	*nmsg = nmsg__nmsg__unpack(NULL, len, payload);
-	if (nmsg != NULL)
+	if (*nmsg != NULL)
 		res = nmsg_res_success;
 	else
 		res = nmsg_res_parse_error;

--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -60,8 +60,10 @@ _input_nmsg_read(nmsg_input_t input, nmsg_message_t *msg) {
 
 	/* pass a pointer to the payload to the caller */
 	*msg = _nmsg_message_from_payload(np);
-	if (*msg == NULL)
+	if (*msg == NULL) {
+		_nmsg_payload_free(&np);
 		return (nmsg_res_memfail);
+	}
 
 	/* possibly sleep a bit if ingress rate control is enabled */
 	if (input->stream->brate != NULL)

--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -60,7 +60,7 @@ _input_nmsg_read(nmsg_input_t input, nmsg_message_t *msg) {
 
 	/* pass a pointer to the payload to the caller */
 	*msg = _nmsg_message_from_payload(np);
-	if (msg == NULL)
+	if (*msg == NULL)
 		return (nmsg_res_memfail);
 
 	/* possibly sleep a bit if ingress rate control is enabled */


### PR DESCRIPTION
Analysis with `cppcheck` identified two cases where a reference-result parameter was populated by a call, but the check for a NULL result checked the address of the result (the non-NULL parameter) rather than the result itself.

This PR fixes those NULL result checks, as well as a memory leak found while analyzing one of the cases.