### PR TITLE
Add libmy coverage, following fstrm example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.gcda
+*.gcno
 *.la
 *.lo
 *.loT

--- a/Makefile.am
+++ b/Makefile.am
@@ -20,6 +20,24 @@ AM_CFLAGS = \
 	$(yajl_CFLAGS)
 AM_LDFLAGS =
 
+#
+##
+### Code coverage
+##
+#
+
+AM_CFLAGS += ${CODE_COVERAGE_CFLAGS}
+AM_LDFLAGS += ${CODE_COVERAGE_LDFLAGS}
+CODE_COVERAGE_LCOV_OPTIONS = --no-external
+CODE_COVERAGE_IGNORE_PATTERN = "$(abs_top_builddir)/tests/*"
+@CODE_COVERAGE_RULES@
+
+#
+##
+### Extra
+##
+#
+
 EXTRA_DIST += ChangeLog
 EXTRA_DIST += COPYRIGHT
 EXTRA_DIST += README.md

--- a/configure.ac
+++ b/configure.ac
@@ -192,6 +192,13 @@ AC_ARG_WITH(
     ]
 )
 
+###
+### Code coverage.
+###
+
+m4_include([libmy/m4/my_code_coverage.m4])
+MY_CODE_COVERAGE
+
 AC_OUTPUT
 AC_MSG_RESULT([
     $PACKAGE $VERSION
@@ -215,4 +222,5 @@ AC_MSG_RESULT([
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}
+        code coverage enabled:  ${CODE_COVERAGE_ENABLED}
 ])

--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Build-Depends:
  docbook5-xml,
  doxygen,
  dpkg-dev (>= 1.16.1~),
+ lcov,
  libpcap0.8-dev,
  libprotobuf-c-dev (>= 1.0.1~),
  libwdns-dev (>= 0.8.0~),


### PR DESCRIPTION
This uses the libmy code coverage macro, following the example in fstrm.  To enable, use `--enable-code-coverage` during configure, then `make check-code-coverage`.  Note that we newly require the installation of lcov .