### PR TITLE
Periodicstats

### DIFF
--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -147,7 +147,7 @@ nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
 		if (io_input->input != NULL &&
 			(nmsg_input_get_count_container_received(io_input->input, &recvs) == nmsg_res_failure ||
 			nmsg_input_get_count_container_dropped(io_input->input, &drops) == nmsg_res_failure))
-			return nmsg_res_failure;
+			continue;
 
 		*sum_in += io_input->count_nmsg_payload_in;
 		*container_drops += drops;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -128,11 +128,12 @@ nmsg_io_init(void) {
 
 nmsg_res
 nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
-		uint64_t *container_drops) {
+		uint64_t *container_recvs, uint64_t *container_drops) {
 	struct nmsg_io_input *io_input;
 	struct nmsg_io_output *io_output;
 
-	if (io == NULL || sum_in == NULL || sum_out == NULL || container_drops == NULL)
+	if (io == NULL || sum_in == NULL || sum_out == NULL ||
+		container_recvs == NULL || container_drops == NULL)
 		return nmsg_res_failure;
 
 	*sum_in = 0;
@@ -141,14 +142,16 @@ nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
 		 io_input != NULL;
 		 io_input = ISC_LIST_NEXT(io_input, link))
 	{
-		uint64_t drops = 0;
+		uint64_t drops = 0, recvs = 0;
 
 		if (io_input->input != NULL &&
-			nmsg_input_get_count_container_dropped(io_input->input, &drops) == nmsg_res_failure)
+			(nmsg_input_get_count_container_received(io_input->input, &recvs) == nmsg_res_failure ||
+			nmsg_input_get_count_container_dropped(io_input->input, &drops) == nmsg_res_failure))
 			return nmsg_res_failure;
 
 		*sum_in += io_input->count_nmsg_payload_in;
 		*container_drops += drops;
+		*container_recvs += recvs;
 	}
 
 	*sum_out = 0;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -126,30 +126,41 @@ nmsg_io_init(void) {
 	return (io);
 }
 
-void
-nmsg_io_emit_stats(struct nmsg_io_close_event *ce) {
-	uint64_t sum_out = 0, sum_in = 0;
+nmsg_res
+nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
+		uint64_t *container_drops) {
+	struct nmsg_io_input *io_input;
+	struct nmsg_io_output *io_output;
 
-	if (ce == NULL)
-		return;
+	if (io == NULL || sum_in == NULL || sum_out == NULL || container_drops == NULL)
+		return nmsg_res_failure;
 
-	struct nmsg_io_input *io_input = ISC_LIST_HEAD(ce->io->io_inputs);
-	while (io_input != NULL)
+	*sum_in = 0;
+
+	for (io_input = ISC_LIST_HEAD(io->io_inputs);
+		 io_input != NULL;
+		 io_input = ISC_LIST_NEXT(io_input, link))
 	{
-		sum_in += io_input->count_nmsg_payload_in;
-		io_input = ISC_LIST_NEXT(io_input, link);
+		uint64_t drops = 0;
+
+		if (io_input->input != NULL &&
+			nmsg_input_get_count_container_dropped(io_input->input, &drops) == nmsg_res_failure)
+			return nmsg_res_failure;
+
+		*sum_in += io_input->count_nmsg_payload_in;
+		*container_drops += drops;
 	}
 
-	struct nmsg_io_output *io_output = ISC_LIST_HEAD(ce->io->io_outputs);
-	while (io_output != NULL)
+	*sum_out = 0;
+
+	for (io_output = ISC_LIST_HEAD(io->io_outputs);
+		 io_output != NULL;
+		 io_output = ISC_LIST_NEXT(io_output, link))
 	{
-		sum_out += io_output->count_nmsg_payload_out;
-		io_output = ISC_LIST_NEXT(io_output, link);
+		*sum_out += io_output->count_nmsg_payload_out;
 	}
 
-	fprintf(stderr, "count_nmsg_payload_out %lu count_nmsg_payload_in %lu\n",
-		sum_out,
-		sum_in);
+	return nmsg_res_success;
 }
 
 void

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -127,6 +127,32 @@ nmsg_io_init(void) {
 }
 
 void
