### PR TITLE
ensure json output files have proper suffix when kicking

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,10 @@
 nmsg (0.13.3)
 
-  * periodicstats
-  * ensure json output files have proper suffix when kicking
+  * Add periodic stats output to nmsgtool.
 
- -- Farsight Security, Inc. <software@fsi.io>  Thu, 16 May 2019 13:04:43 -0600
+  * Add .json suffix to json files output by nmsgtool.
+
+ -- Farsight Security, Inc. <software@fsi.io>  Mon, 22 Jul 2019 16:45:15 -0500
 
 nmsg (0.13.2)
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+nmsg (0.13.3)
+
+  * periodicstats
+  * ensure json output files have proper suffix when kicking
+
+ -- Farsight Security, Inc. <software@fsi.io>  Thu, 16 May 2019 13:04:43 -0600
+
 nmsg (0.13.2)
 
   * Restore terminating NUL character in string fields loaded from JSON.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+nmsg (0.13.3-1) debian-farsightsec; urgency=medium
+
+  * periodstats
+
+ -- Farsight Security, Inc. <software@fsi.io>  Thu, 16 May 2019 17:44:50 +0000
+
 nmsg (0.13.2-1) debian-farsightsec; urgency=medium
 
   * Restore terminating NUL character in string fields loaded from JSON.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 nmsg (0.13.3-1) debian-farsightsec; urgency=medium
 
-  * periodstats
+  * Add periodic stats output to nmsgtool.
+  * Add .json suffix to json output files of nmsgtool.
 
- -- Farsight Security, Inc. <software@fsi.io>  Thu, 16 May 2019 17:44:50 +0000
+ -- Farsight Security, Inc. <software@fsi.io>  Mon, 22 Jul 2019 16:45:15 -0500
 
 nmsg (0.13.2-1) debian-farsightsec; urgency=medium
 

--- a/src/io.c
+++ b/src/io.c
@@ -602,6 +602,7 @@ add_json_output(nmsgtool_ctx *c, const char *fname) {
 
 		kf->cmd = c->kicker;
 		kf->basename = strdup(fname);
+		kf->suffix = strdup(".json");
 		kickfile_rotate(kf);
 
 		output = nmsg_output_open_json(open_wfile(kf->tmpname));


### PR DESCRIPTION
This addresses an inconsistency in nmsgtool in that if you select nmsg output format with the kick option, the output file will be named with a suffix of .nmsg

https://github.com/farsightsec/nmsg/blob/next/src/io.c#L311


However, if you select json or pres output with the kick option, no suffix is added. 

https://github.com/farsightsec/nmsg/blob/next/src/io.c#L538
https://github.com/farsightsec/nmsg/blob/next/src/io.c#L603
