### PR TITLE
port from libxs to zeromq

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,7 @@ AM_CFLAGS = \
 	$(libpcap_CFLAGS) \
 	$(libprotobuf_c_CFLAGS) \
 	$(libwdns_CFLAGS) \
-	$(libxs_CFLAGS) \
+	$(libzmq_CFLAGS) \
 	$(yajl_CFLAGS)
 AM_LDFLAGS =
 
@@ -130,7 +130,7 @@ nmsg_libnmsg_la_LDFLAGS = \
 nmsg_libnmsg_la_LIBADD = \
 	$(libpcap_LIBS) \
 	$(libprotobuf_c_LIBS) \
-	$(libxs_LIBS) \
+	$(libzmq_LIBS) \
 	$(yajl_LIBS)
 nmsg_libnmsg_la_SOURCES = \
 	libmy/crc32c.c libmy/crc32c.h libmy/crc32c-slicing.c libmy/crc32c-sse42.c \
@@ -179,7 +179,7 @@ nmsg_libnmsg_la_SOURCES = \
 	nmsg/strbuf.c \
 	nmsg/timespec.c \
 	nmsg/version.c nmsg/version.h \
-	nmsg/xsio.c \
+	nmsg/zmqio.c \
 	nmsg/zbuf.c \
 	nmsg/msgmod/lookup.c \
 	nmsg/msgmod/message.c \
@@ -322,7 +322,7 @@ bin_PROGRAMS += src/nmsgtool
 src_nmsgtool_LDADD = \
 	nmsg/libnmsg.la \
 	$(libpcap_LIBS) \