+nmsg_io_emit_stats(struct nmsg_io_close_event *ce) {
+	uint64_t sum_out = 0, sum_in = 0;
+
+	if (ce == NULL)
+		return;
+
+	struct nmsg_io_input *io_input = ISC_LIST_HEAD(ce->io->io_inputs);
+	while (io_input != NULL)
+	{
+		sum_in += io_input->count_nmsg_payload_in;
+		io_input = ISC_LIST_NEXT(io_input, link);
+	}
+
+	struct nmsg_io_output *io_output = ISC_LIST_HEAD(ce->io->io_outputs);
+	while (io_output != NULL)
+	{
+		sum_out += io_output->count_nmsg_payload_out;
+		io_output = ISC_LIST_NEXT(io_output, link);
+	}
+
+	fprintf(stderr, "count_nmsg_payload_out %lu count_nmsg_payload_in %lu\n",
+		sum_out,
+		sum_in);
+}
+
+void
 nmsg_io_breakloop(nmsg_io_t io) {
 	struct nmsg_io_output *io_output;
 

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -514,11 +514,13 @@ nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
  *
  * \param[in] io Valid uint64_t object.
  *
+ * \param[in] io Valid uint64_t object.
+ *
  * \return #nmsg_res_success
  * \return #nmsg_res_failure
  */
 nmsg_res
-nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out, uint64_t *container_drops);
+nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out, uint64_t *container_recvs, uint64_t *container_drops);
 
 
 #endif /* NMSG_IO_H */

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -512,6 +512,8 @@ nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
  *
  * \param[in] io Valid uint64_t object.
  *
+ * \param[in] io Valid uint64_t object.
+ *
  * \return #nmsg_res_success
  * \return #nmsg_res_failure
  */

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -506,9 +506,17 @@ nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
  * metrics during the life time of the nmsgtool process (e.g. at
  * file rotation time)
  *
- * \param[in] io Valid nmsg_io_close_event object.
+ * \param[in] io Valid nmsg_io_t object.
+ *
+ * \param[in] io Valid uint64_t object.
+ *
+ * \param[in] io Valid uint64_t object.
+ *
+ * \return #nmsg_res_success
+ * \return #nmsg_res_failure
  */
-void
-nmsg_io_emit_stats(struct nmsg_io_close_event *ce);
+nmsg_res
+nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out, uint64_t *container_drops);
+
 
 #endif /* NMSG_IO_H */

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -500,7 +500,7 @@ void
 nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
 
 /**
- * Emit counters related to payloads_in and payloads_out
+ * Get counters related to payloads_in and payloads_out
  * These are normally emitted at process exit, but when using the
  * kicker option, it is useful to obtain these health related
  * metrics during the life time of the nmsgtool process (e.g. at
@@ -508,13 +508,13 @@ nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
  *
  * \param[in] io Valid nmsg_io_t object.
  *
- * \param[in] io Valid uint64_t object.
+ * \param[out] sum_in Number of input payloads.
  *
- * \param[in] io Valid uint64_t object.
+ * \param[out] sum_out Number of output payloads.
  *
- * \param[in] io Valid uint64_t object.
+ * \param[out] container_recvs Number of containers received.
  *
- * \param[in] io Valid uint64_t object.
+ * \param[out] container_drops Number of container drops detected.
  *
  * \return #nmsg_res_success
  * \return #nmsg_res_failure

--- a/nmsg/io.h
+++ b/nmsg/io.h
@@ -499,4 +499,16 @@ nmsg_io_set_interval_randomized(nmsg_io_t io, bool randomized);
 void
 nmsg_io_set_output_mode(nmsg_io_t io, nmsg_io_output_mode output_mode);
 
+/**
+ * Emit counters related to payloads_in and payloads_out
+ * These are normally emitted at process exit, but when using the
+ * kicker option, it is useful to obtain these health related
+ * metrics during the life time of the nmsgtool process (e.g. at
+ * file rotation time)
+ *
+ * \param[in] io Valid nmsg_io_close_event object.
+ */
+void
+nmsg_io_emit_stats(struct nmsg_io_close_event *ce);
+
 #endif /* NMSG_IO_H */