-	$(libxs_LIBS)
+	$(libzmq_LIBS)
 src_nmsgtool_SOURCES = \
 	libmy/argv.c \
 	libmy/argv.h \

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ nmsg has the following external dependencies:
 
 * [wdns](https://github.com/farsightsec/wdns)
 
-* [libxs](http://www.crossroads.io/)
+* [zmq](http://zeromq.org/)
 
 * [yajl](http://lloyd.github.io/yajl/)
 
@@ -34,7 +34,7 @@ nmsg has the following external dependencies:
 
 On Debian systems, the following packages should be installed, if available:
 
-    pkg-config libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libxs-dev libyajl-dev zlib1g-dev
+    pkg-config libpcap0.8-dev libprotobuf-c-dev protobuf-c-compiler libzmq3-dev libyajl-dev zlib1g-dev
 
 Note that on Debian systems, binary packages of nmsg and its dependencies are
 available from
@@ -44,7 +44,7 @@ Debian-based systems.
 
 On FreeBSD systems, the following ports should be installed, if available:
 
-    devel/libxs
+    devel/libzmq
     devel/yajl
     devel/pkgconf
     devel/protobuf
@@ -60,7 +60,7 @@ compile and install `libnmsg` and `nmsgtool` to `/usr/local`. If building from a
 git checkout, run the `./autogen.sh` command first to generate the `configure`
 script.
 
-Support for `libxs` can be disabled by passing the `--without-libxs` parameter
+Support for `libzmq` can be disabled by passing the `--without-libzmq` parameter
 to the `configure` script.
 
 Support for `yajl` can be disabled by passing the `--without-yajl` parameter

--- a/configure.ac
+++ b/configure.ac
@@ -118,7 +118,7 @@ AC_CHECK_MEMBER(
 )
 
 ###
-### External library dependencies: libpcap, libprotobuf-c, libwdns, libxs, yajl, libz
+### External library dependencies: libpcap, libprotobuf-c, libwdns, zeromq, yajl, libz
 ###
 
 MY_CHECK_LIBPCAP
@@ -130,13 +130,13 @@ AS_IF([test -z "$PROTOC_C"],
 
 PKG_CHECK_MODULES([libwdns], [libwdns >= 0.8.0])
 
-AC_ARG_WITH([libxs], AS_HELP_STRING([--without-libxs], [Disable libxs support]))
-if test "x$with_libxs" != "xno"; then
-    PKG_CHECK_MODULES([libxs], [libxs >= 1.2.0])
-    AC_DEFINE([HAVE_LIBXS], [1], [Define to 1 if libxs support is enabled.])
-    use_libxs="true"
+AC_ARG_WITH([zmq], AS_HELP_STRING([--without-libzmq], [Disable zmq support]))
+if test "x$with_libzmq" != "xno"; then
+    PKG_CHECK_MODULES([libzmq], [libzmq >= 4.2.0])
+    AC_DEFINE([HAVE_LIBZMQ], [1], [Define to 1 if libzmq support is enabled.])
+    use_libzmq="true"
 else
-    use_libxs="false"
+    use_libzmq="false"
 fi
 
 AC_ARG_WITH([yajl], AS_HELP_STRING([--without-yajl], [Disable yajl support]))
@@ -210,7 +210,7 @@ AC_MSG_RESULT([
         plugin directory:       ${NMSG_LIBDIR}
 
         bigendian:              ${ac_cv_c_bigendian}
-        libxs support:          ${use_libxs}
+        libzmq support:         ${use_libzmq}
         yajl support:           ${use_yajl}
 
         building html docs:     ${DOC_HTML_MSG}

--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,7 @@ Build-Depends:
  libpcap0.8-dev,
  libprotobuf-c-dev (>= 1.0.1~),
  libwdns-dev (>= 0.8.0~),
- libxs-dev (>= 1.2.0~),
+ libzmq3-dev (>= 4.2.0~),
  libyajl-dev (>= 2.1.0~),
  pkg-config,
  protobuf-c-compiler (>= 1.0.1~),

--- a/debian/libnmsg6.symbols
+++ b/debian/libnmsg6.symbols
@@ -17,6 +17,8 @@ libnmsg.so.6 libnmsg6 #MINVER#
  nmsg_fltmod_thread_fini@Base 0.11.0
  nmsg_fltmod_thread_init@Base 0.11.0
  nmsg_get_debug@Base 0.8.0
+ nmsg_get_version@Base 0.14.0
+ nmsg_get_version_number@Base 0.14.0
  nmsg_init@Base 0.5.0
  nmsg_input_breakloop@Base 0.7.0
  nmsg_input_close@Base 0.5.0
@@ -30,8 +32,8 @@ libnmsg.so.6 libnmsg6 #MINVER#
  nmsg_input_open_pcap@Base 0.5.0
  nmsg_input_open_pres@Base 0.5.0
  nmsg_input_open_sock@Base 0.5.0
- nmsg_input_open_xs@Base 0.7.0
- nmsg_input_open_xs_endpoint@Base 0.7.0
+ nmsg_input_open_zmq@Base 0.14.0
+ nmsg_input_open_zmq_endpoint@Base 0.14.0
  nmsg_input_read@Base 0.9.1
  nmsg_input_read_null@Base 0.8.0
  nmsg_input_set_blocking_io@Base 0.5.17
@@ -48,7 +50,7 @@ libnmsg.so.6 libnmsg6 #MINVER#
  nmsg_io_add_input_channel@Base 0.6.11
  nmsg_io_add_input_fname@Base 0.6.11
  nmsg_io_add_input_sockspec@Base 0.6.11
- nmsg_io_add_input_xs_channel@Base 0.7.0
+ nmsg_io_add_input_zmq_channel@Base 0.14.0
  nmsg_io_add_output@Base 0.5.0
  nmsg_io_breakloop@Base 0.5.0
  nmsg_io_destroy@Base 0.5.0
@@ -130,8 +132,8 @@ libnmsg.so.6 libnmsg6 #MINVER#
  nmsg_output_open_json@Base 0.10.0
  nmsg_output_open_pres@Base 0.11.1
  nmsg_output_open_sock@Base 0.5.0
- nmsg_output_open_xs@Base 0.7.0
- nmsg_output_open_xs_endpoint@Base 0.7.0
+ nmsg_output_open_zmq@Base 0.14.0
+ nmsg_output_open_zmq_endpoint@Base 0.14.0
  nmsg_output_set_buffered@Base 0.5.0
  nmsg_output_set_endline@Base 0.5.0
  nmsg_output_set_filter_msgtype@Base 0.5.0

--- a/doc/docbook/nmsgtool.1
+++ b/doc/docbook/nmsgtool.1
@@ -349,41 +349,41 @@ would be equivalent to
 .\}
 .RE
 .PP
-\fB\-L\fR \fIxep\fR, \fB\-\-readxsock\fR \fIxep\fR
+\fB\-L\fR \fIzep\fR, \fB\-\-readzsock\fR \fIzep\fR
 .RS 4
-Read NMSG payloads from a Crossroads I/O endpoint\&. The endpoint
-\fIxep\fR
-is very similar to the "transport://address" specifiers used by the libxs library, except that additional configuration may be needed in order to set up the XS connection, which is specified by appending comma\-separated arguments\&. See the xs_tcp(7) and xs_ipc(7) manpages for details\&.
+Read NMSG payloads from a ZeroMQ endpoint\&. The endpoint
+\fIzep\fR
+is very similar to the "transport://address" specifiers used by the libzmq library, except that additional configuration may be needed in order to set up the ZMQ connection, which is specified by appending comma\-separated arguments\&. See the zmq_tcp(7) and zmq_ipc(7) manpages for details\&.
 .sp
-In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected XS socket by appending ",accept" or ",connect" to the
-\fIxep\fR
-argument\&. (If not given, nmsgtool behaves as if ",connect" was given\&.) That is, ",accept" uses the xs_bind(3) function to obtain an XS endpoint, and ",connect" uses the xs_connect(3) function\&.
+In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected ZMQ socket by appending ",accept" or ",connect" to the
+\fIzep\fR
+argument\&. (If not given, nmsgtool behaves as if ",connect" was given\&.) That is, ",accept" uses the zmq_bind(3) function to obtain an ZMQ endpoint, and ",connect" uses the zmq_connect(3) function\&.
 .sp
-The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull"\&. (If not given, nmsgtool behaves as if ",pubsub" was passed\&.) See the xs_socket(3) manpage for details\&. When PUB/SUB is used with
+The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull"\&. (If not given, nmsgtool behaves as if ",pubsub" was passed\&.) See the zmq_socket(3) manpage for details\&. When PUB/SUB is used with
 \fB\-L\fR, nmsgtool participates in the "SUB" role of the Crossroads I/O PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PULL" role\&.
 .sp
 Examples of possible
-\fIxep\fR
+\fIzep\fR
 arguments to
 \fB\-L\fR
 include "ipc:///tmp/nmsg\&.sock,accept,pubsub" to indicate a Crossroads I/O endpoint that accepts PUB/SUB connections on the IPC path /tmp/nmsg\&.sock (in the SUB role), and "tcp://127\&.0\&.0\&.1:5555,accept,pushpull" to indicate a Crossroads I/O endpoint that listens for PUSH/PULL connections on the TCP socket 127\&.0\&.0\&.1:5555 (in the PULL role)\&.
 .RE
 .PP
-\fB\-S\fR \fIxep\fR, \fB\-\-writexsock\fR \fIxep\fR
+\fB\-S\fR \fIzep\fR, \fB\-\-writezsock\fR \fIzep\fR
 .RS 4
-Write NMSG payloads to a Crossroads X/O endpoint\&. The endpoint
-\fIxep\fR
-is very similiar to the "transport://address" specifiers used by the libxs library, except that additional configuration may be needed in order to set up the XS connection, which is specified by appending comma\-separated arguments\&. See the xs_tcp(7) and xs_ipc(7) manpages for details\&.
+Write NMSG payloads to a ZeroMQ endpoint\&. The endpoint
+\fIzep\fR
+is very similiar to the "transport://address" specifiers used by the libzmq library, except that additional configuration may be needed in order to set up the ZMQ connection, which is specified by appending comma\-separated arguments\&. See the zmq_tcp(7) and zmq_ipc(7) manpages for details\&.
 .sp
-In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected XS socket by appending ",accept" or ",connect" to the
-\fIxep\fR
-argument\&. (If not given, nmsgtool behaves as if ",connect" was given\&.) That is, ",accept" uses the xs_bind(3) function to obtain an XS endpoint, and ",connect" uses the xs_connect(3) function\&.
+In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected ZMQ socket by appending ",accept" or ",connect" to the
+\fIzep\fR
+argument\&. (If not given, nmsgtool behaves as if ",connect" was given\&.) That is, ",accept" uses the zmq_bind(3) function to obtain an ZMQ endpoint, and ",connect" uses the zmq_connect(3) function\&.
 .sp
-The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull"\&. (If not given, nmsgtool behaves as if ",pubsub" was passed\&.) See the xs_socket(3) manpage for details\&. When PUB/SUB is used with
+The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull"\&. (If not given, nmsgtool behaves as if ",pubsub" was passed\&.) See the zmq_socket(3) manpage for details\&. When PUB/SUB is used with
 \fB\-S\fR, nmsgtool participates in the "PUB" role of the Crossroads I/O PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PUSH" role\&.
 .sp
 Examples of possible
-\fIxep\fR
+\fIzep\fR
 arguments to
 \fB\-S\fR
 include "ipc:///tmp/nmsg\&.sock,connect,pubsub" to indicate a Crossroads I/O endpoint that connects to a PUB/SUB socket on the IPC path /tmp/nmsg\&.sock (in the PUB role), and "tcp://127\&.0\&.0\&.1:5555,connect,pushpull" to indicate a Crossroads I/O endpoint that connects to a PUSH/PULL socket on the TCP socket 127\&.0\&.0\&.1:5555 (in the PULL role)\&.

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -365,24 +365,24 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-L</option> <replaceable>xep</replaceable></term>
-        <term><option>--readxsock</option> <replaceable>xep</replaceable></term>
+        <term><option>-L</option> <replaceable>zep</replaceable></term>
+        <term><option>--readzsock</option> <replaceable>zep</replaceable></term>
         <listitem>
-          <para>Read NMSG payloads from a Crossroads I/O endpoint. The endpoint <replaceable>xep</replaceable> is very similar to the "transport://address" specifiers used by the libxs library, except that additional configuration may be needed in order to set up the XS connection, which is specified by appending comma-separated arguments. See the xs_tcp(7) and xs_ipc(7) manpages for details.</para>
-          <para>In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected XS socket by appending ",accept" or ",connect" to the <replaceable>xep</replaceable> argument. (If not given, nmsgtool behaves as if ",connect" was given.) That is, ",accept" uses the xs_bind(3) function to obtain an XS endpoint, and ",connect" uses the xs_connect(3) function.</para>
-          <para>The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull". (If not given, nmsgtool behaves as if ",pubsub" was passed.) See the xs_socket(3) manpage for details. When PUB/SUB is used with <option>-L</option>, nmsgtool participates in the "SUB" role of the Crossroads I/O PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PULL" role.</para>
-          <para>Examples of possible <replaceable>xep</replaceable> arguments to <option>-L</option> include "ipc:///tmp/nmsg.sock,accept,pubsub" to indicate a Crossroads I/O endpoint that accepts PUB/SUB connections on the IPC path /tmp/nmsg.sock (in the SUB role), and "tcp://127.0.0.1:5555,accept,pushpull" to indicate a Crossroads I/O endpoint that listens for PUSH/PULL connections on the TCP socket 127.0.0.1:5555 (in the PULL role).</para>
+          <para>Read NMSG payloads from a ZeroMQ endpoint. The endpoint <replaceable>zep</replaceable> is very similar to the "transport://address" specifiers used by the libzmq library, except that additional configuration may be needed in order to set up the ZMQ connection, which is specified by appending comma-separated arguments. See the zmq_tcp(7) and zmq_ipc(7) manpages for details.</para>
+          <para>In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected zmq socket by appending ",accept" or ",connect" to the <replaceable>zep</replaceable> argument. (If not given, nmsgtool behaves as if ",connect" was given.) That is, ",accept" uses the zmq_bind(3) function to obtain an zmq endpoint, and ",connect" uses the zmq_connect(3) function.</para>
+          <para>The user may also select between the ZeroMQ PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull". (If not given, nmsgtool behaves as if ",pubsub" was passed.) See the zmq_socket(3) manpage for details. When PUB/SUB is used with <option>-L</option>, nmsgtool participates in the "SUB" role of the ZeroMQ PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PULL" role.</para>
+          <para>Examples of possible <replaceable>zep</replaceable> arguments to <option>-L</option> include "ipc:///tmp/nmsg.sock,accept,pubsub" to indicate a ZeroMQ endpoint that accepts PUB/SUB connections on the IPC path /tmp/nmsg.sock (in the SUB role), and "tcp://127.0.0.1:5555,accept,pushpull" to indicate a ZeroMQ endpoint that listens for PUSH/PULL connections on the TCP socket 127.0.0.1:5555 (in the PULL role).</para>
         </listitem>
       </varlistentry>
 
       <varlistentry>
-        <term><option>-S</option> <replaceable>xep</replaceable></term>
-        <term><option>--writexsock</option> <replaceable>xep</replaceable></term>
+        <term><option>-S</option> <replaceable>zep</replaceable></term>
+        <term><option>--writezsock</option> <replaceable>zep</replaceable></term>
         <listitem>
-          <para>Write NMSG payloads to a Crossroads X/O endpoint. The endpoint <replaceable>xep</replaceable> is very similiar to the "transport://address" specifiers used by the libxs library, except that additional configuration may be needed in order to set up the XS connection, which is specified by appending comma-separated arguments. See the xs_tcp(7) and xs_ipc(7) manpages for details.</para>
-          <para>In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected XS socket by appending ",accept" or ",connect" to the <replaceable>xep</replaceable> argument. (If not given, nmsgtool behaves as if ",connect" was given.) That is, ",accept" uses the xs_bind(3) function to obtain an XS endpoint, and ",connect" uses the xs_connect(3) function.</para>
-          <para>The user may also select between the Crossroads I/O PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull". (If not given, nmsgtool behaves as if ",pubsub" was passed.) See the xs_socket(3) manpage for details. When PUB/SUB is used with <option>-S</option>, nmsgtool participates in the "PUB" role of the Crossroads I/O PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PUSH" role.</para>
-          <para>Examples of possible <replaceable>xep</replaceable> arguments to <option>-S</option> include "ipc:///tmp/nmsg.sock,connect,pubsub" to indicate a Crossroads I/O endpoint that connects to a PUB/SUB socket on the IPC path /tmp/nmsg.sock (in the PUB role), and "tcp://127.0.0.1:5555,connect,pushpull" to indicate a Crossroads I/O endpoint that connects to a PUSH/PULL socket on the TCP socket 127.0.0.1:5555 (in the PULL role).</para>
+          <para>Write NMSG payloads to a ZeroMQ endpoint. The endpoint <replaceable>zep</replaceable> is very similiar to the "transport://address" specifiers used by the libzmq library, except that additional configuration may be needed in order to set up the zmq connection, which is specified by appending comma-separated arguments. See the zmq_tcp(7) and zmq_ipc(7) manpages for details.</para>
+          <para>In addition to the base "transport://address" specifier, the user may specifically select between a bound or connected zmq socket by appending ",accept" or ",connect" to the <replaceable>zep</replaceable> argument. (If not given, nmsgtool behaves as if ",connect" was given.) That is, ",accept" uses the zmq_bind(3) function to obtain an zmq endpoint, and ",connect" uses the zmq_connect(3) function.</para>
+          <para>The user may also select between the ZeroMQ PUB/SUB and PUSH/PULL messaging patterns by appending either ",pubsub" or ",pushpull". (If not given, nmsgtool behaves as if ",pubsub" was passed.) See the zmq_socket(3) manpage for details. When PUB/SUB is used with <option>-S</option>, nmsgtool participates in the "PUB" role of the ZeroMQ PUB/SUB messaging pattern, and when PUSH/PULL is used, nmsgtool participates in the "PUSH" role.</para>
+          <para>Examples of possible <replaceable>zep</replaceable> arguments to <option>-S</option> include "ipc:///tmp/nmsg.sock,connect,pubsub" to indicate a ZeroMQ endpoint that connects to a PUB/SUB socket on the IPC path /tmp/nmsg.sock (in the PUB role), and "tcp://127.0.0.1:5555,connect,pushpull" to indicate a ZeroMQ endpoint that connects to a PUSH/PULL socket on the TCP socket 127.0.0.1:5555 (in the PULL role).</para>
         </listitem>
       </varlistentry>
 
@@ -636,11 +636,11 @@
     to a series of compressed files, rotated every hour:</para>
     <programlisting><command>nmsgtool -l 192.0.2.255/8430..8437 -w /tmp/file -t 3600 -k '' -z</command></programlisting>
 
-    <para>To read NMSG payloads from a Crossroads I/O "PULL" socket over a TCP connection:</para>
+    <para>To read NMSG payloads from a ZeroMQ "PULL" socket over a TCP connection:</para>
     <programlisting><command>nmsgtool -L tcp://127.0.0.1:5555,accept,pushpull</command></programlisting>
     <para>This waits for TCP connections on 127.0.0.1:5555.</para>
 
-    <para>To read NMSG payloads from a file and write them to a Crossroads I/O "PUSH" socket over a TCP connection:</para>
+    <para>To read NMSG payloads from a file and write them to a ZeroMQ "PUSH" socket over a TCP connection:</para>
     <programlisting><command>nmsgtool -r /tmp/file.nmsg -S tcp://127.0.0.1:5555,connect,pushpull</command></programlisting>
     <para>This attempts to connect to a TCP reader on 127.0.0.1:5555, such as the nmsgtool command in the previous example.</para>
 

--- a/nmsg/input.c
+++ b/nmsg/input.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2019 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,25 +37,25 @@ nmsg_input_open_sock(int fd) {
 	return (input_open_stream(nmsg_stream_type_sock, fd));
 }
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 nmsg_input_t
-nmsg_input_open_xs(void *s) {
+nmsg_input_open_zmq(void *s) {
 	struct nmsg_input *input;
 
-	input = input_open_stream_base(nmsg_stream_type_xs);
+	input = input_open_stream_base(nmsg_stream_type_zmq);
 	if (input == NULL)
 		return (input);
 
-	input->stream->xs = s;
+	input->stream->zmq = s;
 
 	return (input);
 }
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 nmsg_input_t
-nmsg_input_open_xs(void *s __attribute__((unused))) {
+nmsg_input_open_zmq(void *s __attribute__((unused))) {
 	return (NULL);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 nmsg_input_t
 nmsg_input_open_callback(nmsg_cb_message_read cb, void *user) {
@@ -216,12 +216,12 @@ nmsg_input_close(nmsg_input_t *input) {
 	switch ((*input)->type) {
 	case nmsg_input_type_stream:
 		_nmsg_brate_destroy(&((*input)->stream->brate));
-#ifdef HAVE_LIBXS
-		if ((*input)->stream->type == nmsg_stream_type_xs)
-			xs_close((*input)->stream->xs);
-#else /* HAVE_LIBXS */
-		assert((*input)->stream->type != nmsg_stream_type_xs);
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+		if ((*input)->stream->type == nmsg_stream_type_zmq)
+			zmq_close((*input)->stream->zmq);
+#else /* HAVE_LIBZMQ */
+		assert((*input)->stream->type != nmsg_stream_type_zmq);
+#endif /* HAVE_LIBZMQ */
 		input_close_stream(*input);
 		break;
 	case nmsg_input_type_pcap:
@@ -461,12 +461,12 @@ input_open_stream_base(nmsg_stream_type type) {
 		input->stream->stream_read_fp = _input_nmsg_read_container_file;
 	} else if (type == nmsg_stream_type_sock) {
 		input->stream->stream_read_fp = _input_nmsg_read_container_sock;
-	} else if (type == nmsg_stream_type_xs) {
-#ifdef HAVE_LIBXS
-		input->stream->stream_read_fp = _input_nmsg_read_container_xs;
-#else /* HAVE_LIBXS */
-		assert(type != nmsg_stream_type_xs);
-#endif /* HAVE_LIBXS */
+	} else if (type == nmsg_stream_type_zmq) {
+#ifdef HAVE_LIBZMQ
+		input->stream->stream_read_fp = _input_nmsg_read_container_zmq;
+#else /* HAVE_LIBZMQ */
+		assert(type != nmsg_stream_type_zmq);
+#endif /* HAVE_LIBZMQ */
 	}
 
 	/* nmsg_zbuf */

--- a/nmsg/input.h
+++ b/nmsg/input.h
@@ -80,44 +80,44 @@ nmsg_input_t
 nmsg_input_open_sock(int fd);
 
 /**
- * Initialize a new NMSG stream input from an XS socket source.
+ * Initialize a new NMSG stream input from a ZMQ socket source.
  *
- * \param[in] s XS socket.
+ * \param[in] s ZMQ socket.
  *
  * \return Opaque pointer that is NULL on failure or non-NULL on success.
  */
 nmsg_input_t
-nmsg_input_open_xs(void *s);
+nmsg_input_open_zmq(void *s);
 
 /**
- * Create an XS socket and initialize a new NMSG stream input from it.
+ * Create an ZMQ socket and initialize a new NMSG stream input from it.
  *
- * This function is a wrapper for nmsg_input_open_xs(). Instead of taking an
- * already initialized XS socket object, it takes an endpoint argument like
- * xs_connect() and xs_bind() do which is a string containing a
- * "transport://address" specification and initializes an XS socket object.
+ * This function is a wrapper for nmsg_input_open_zmq(). Instead of taking an
+ * already initialized ZMQ socket object, it takes an endpoint argument like
+ * zmq_connect() and zmq_bind() do which is a string containing a
+ * "transport://address" specification and initializes an ZMQ socket object.
  * However, this endpoint string will be munged in order to support additional
  * functionality:
  *
- * The caller may select between a bound or connected XS socket by appending
+ * The caller may select between a bound or connected ZMQ socket by appending
  * ",accept" or ",connect" to the endpoint argument. (If not given, this
  * function behaves as if ",connect" was passed.) That is, ",accept" uses
- * xs_bind() to obtain a XS endpoint, and ",connect" uses xs_connect().
+ * zmq_bind() to obtain a ZMQ endpoint, and ",connect" uses zmq_connect().
  *
  * The caller may additionally select between a SUB socket or a PULL
  * socket by appending ",pubsub" or ",pushpull". (If not given, this function
  * behaves as if ",pubsub" was passed.)
  *
- * \see nmsg_output_open_xs_endpoint()
+ * \see nmsg_output_open_zmq_endpoint()
  *
- * \param[in] xs_ctx XS context object.
+ * \param[in] zmq_ctx ZMQ context object.
  *
- * \param[in] ep XS endpoint (with nmsg-specific extensions)
+ * \param[in] ep ZMQ endpoint (with nmsg-specific extensions)
  *
  * \return Opaque pointer that is NULL on failure or non-NULL on success.
  */
 nmsg_input_t
-nmsg_input_open_xs_endpoint(void *xs_ctx, const char *ep);
+nmsg_input_open_zmq_endpoint(void *zmq_ctx, const char *ep);
 
 /**
  * Initialize a new nmsg input closure. This allows a user-provided callback to

--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009-2013 by Farsight Security, Inc.
+ * Copyright (c) 2009-2019 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -349,40 +349,40 @@ _input_nmsg_read_container_sock(nmsg_input_t input, Nmsg__Nmsg **nmsg) {
 	return (res);
 }
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 nmsg_res
-_input_nmsg_read_container_xs(nmsg_input_t input, Nmsg__Nmsg **nmsg) {
+_input_nmsg_read_container_zmq(nmsg_input_t input, Nmsg__Nmsg **nmsg) {
 	int ret;
 	nmsg_res res;
 	uint8_t *buf;
 	size_t buf_len;
 	ssize_t msgsize = 0;
-	xs_msg_t xmsg;
-	xs_pollitem_t xitems[1];
+	zmq_msg_t zmsg;
+	zmq_pollitem_t zitems[1];
 
 	/* poll */
-	xitems[0].socket = input->stream->xs;
-	xitems[0].events = XS_POLLIN;
-	ret = xs_poll(xitems, 1, NMSG_RBUF_TIMEOUT);
+	zitems[0].socket = input->stream->zmq;
+	zitems[0].events = ZMQ_POLLIN;
+	ret = zmq_poll(zitems, 1, NMSG_RBUF_TIMEOUT);
 	if (ret == 0 || (ret == -1 && errno == EINTR))
 		return (nmsg_res_again);
 	else if (ret == -1)
 		return (nmsg_res_read_failure);
 
-	/* initialize XS message object */
-	if (xs_msg_init(&xmsg))
+	/* initialize ZMQ message object */
+	if (zmq_msg_init(&zmsg))
 		return (nmsg_res_failure);
 
 	/* read the NMSG container */
-	if (xs_recvmsg(input->stream->xs, &xmsg, 0) == -1) {
+	if (zmq_recvmsg(input->stream->zmq, &zmsg, 0) == -1) {
 		res = nmsg_res_failure;
 		goto out;
 	}
 	nmsg_timespec_get(&input->stream->now);
 
-	/* get buffer from the XS message */
-	buf = xs_msg_data(&xmsg);
-	buf_len = xs_msg_size(&xmsg);
+	/* get buffer from the ZMQ message */
+	buf = zmq_msg_data(&zmsg);
+	buf_len = zmq_msg_size(&zmsg);
 	if (buf_len < NMSG_HDRLSZ_V2) {
 		res = nmsg_res_failure;
 		goto out;
@@ -394,7 +394,7 @@ _input_nmsg_read_container_xs(nmsg_input_t input, Nmsg__Nmsg **nmsg) {
 		goto out;
 	buf += NMSG_HDRLSZ_V2;
 
-	/* the entire message must have been read by xs_recvmsg() */
+	/* the entire message must have been read by zmq_recvmsg() */
 	assert((size_t) msgsize == buf_len - NMSG_HDRLSZ_V2);
 
 	/* unpack message */
@@ -411,10 +411,10 @@ _input_nmsg_read_container_xs(nmsg_input_t input, Nmsg__Nmsg **nmsg) {
 	_input_frag_gc(input->stream);
 
 out:
-	xs_msg_close(&xmsg);
+	zmq_msg_close(&zmsg);
 	return (res);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 nmsg_res
 _input_nmsg_deserialize_header(const uint8_t *buf, size_t buf_len,

--- a/nmsg/input_seqsrc.c
+++ b/nmsg/input_seqsrc.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011-2013 by Farsight Security, Inc.
+ * Copyright (c) 2011-2019 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,14 +202,14 @@ _input_seqsrc_get(nmsg_input_t input, Nmsg__Nmsg *nmsg) {
 					  seqsrc->addr_str,
 					  sizeof(seqsrc->addr_str));
 			}
-#ifdef HAVE_LIBXS
-		} else if (input->stream->type == nmsg_stream_type_xs) {
+#ifdef HAVE_LIBZMQ
+		} else if (input->stream->type == nmsg_stream_type_zmq) {
 			seqsrc->key.sequence_id = nmsg->sequence_id;
 			seqsrc->key.af = AF_UNSPEC;
 		}
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 		}
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 		ISC_LINK_INIT(seqsrc, link);
 		ISC_LIST_APPEND(input->stream->seqsrcs, seqsrc, link);

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -497,23 +497,23 @@ out:
 	return (res);
 }
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 static nmsg_res
-_nmsg_io_add_input_xs(nmsg_io_t io, void *xs_ctx, const char *str_socket, void *user) {
+_nmsg_io_add_input_zmq(nmsg_io_t io, void *zmq_ctx, const char *str_socket, void *user) {
 	nmsg_input_t input;
 
-	input = nmsg_input_open_xs_endpoint(xs_ctx, str_socket);
+	input = nmsg_input_open_zmq_endpoint(zmq_ctx, str_socket);
 	if (input == NULL) {
-		_nmsg_dprintfv(io->debug, 2, "nmsg_io: nmsg_input_open_sock() failed\n");
+		_nmsg_dprintfv(io->debug, 2, "nmsg_io: nmsg_input_open_zmq_endpoint() failed\n");
 		return (nmsg_res_failure);
 	}
 	return (nmsg_io_add_input(io, input, user));
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 nmsg_res
-nmsg_io_add_input_xs_channel(nmsg_io_t io, void *xs_ctx, const char *chan, void *user) {
+nmsg_io_add_input_zmq_channel(nmsg_io_t io, void *zmq_ctx, const char *chan, void *user) {
 	char **alias = NULL;
 	int num_aliases;
 	nmsg_res res;
@@ -521,12 +521,12 @@ nmsg_io_add_input_xs_channel(nmsg_io_t io, void *xs_ctx, const char *chan, void 
 	num_aliases = nmsg_chalias_lookup(chan, &alias);
 	if (num_aliases <= 0) {
 		_nmsg_dprintfv(io->debug, 2,
-			       "nmsg_io: XS channel alias lookup '%s' failed\n", chan);
+			       "nmsg_io: ZMQ channel alias lookup '%s' failed\n", chan);
 		res = nmsg_res_failure;
 		goto out;
 	}
 	for (int i = 0; i < num_aliases; i++) {
-		res = _nmsg_io_add_input_xs(io, xs_ctx, alias[i], user);
+		res = _nmsg_io_add_input_zmq(io, zmq_ctx, alias[i], user);
 		if (res != nmsg_res_success)
 			goto out;
 	}
@@ -536,17 +536,17 @@ out:
 	nmsg_chalias_free(&alias);
 	return (res);
 }
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 nmsg_res
-nmsg_io_add_input_xs_channel(nmsg_io_t io,
-			     void *xs_ctx __attribute__((unused)),
+nmsg_io_add_input_zmq_channel(nmsg_io_t io,
+			     void *zmq_ctx __attribute__((unused)),
 			     const char *chan __attribute__((unused)),
 			     void *user __attribute__((unused)))
 {
-	_nmsg_dprintfv(io->debug, 2, "nmsg_io: %s: compiled without libxs support\n", __func__);
+	_nmsg_dprintfv(io->debug, 2, "nmsg_io: %s: compiled without libzmq support\n", __func__);
 	return (nmsg_res_failure);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 nmsg_res
 nmsg_io_add_input_sockspec(nmsg_io_t io, const char *sockspec, void *user) {

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -243,11 +243,11 @@ nmsg_res
 nmsg_io_add_input_channel(nmsg_io_t io, const char *chan, void *user);
 
 /**
- * Add an nmsg XS input channel to an nmsg_io_t object.
+ * Add an nmsg ZMQ input channel to an nmsg_io_t object.
  *
  * \param[in] io Valid nmsg_io_t object.
  *
- * \param[in] xs_ctx XS context object.
+ * \param[in] zmq_ctx ZMQ context object.
  *
  * \param[in] chan Input channel name.
  *
@@ -258,7 +258,7 @@ nmsg_io_add_input_channel(nmsg_io_t io, const char *chan, void *user);
  * \return #nmsg_res_memfail
  */
 nmsg_res
-nmsg_io_add_input_xs_channel(nmsg_io_t io, void *xs_ctx, const char *chan, void *user);
+nmsg_io_add_input_zmq_channel(nmsg_io_t io, void *zmq_ctx, const char *chan, void *user);
 
 /**
  * Add an nmsg input sockspec to an nmsg_io_t object. When nmsg_io_loop() is

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013, 2015 by Farsight Security, Inc.
+ * Copyright (c) 2008-2019 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,27 +36,27 @@ nmsg_output_open_sock(int fd, size_t bufsz) {
 	return (output_open_stream(nmsg_stream_type_sock, fd, bufsz));
 }
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 nmsg_output_t
-nmsg_output_open_xs(void *s, size_t bufsz) {
+nmsg_output_open_zmq(void *s, size_t bufsz) {
 	struct nmsg_output *output;
 
-	output = output_open_stream_base(nmsg_stream_type_xs, bufsz);
+	output = output_open_stream_base(nmsg_stream_type_zmq, bufsz);
 	if (output == NULL)
 		return (output);
 
-	output->stream->xs = s;
+	output->stream->zmq = s;
 
 	return (output);
 }
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 nmsg_output_t
-nmsg_output_open_xs(void *s __attribute__((unused)),
+nmsg_output_open_zmq(void *s __attribute__((unused)),
 		    size_t bufsz __attribute__((unused)))
 {
 	return (NULL);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 nmsg_output_t
 nmsg_output_open_pres(int fd) {
@@ -184,12 +184,12 @@ nmsg_output_close(nmsg_output_t *output) {
 		res = _output_nmsg_flush(*output);
 		if ((*output)->stream->random != NULL)
 			nmsg_random_destroy(&((*output)->stream->random));
-#ifdef HAVE_LIBXS
-		if ((*output)->stream->type == nmsg_stream_type_xs)
-			xs_close((*output)->stream->xs);
-#else /* HAVE_LIBXS */
-		assert((*output)->stream->type != nmsg_stream_type_xs);
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+		if ((*output)->stream->type == nmsg_stream_type_zmq)
+			zmq_close((*output)->stream->zmq);
+#else /* HAVE_LIBZMQ */
+		assert((*output)->stream->type != nmsg_stream_type_zmq);
+#endif /* HAVE_LIBZMQ */
 		if ((*output)->stream->type == nmsg_stream_type_file ||
 		    (*output)->stream->type == nmsg_stream_type_sock)
 		{
@@ -362,7 +362,7 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 
 	/* enable container sequencing */
 	if (output->stream->type == nmsg_stream_type_sock ||
-	    output->stream->type == nmsg_stream_type_xs)
+	    output->stream->type == nmsg_stream_type_zmq)
 	{
 		output->stream->do_sequence = true;
 

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -74,48 +74,48 @@ nmsg_output_t
 nmsg_output_open_sock(int fd, size_t bufsz);
 
 /**
- * Initialize a new XS socket NMSG output.
+ * Initialize a new ZMQ socket NMSG output.
  *
- * \param[in] s XS output socket.
+ * \param[in] s ZMQ output socket.
  *
  * \param[in] bufsz Value between #NMSG_WBUFSZ_MIN and #NMSG_WBUFSZ_MAX.
  *
  * \return Opaque pointer that is NULL on failure or non-NULL on success.
  */
 nmsg_output_t
-nmsg_output_open_xs(void *s, size_t bufsz);
+nmsg_output_open_zmq(void *s, size_t bufsz);
 
 /**
- * Create an XS socket and initialize a new NMSG stream output from it.
+ * Create an ZMQ socket and initialize a new NMSG stream output from it.
  *
- * This function is a wrapper for nmsg_output_open_xs(). Instead of taking an
- * already initialized XS socket object, it takes an endpoint argument like
- * xs_connect() and xs_bind() do which is a string containing a
- * "transport://address" specification and initializes a XS socket object.
+ * This function is a wrapper for nmsg_output_open_zmq(). Instead of taking an
+ * already initialized ZMQ socket object, it takes an endpoint argument like
+ * zmq_connect() and zmq_bind() do which is a string containing a
+ * "transport://address" specification and initializes a ZMQ socket object.
  * However, this endpoint string will be munged in order to support additional
  * functionality:
  *
- * The caller may select between a bound or connected XS socket by appending
+ * The caller may select between a bound or connected ZMQ socket by appending
  * ",accept" or ",connect" to the endpoint argument. (If not given, this
  * function behaves as if ",connect" was passed.) That is, ",accept" uses
- * xs_bind() to obtain a XS endpoint, and ",connect" uses xs_connect().
+ * zmq_bind() to obtain a ZMQ endpoint, and ",connect" uses zmq_connect().
  *
  * The caller may additionally select between a PUB socket or a PUSH
  * socket by appending ",pubsub" or ",pushpull". (If not given, this function
  * behaves as if ",pubsub" was passed.)
  *
- * \see nmsg_input_open_xs_endpoint()
+ * \see nmsg_input_open_zmq_endpoint()
  *
- * \param[in] xs_ctx XS context object.
+ * \param[in] zmq_ctx ZMQ context object.
  *
- * \param[in] ep XS endpoint (with nmsg-specific extensions)
+ * \param[in] ep ZMQ endpoint (with nmsg-specific extensions)
  *
  * \param[in] bufsz Value between #NMSG_WBUFSZ_MIN and #NMSG_WBUFSZ_MAX.
  *
  * \return Opaque pointer that is NULL on failure or non-NULL on success.
  */
 nmsg_output_t
-nmsg_output_open_xs_endpoint(void *xs_ctx, const char *ep, size_t bufsz);
+nmsg_output_open_zmq_endpoint(void *zmq_ctx, const char *ep, size_t bufsz);
 
 /**
  * Initialize a new presentation format (ASCII lines) nmsg output.

--- a/nmsg/output_frag.c
+++ b/nmsg/output_frag.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2013 by Farsight Security, Inc.
+ * Copyright (c) 2008-2019 by Farsight Security, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,14 +33,14 @@ _output_frag_write(nmsg_output_t output) {
 
 	assert(output->type == nmsg_output_type_stream);
 
-#ifdef HAVE_LIBXS
-	if (output->stream->type == nmsg_stream_type_xs) {
-		/* let XS do fragmentation instead */
+#ifdef HAVE_LIBZMQ
+	if (output->stream->type == nmsg_stream_type_zmq) {
+		/* let ZMQ do fragmentation instead */
 		return (_output_nmsg_write_container(output));
 	}
-#else /* HAVE_LIBXS */
-	assert(output->stream->type != nmsg_stream_type_xs);
-#endif /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
+	assert(output->stream->type != nmsg_stream_type_zmq);
+#endif /* HAVE_LIBZMQ */
 
 	nmsg__nmsg_fragment__init(&nf);
 	max_fragsz = output->stream->bufsz - 32;
@@ -69,7 +69,7 @@ _output_frag_write(nmsg_output_t output) {
 			res = _output_nmsg_write_sock(output, packed, len);
 		} else if (output->stream->type == nmsg_stream_type_file) {
 			res = _output_nmsg_write_file(output, packed, len);
-		} else if (output->stream->type == nmsg_stream_type_xs) {
+		} else if (output->stream->type == nmsg_stream_type_zmq) {
 			assert(0);
 		}
 		goto frag_out;

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -55,9 +55,9 @@
 
 #include <protobuf-c/protobuf-c.h>
 
-#ifdef HAVE_LIBXS
-# include <xs/xs.h>
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+# include <zmq.h>
+#endif /* HAVE_LIBZMQ */
 
 #ifdef HAVE_YAJL
 #include <yajl/yajl_gen.h>
@@ -110,7 +110,7 @@ do { \
 typedef enum {
 	nmsg_stream_type_file,
 	nmsg_stream_type_sock,
-	nmsg_stream_type_xs,
+	nmsg_stream_type_zmq,
 	nmsg_stream_type_null,
 } nmsg_stream_type;
 
@@ -243,9 +243,9 @@ struct nmsg_json {
 struct nmsg_stream_input {
 	nmsg_stream_type	type;
 	struct nmsg_buf		*buf;
-#ifdef HAVE_LIBXS
-	void			*xs;
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+	void			*zmq;
+#endif /* HAVE_LIBZMQ */
 	Nmsg__Nmsg		*nmsg;
 	unsigned		np_index;
 	size_t			nc_size;
@@ -276,9 +276,9 @@ struct nmsg_stream_output {
 	pthread_mutex_t		lock;
 	nmsg_stream_type	type;
 	int			fd;
-#ifdef HAVE_LIBXS
-	void			*xs;
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+	void			*zmq;
+#endif /* HAVE_LIBZMQ */
 	nmsg_container_t	c;
 	size_t			bufsz;
 	nmsg_random_t		random;
@@ -482,9 +482,9 @@ nmsg_res		_input_nmsg_unpack_container(nmsg_input_t, Nmsg__Nmsg **, uint8_t *, s
 nmsg_res		_input_nmsg_unpack_container2(const uint8_t *, size_t, unsigned, Nmsg__Nmsg **);
 nmsg_res		_input_nmsg_read_container_file(nmsg_input_t, Nmsg__Nmsg **);
 nmsg_res		_input_nmsg_read_container_sock(nmsg_input_t, Nmsg__Nmsg **);
-#ifdef HAVE_LIBXS
-nmsg_res		_input_nmsg_read_container_xs(nmsg_input_t, Nmsg__Nmsg **);
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+nmsg_res		_input_nmsg_read_container_zmq(nmsg_input_t, Nmsg__Nmsg **);
+#endif /* HAVE_LIBZMQ */
 nmsg_res		_input_nmsg_deserialize_header(const uint8_t *, size_t, ssize_t *, unsigned *);
 
 /* from input_callback.c */
@@ -521,9 +521,9 @@ nmsg_res		_output_nmsg_write(nmsg_output_t, nmsg_message_t);
 nmsg_res		_output_nmsg_write_container(nmsg_output_t);
 nmsg_res		_output_nmsg_write_sock(nmsg_output_t, uint8_t *buf, size_t len);
 nmsg_res		_output_nmsg_write_file(nmsg_output_t, uint8_t *buf, size_t len);
-#ifdef HAVE_LIBXS
-nmsg_res		_output_nmsg_write_xs(nmsg_output_t, uint8_t *buf, size_t len);
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+nmsg_res		_output_nmsg_write_zmq(nmsg_output_t, uint8_t *buf, size_t len);
+#endif /* HAVE_LIBZMQ */
 
 /* from output_pres.c */
 nmsg_res		_output_pres_write(nmsg_output_t, nmsg_message_t);

--- a/src/io.c
+++ b/src/io.c
@@ -24,9 +24,9 @@
 
 #include <pcap.h>
 
-#ifdef HAVE_LIBXS
-# include <xs/xs.h>
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+# include <zmq.h>
+#endif /* HAVE_LIBZMQ */
 
 #include "kickfile.h"
 #include "nmsgtool.h"
@@ -198,17 +198,17 @@ add_sock_output(nmsgtool_ctx *c, const char *ss) {
 	}
 }
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 void
-add_xsock_input(nmsgtool_ctx *c, const char *str_socket) {
+add_zsock_input(nmsgtool_ctx *c, const char *str_socket) {
 	nmsg_res res;
 	nmsg_input_t input;
 
-	input = nmsg_input_open_xs_endpoint(c->xs_ctx, str_socket);
+	input = nmsg_input_open_zmq_endpoint(c->zmq_ctx, str_socket);
 	if (c->debug >= 2)
-		fprintf(stderr, "%s: nmsg XS input: %s\n", argv_program, str_socket);
+		fprintf(stderr, "%s: nmsg ZMQ input: %s\n", argv_program, str_socket);
 	if (input == NULL) {
-		fprintf(stderr, "%s: nmsg_input_open_xs_endpoint() failed\n", argv_program);
+		fprintf(stderr, "%s: nmsg_input_open_zmq_endpoint() failed\n", argv_program);
 		exit(1);
 	}
 	setup_nmsg_input(c, input);
@@ -219,28 +219,28 @@ add_xsock_input(nmsgtool_ctx *c, const char *str_socket) {
 	}
 	c->n_inputs += 1;
 }
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 void
-add_xsock_input(nmsgtool_ctx *c __attribute__((unused)),
+add_zsock_input(nmsgtool_ctx *c __attribute__((unused)),
 		const char *str_socket __attribute__((unused)))
 {
-	fprintf(stderr, "%s: Error: compiled without libxs support\n",
+	fprintf(stderr, "%s: Error: compiled without libzmq support\n",
 		argv_program);
 	exit(EXIT_FAILURE);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 void
-add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
+add_zsock_output(nmsgtool_ctx *c, const char *str_socket) {
 	nmsg_res res;
 	nmsg_output_t output;
 
-	output = nmsg_output_open_xs_endpoint(c->xs_ctx, str_socket, NMSG_WBUFSZ_JUMBO);
+	output = nmsg_output_open_zmq_endpoint(c->zmq_ctx, str_socket, NMSG_WBUFSZ_JUMBO);
 	if (c->debug >= 2)
-		fprintf(stderr, "%s: nmsg XS output: %s\n", argv_program, str_socket);
+		fprintf(stderr, "%s: nmsg ZMQ output: %s\n", argv_program, str_socket);
 	if (output == NULL) {
-		fprintf(stderr, "%s: nmsg_output_open_xs_endpoint() failed\n", argv_program);
+		fprintf(stderr, "%s: nmsg_output_open_zmq_endpoint() failed\n", argv_program);
 		exit(1);
 	}
 	setup_nmsg_output(c, output);
@@ -256,16 +256,16 @@ add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
 	if (c->stats_user == NULL)
 		c->stats_output = output;
 }
-#else /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
 void
-add_xsock_output(nmsgtool_ctx *c __attribute__((unused)),
+add_zsock_output(nmsgtool_ctx *c __attribute__((unused)),
 		 const char *str_socket __attribute__((unused)))
 {
-	fprintf(stderr, "%s: Error: compiled without libxs support\n",
+	fprintf(stderr, "%s: Error: compiled without libzmq support\n",
 		argv_program);
 	exit(EXIT_FAILURE);
 }
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 
 void
 add_file_input(nmsgtool_ctx *c, const char *fname) {

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -140,15 +140,15 @@ static argv_t args[] = {
 		"so",
 		"read nmsg data from socket (addr/port)" },
 
-	{ 'L', "readxsock",
+	{ 'L', "readzsock",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
-		&ctx.r_xsock,
-		"xep",
-#ifdef HAVE_LIBXS
-		"read nmsg data from XS endpoint" },
-#else /* HAVE_LIBXS */
-		"read nmsg data from XS endpoint (no support)" },
-#endif /* HAVE_LIBXS */
+		&ctx.r_zsock,
+		"zep",
+#ifdef HAVE_LIBZMQ
+		"read nmsg data from ZMQ endpoint" },
+#else /* HAVE_LIBZMQ */
+		"read nmsg data from ZMQ endpoint (no support)" },
+#endif /* HAVE_LIBZMQ */
 
 	{ 'C', "readchan",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
@@ -156,11 +156,11 @@ static argv_t args[] = {
 		"channel",
 		"read nmsg data from socket(s)" },
 
-	{ 'X', "readxchan",
+	{ 'X', "readzchan",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
-		&ctx.r_xchannel,
-		"xchannel",
-		"read nmsg data from XS channels" },
+		&ctx.r_zchannel,
+		"zchannel",
+		"read nmsg data from ZMQ channels" },
 
 	{ 'p',	"readpcap",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
@@ -202,15 +202,15 @@ static argv_t args[] = {
 		"so[,r[,f]]",
 		"write nmsg data to socket (addr/port)" },
 
-	{ 'S', "writexsock",
+	{ 'S', "writezsock",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
-		&ctx.w_xsock,
-		"xep",
-#ifdef HAVE_LIBXS
-		"write nmsg data to XS endpoint" },
-#else /* HAVE_LIBXS */
-		"write nmsg data to XS endpoint (no support)" },
-#endif /* HAVE_LIBXS */
+		&ctx.w_zsock,
+		"zep",
+#ifdef HAVE_LIBZMQ
+		"write nmsg data to ZMQ endpoint" },
+#else /* HAVE_LIBZMQ */
+		"write nmsg data to ZMQ endpoint (no support)" },
+#endif /* HAVE_LIBZMQ */
 
 	{ 'z', "zlibout",
 		ARGV_BOOL,
@@ -322,11 +322,11 @@ int main(int argc, char **argv) {
 		return (EXIT_FAILURE);
 	}
 	if (ctx.debug >= 2)
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 		fprintf(stderr, "nmsgtool: version " VERSION "\n");
-#else /* HAVE_LIBXS */
-		fprintf(stderr, "nmsgtool: version " VERSION " (without libxs support)\n");
-#endif /* HAVE_LIBXS */
+#else /* HAVE_LIBZMQ */
+		fprintf(stderr, "nmsgtool: version " VERSION " (without libzmq support)\n");
+#endif /* HAVE_LIBZMQ */
 
 	/* initialize the nmsg_io engine */
 	ctx.io = nmsg_io_init();
@@ -349,10 +349,10 @@ int main(int argc, char **argv) {
 		}
 	}
 	nmsg_io_destroy(&ctx.io);
-#ifdef HAVE_LIBXS
-	if (ctx.xs_ctx)
-		xs_term(ctx.xs_ctx);
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+	if (ctx.zmq_ctx)
+		zmq_term(ctx.zmq_ctx);
+#endif /* HAVE_LIBZMQ */
 	free(ctx.endline_str);
 	argv_cleanup(args);
 

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -29,9 +29,9 @@
 
 #include <nmsg.h>
 
-#ifdef HAVE_LIBXS
-# include <xs/xs.h>
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+# include <zmq.h>
+#endif /* HAVE_LIBZMQ */
 
 #include "libmy/argv.h"
 
@@ -45,9 +45,9 @@ typedef union nmsgtool_sockaddr nmsgtool_sockaddr;
 typedef struct {
 	/* parameters */
 	argv_array_t	filters;
-	argv_array_t	r_nmsg, r_pres, r_sock, r_xsock, r_channel, r_xchannel, r_json;
+	argv_array_t	r_nmsg, r_pres, r_sock, r_zsock, r_channel, r_zchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
-	argv_array_t	w_nmsg, w_pres, w_sock, w_xsock, w_json;
+	argv_array_t	w_nmsg, w_pres, w_sock, w_zsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
 	char		*endline, *kicker, *mname, *vname, *bpfstr, *filter_policy;
 	int		debug;
@@ -61,9 +61,9 @@ typedef struct {
 	char		*endline_str;
 	int		n_inputs, n_outputs;
 	nmsg_io_t	io;
-#ifdef HAVE_LIBXS
-	void		*xs_ctx;
-#endif /* HAVE_LIBXS */
+#ifdef HAVE_LIBZMQ
+	void		*zmq_ctx;
+#endif /* HAVE_LIBZMQ */
 	unsigned	vid, msgtype;
 	unsigned	set_source, set_operator, set_group;
 	unsigned	get_source, get_operator, get_group;
@@ -124,8 +124,8 @@ void add_json_input(nmsgtool_ctx *, const char *);
 void add_json_output(nmsgtool_ctx *, const char *);
 void add_sock_input(nmsgtool_ctx *, const char *);
 void add_sock_output(nmsgtool_ctx *, const char *);
-void add_xsock_input(nmsgtool_ctx *, const char *);
-void add_xsock_output(nmsgtool_ctx *, const char *);
+void add_zsock_input(nmsgtool_ctx *, const char *);
+void add_zsock_output(nmsgtool_ctx *, const char *);
 void add_filter_module(nmsgtool_ctx *, const char *);
 void pidfile_write(FILE *);
 void process_args(nmsgtool_ctx *);

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -68,12 +68,12 @@ process_args(nmsgtool_ctx *c) {
 		usage(NULL);
 
 	if (c->version) {
-#ifdef HAVE_LIBXS
+#ifdef HAVE_LIBZMQ
 		fprintf(stderr, "%s: version %s\n", argv_program, PACKAGE_VERSION);
-#else /* HAVE_LIBXS */
-		fprintf(stderr, "%s: version %s (without libxs support)\n",
+#else /* HAVE_LIBZMQ */
+		fprintf(stderr, "%s: version %s (without libzmq support)\n",
 			argv_program, PACKAGE_VERSION);
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 		exit(EXIT_SUCCESS);
 	}
 
@@ -245,30 +245,30 @@ process_args(nmsgtool_ctx *c) {
 	/* pcap file inputs */
 	process_args_loop_mod(c->r_pcapfile, add_pcapfile_input, mod);
 
-	/* XS context */
-	if (ARGV_ARRAY_COUNT(c->r_xsock) > 0 ||
-	    ARGV_ARRAY_COUNT(c->w_xsock) > 0 ||
-	    ARGV_ARRAY_COUNT(c->r_xchannel) > 0)
+	/* ZMQ context */
+	if (ARGV_ARRAY_COUNT(c->r_zsock) > 0 ||
+	    ARGV_ARRAY_COUNT(c->w_zsock) > 0 ||
+	    ARGV_ARRAY_COUNT(c->r_zchannel) > 0)
 	{
-#ifdef HAVE_LIBXS
-		c->xs_ctx = xs_init();
-		if (c->xs_ctx == NULL) {
-			fprintf(stderr, "%s: xs_init() failed: %s\n",
+#ifdef HAVE_LIBZMQ
+		c->zmq_ctx = zmq_ctx_new();
+		if (c->zmq_ctx == NULL) {
+			fprintf(stderr, "%s: zmq_ctx_new() failed: %s\n",
 				argv_program, strerror(errno));
 			exit(EXIT_FAILURE);
 		}
-#else /* HAVE_LIBXS */
-		fprintf(stderr, "%s: Error: compiled without libxs support\n",
+#else /* HAVE_LIBZMQ */
+		fprintf(stderr, "%s: Error: compiled without libzmq support\n",
 			argv_program);
 		exit(EXIT_FAILURE);
-#endif /* HAVE_LIBXS */
+#endif /* HAVE_LIBZMQ */
 	}
 
 	/* nmsg inputs and outputs */
 	process_args_loop(c->r_sock, add_sock_input);
 	process_args_loop(c->w_sock, add_sock_output);
-	process_args_loop(c->r_xsock, add_xsock_input);
-	process_args_loop(c->w_xsock, add_xsock_output);
+	process_args_loop(c->r_zsock, add_zsock_input);
+	process_args_loop(c->w_zsock, add_zsock_output);
 	process_args_loop(c->r_nmsg, add_file_input);
 	process_args_loop(c->w_nmsg, add_file_output);
 
@@ -291,19 +291,19 @@ process_args(nmsgtool_ctx *c) {
 		nmsg_chalias_free(&alias);
 	}
 
-	for (int i = 0; i < ARGV_ARRAY_COUNT(c->r_xchannel); i++) {
+	for (int i = 0; i < ARGV_ARRAY_COUNT(c->r_zchannel); i++) {
 		char *ch;
 		char **alias = NULL;
 		int num_aliases;
 
-		ch = *ARGV_ARRAY_ENTRY_P(c->r_xchannel, char *, i);
+		ch = *ARGV_ARRAY_ENTRY_P(c->r_zchannel, char *, i);
 		if (c->debug >= 2)
-			fprintf(stderr, "%s: looking up xchannel '%s'\n", argv_program, ch);
+			fprintf(stderr, "%s: looking up zchannel '%s'\n", argv_program, ch);
 		num_aliases = nmsg_chalias_lookup(ch, &alias);
 		if (num_aliases <= 0)
-			usage("xchannel alias lookup failed");
+			usage("zchannel alias lookup failed");
 		for (int j = 0; j < num_aliases; j++)
-			add_xsock_input(c, alias[j]);
+			add_zsock_input(c, alias[j]);
 		nmsg_chalias_free(&alias);
 	}
 


### PR DESCRIPTION
This port removes the old libxs API (*_xs(...)) in favor of a new but commensurate (*_zmq(...)) zeromq API. It should be a drop-in replacement for nmsgtool as it uses the same libxs command line options to invoke zeromq behaviors (-L/-S/-X).