--- a/src/io.c
+++ b/src/io.c
@@ -34,8 +34,6 @@
 #include "libmy/my_alloc.h"
 
 static const int on = 1;
-extern nmsg_output_t stats_output;
-extern void *stats_user;
 
 void
 add_sock_input(nmsgtool_ctx *c, const char *ss) {
@@ -195,7 +193,7 @@ add_sock_output(nmsgtool_ctx *c, const char *ss) {
 			exit(1);
 		}
 		c->n_outputs += 1;
-		stats_output = output;
+		c->stats_output = output;
 	}
 }
 
@@ -254,7 +252,7 @@ add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
 		exit(1);
 	}
 	c->n_outputs += 1;
-	stats_output = output;
+	c->stats_output = output;
 }
 #else /* HAVE_LIBXS */
 void
@@ -322,7 +320,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		stats_user = kf;
+		c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_file(open_wfile(fname),
 					       NMSG_WBUFSZ_MAX);
@@ -333,7 +331,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		stats_output = output;
+		c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -540,12 +538,12 @@ add_pres_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_pres(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		stats_user = kf;
+		c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_pres(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		stats_output = output;
+		c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -603,12 +601,12 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_json(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		stats_user = kf;
+		c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_json(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		stats_output = output;
+		c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",

--- a/src/io.c
+++ b/src/io.c
@@ -34,8 +34,8 @@
 #include "libmy/my_alloc.h"
 
 static const int on = 1;
-extern nmsg_output_t designated_output;
-extern void *designated_user;
+extern nmsg_output_t stats_output;
+extern void *stats_user;
 
 void
 add_sock_input(nmsgtool_ctx *c, const char *ss) {
@@ -195,7 +195,7 @@ add_sock_output(nmsgtool_ctx *c, const char *ss) {
 			exit(1);
 		}
 		c->n_outputs += 1;
-		designated_output = output;
+		stats_output = output;
 	}
 }
 
@@ -254,7 +254,7 @@ add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
 		exit(1);
 	}
 	c->n_outputs += 1;
-	designated_output = output;
+	stats_output = output;
 }
 #else /* HAVE_LIBXS */
 void
@@ -322,7 +322,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		designated_user = kf;
+		stats_user = kf;
 	} else {
 		output = nmsg_output_open_file(open_wfile(fname),
 					       NMSG_WBUFSZ_MAX);
@@ -333,7 +333,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		designated_output = output;
+		stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -540,12 +540,12 @@ add_pres_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_pres(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		designated_user = kf;
+		stats_user = kf;
 	} else {
 		output = nmsg_output_open_pres(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		designated_output = output;
+		stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -603,12 +603,12 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_json(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		designated_user = kf;
+		stats_user = kf;
 	} else {
 		output = nmsg_output_open_json(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		designated_output = output;
+		stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",

--- a/src/io.c
+++ b/src/io.c
@@ -193,7 +193,8 @@ add_sock_output(nmsgtool_ctx *c, const char *ss) {
 			exit(1);
 		}
 		c->n_outputs += 1;
-		c->stats_output = output;
+		if (c->stats_user == NULL)
+			c->stats_output = output;
 	}
 }
 
@@ -252,7 +253,8 @@ add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
 		exit(1);
 	}
 	c->n_outputs += 1;
-	c->stats_output = output;
+	if (c->stats_user == NULL)
+		c->stats_output = output;
 }
 #else /* HAVE_LIBXS */
 void
@@ -320,7 +322,8 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		c->stats_user = kf;
+		if (c->stats_output == NULL)
+			c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_file(open_wfile(fname),
 					       NMSG_WBUFSZ_MAX);
@@ -331,7 +334,8 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		c->stats_output = output;
+		if (c->stats_user == NULL)
+			c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -538,12 +542,14 @@ add_pres_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_pres(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		c->stats_user = kf;
+		if (c->stats_output == NULL)
+			c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_pres(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		c->stats_output = output;
+		if (c->stats_user == NULL)
+			c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -601,12 +607,14 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_json(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
-		c->stats_user = kf;
+		if (c->stats_output == NULL)
+			c->stats_user = kf;
 	} else {
 		output = nmsg_output_open_json(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
-		c->stats_output = output;
+		if (c->stats_user == NULL)
+			c->stats_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",

--- a/src/io.c
+++ b/src/io.c
@@ -34,6 +34,8 @@
 #include "libmy/my_alloc.h"
 
 static const int on = 1;
+extern nmsg_output_t designated_output;
+extern void *designated_user;
 
 void
 add_sock_input(nmsgtool_ctx *c, const char *ss) {
@@ -193,6 +195,7 @@ add_sock_output(nmsgtool_ctx *c, const char *ss) {
 			exit(1);
 		}
 		c->n_outputs += 1;
+		designated_output = output;
 	}
 }
 
@@ -251,6 +254,7 @@ add_xsock_output(nmsgtool_ctx *c, const char *str_socket) {
 		exit(1);
 	}
 	c->n_outputs += 1;
+	designated_output = output;
 }
 #else /* HAVE_LIBXS */
 void
@@ -318,6 +322,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
+		designated_user = kf;
 	} else {
 		output = nmsg_output_open_file(open_wfile(fname),
 					       NMSG_WBUFSZ_MAX);
@@ -328,6 +333,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		}
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
+		designated_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -534,10 +540,12 @@ add_pres_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_pres(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
+		designated_user = kf;
 	} else {
 		output = nmsg_output_open_pres(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
+		designated_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",
@@ -595,10 +603,12 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 		output = nmsg_output_open_json(open_wfile(kf->tmpname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, (void *) kf);
+		designated_user = kf;
 	} else {
 		output = nmsg_output_open_json(open_wfile(fname));
 		setup_nmsg_output(c, output);
 		res = nmsg_io_add_output(c->io, output, NULL);
+		designated_output = output;
 	}
 	if (res != nmsg_res_success) {
 		fprintf(stderr, "%s: nmsg_io_add_output() failed\n",

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -445,10 +445,13 @@ io_close(struct nmsg_io_close_event *ce) {
 				assert(0);
 			}
 			setup_nmsg_output(&ctx, *(ce->output));
-			if (ctx.debug >= 2)
+
+			if (ctx.debug >= 2) {
+				nmsg_io_emit_stats(ce);
 				fprintf(stderr,
 					"%s: reopened %s file output: %s\n",
 					argv_program, output_type_descr, kf->curname);
+			}
 		}
 	} else if (ce->io_type == nmsg_io_io_type_input) {
 		if ((ce->user == NULL || ce->close_type == nmsg_io_close_type_eof) &&

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -32,8 +32,6 @@
 /* Globals. */
 
 static nmsgtool_ctx ctx;
-nmsg_output_t stats_output = NULL;
-void *stats_user = NULL;
 
 static argv_t args[] = {
 	{ 'h',	"help",
@@ -395,8 +393,8 @@ io_close(struct nmsg_io_close_event *ce) {
 	struct kickfile *kf;
 
 	if (ctx.debug >= 2) {
-		if ((stats_output != NULL && *(ce->output) == stats_output) ||
-			(stats_user != NULL && ce->user == stats_user)) {
+		if ((ctx.stats_output != NULL && *(ce->output) == ctx.stats_output) ||
+			(ctx.stats_user != NULL && ce->user == ctx.stats_user)) {
 			uint64_t sum_in = 0, sum_out = 0, container_drops = 0, container_recvs = 0;
 			if (nmsg_io_get_stats(ce->io, &sum_in, &sum_out, &container_recvs, &container_drops) == nmsg_res_success)
 				fprintf(stderr,

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -397,10 +397,11 @@ io_close(struct nmsg_io_close_event *ce) {
 	if (ctx.debug >= 2) {
 		if ((designated_output != NULL && *(ce->output) == designated_output) ||
 			(designated_user != NULL && ce->user == designated_user)) {
-			uint64_t sum_in = 0, sum_out = 0, container_drops = 0;
-			if (nmsg_io_get_stats(ce->io, &sum_in, &sum_out, &container_drops) == nmsg_res_success)
-				fprintf(stderr, "%s: totals: payloads_in %lu payloads_out %lu container_drops %lu\n",
-						argv_program, sum_in, sum_out, container_drops);
+			uint64_t sum_in = 0, sum_out = 0, container_drops = 0, container_recvs = 0;
+			if (nmsg_io_get_stats(ce->io, &sum_in, &sum_out, &container_recvs, &container_drops) == nmsg_res_success)
+				fprintf(stderr,
+					"%s: totals: payloads_in %lu payloads_out %lu container_recvs %lu container_drops %lu\n",
+					argv_program, sum_in, sum_out, container_recvs, container_drops);
 		}
 	}
 

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -32,8 +32,8 @@
 /* Globals. */
 
 static nmsgtool_ctx ctx;
-nmsg_output_t designated_output = NULL;
-void *designated_user = NULL;
+nmsg_output_t stats_output = NULL;
+void *stats_user = NULL;
 
 static argv_t args[] = {
 	{ 'h',	"help",
@@ -395,8 +395,8 @@ io_close(struct nmsg_io_close_event *ce) {
 	struct kickfile *kf;
 
 	if (ctx.debug >= 2) {
-		if ((designated_output != NULL && *(ce->output) == designated_output) ||
-			(designated_user != NULL && ce->user == designated_user)) {
+		if ((stats_output != NULL && *(ce->output) == stats_output) ||
+			(stats_user != NULL && ce->user == stats_user)) {
 			uint64_t sum_in = 0, sum_out = 0, container_drops = 0, container_recvs = 0;
 			if (nmsg_io_get_stats(ce->io, &sum_in, &sum_out, &container_recvs, &container_drops) == nmsg_res_success)
 				fprintf(stderr,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -68,6 +68,20 @@ typedef struct {
 	unsigned	set_source, set_operator, set_group;
 	unsigned	get_source, get_operator, get_group;
 
+	/*
+	 * Selected output for which we will report statistics on close events.
+	 *
+	 * If nmsgtool has multiple outputs, we will generate a close event for
+	 * each output. To avoid duplicate statistics reports, we choose one
+	 * output for reporting purposes and store this in stats_output.
+	 *
+	 * With kicker scripts, file outputs are reopened on close events, so
+	 * we can't use the output value to identify the file output. However,
+	 * each kicker-managed file has a unique kickfile structure, a pointe
+	 * to which is passed as the user pointer to the close event callback.
+	 * We store this in stats_user to identify the chosen file output for
+	 * stats reporting.
+	 */
 	nmsg_output_t	stats_output;
 	void		*stats_user;
 } nmsgtool_ctx;

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -67,6 +67,9 @@ typedef struct {
 	unsigned	vid, msgtype;
 	unsigned	set_source, set_operator, set_group;
 	unsigned	get_source, get_operator, get_group;
+
+	nmsg_output_t	stats_output;
+	void		*stats_user;
 } nmsgtool_ctx;
 
 /* Macros. */


### PR DESCRIPTION
emit total (sum of all threads) payload_in,  _out, and dropped container stats upon io_close (in particular, but not exclusively, when files rotate via the kicker option). only is emitted when debug>=2