### PR TITLE
Fix protos

### DIFF
--- a/nmsg/base/dns.proto
+++ b/nmsg/base/dns.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 message Dns {

--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -345,7 +345,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 	if (dnsqr->has_resolver_address_zeroed &&
 	    dnsqr->resolver_address_zeroed)
 	{
-		return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+		return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 	}
 
 	/* locate the initial fragment and create the pseudo header */
@@ -358,7 +358,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 
 		res = nmsg_ipdg_parse_pcap_raw(&dg, DLT_RAW, (uint8_t *) ip, ip_len);
 		if (res != nmsg_res_success)
-			return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+			return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 
 		if (dg.proto_network == PF_INET && dg.proto_transport == IPPROTO_UDP) {
 			data = (uint8_t *) dg.payload;
@@ -367,7 +367,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 			if (dg.transport != NULL) {
 				/* this is the initial fragment */
 				if (dg.len_transport < sizeof(struct nmsg_udphdr))
-					return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+					return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 
 				p = (uint8_t *) &ph;
 				pseudo_len = sizeof(ph);
@@ -375,7 +375,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 				udp = (struct nmsg_udphdr *) (dg.transport);
 
 				if (udp->uh_sum == 0)
-					return (NMSG__BASE__UDP_CHECKSUM__ABSENT);
+					return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ABSENT);
 
 				/* create the IPv4 UDP pseudo header */
 				memcpy(&ph.src[0],	&ip->ip_src,	4);
@@ -394,7 +394,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 			if (dg.transport != NULL) {
 				/* this is the initial fragment */
 				if (dg.len_transport < sizeof(struct nmsg_udphdr))
-					return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+					return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 
 				p = (uint8_t *) &ph6;
 				pseudo_len = sizeof(ph6);
@@ -403,7 +403,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 				memset(&ph6, 0, sizeof(ph6));
 
 				if (udp->uh_sum == 0)
-					return (NMSG__BASE__UDP_CHECKSUM__ABSENT);
+					return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ABSENT);
 
 				/* create the IPv6 UDP pseudo header */
 				memcpy(&ph6.src[0],	&ip6->ip6_src,	16);
@@ -418,11 +418,11 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 				ph6.next = IPPROTO_UDP;
 			}
 		} else {
-			return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+			return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 		}
 
 		if (data_len < 0)
-			return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+			return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 
 		/* sum the payload, less the last octet if an odd number of octets */
 		for (int i = 0; i < data_len - 1; i += 2) {
@@ -440,7 +440,7 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 	/* if p was not set, the initial fragment was not found
 	 * (and thus the pseudo header could not be created) */
 	if (p == NULL)
-		return (NMSG__BASE__UDP_CHECKSUM__ERROR);
+		return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR);
 
 	/* sum the pseudo header */
 	for (int i = 0; i < (ssize_t) pseudo_len; i += 2) {
@@ -455,8 +455,8 @@ dnsqr_checksum_verify(Nmsg__Base__DnsQR *dnsqr) {
 
 	/* check if checksum is correct */
 	if (sum == 0)
-		return (NMSG__BASE__UDP_CHECKSUM__CORRECT);
-	return (NMSG__BASE__UDP_CHECKSUM__INCORRECT);
+		return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__CORRECT);
+	return (NMSG__BASE__DNS_QR__UDP_CHECKSUM__INCORRECT);
 }
 
 static void
@@ -1209,7 +1209,7 @@ dnsqr_get_delay(nmsg_message_t msg,
 	struct timespec ts_delay;
 
 	if (dnsqr == NULL || val_idx != 0 ||
-	    dnsqr->type != NMSG__BASE__DNS_QRTYPE__UDP_QUERY_RESPONSE)
+	    dnsqr->type != NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_RESPONSE)
 		return (nmsg_res_failure);
 
 	if ((dnsqr->n_query_time_sec != dnsqr->n_query_time_nsec) ||
@@ -1816,7 +1816,7 @@ do_packet_tcp(Nmsg__Base__DnsQR *dnsqr, struct nmsg_ipdg *dg, uint16_t *flags) {
 	dnsqr->tcp.len = dg->len_network;
 	dnsqr->has_tcp = true;
 
-	dnsqr->type = NMSG__BASE__DNS_QRTYPE__TCP;
+	dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__TCP;
 
 	return (nmsg_res_success);
 }
@@ -1860,7 +1860,7 @@ do_packet_icmp(Nmsg__Base__DnsQR *dnsqr, struct nmsg_ipdg *dg, uint16_t *flags) 
 	dnsqr->icmp.len = dg->len_network;
 	dnsqr->has_icmp = true;
 
-	dnsqr->type = NMSG__BASE__DNS_QRTYPE__ICMP;
+	dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__ICMP;
 
 	return (nmsg_res_success);
 }
@@ -2289,7 +2289,7 @@ do_packet(dnsqr_ctx_t *ctx, nmsg_pcap_t pcap, nmsg_message_t *m,
 
 		if (ctx->capture_qr == 0 && DNS_FLAG_QR(flags) == false) {
 			/* udp query */
-			dnsqr->type = NMSG__BASE__DNS_QRTYPE__UDP_QUERY_ONLY;
+			dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_ONLY;
 
 			res = dnsqr_append_query_packet(dnsqr, dg.network, dg.len_network, ts);
 			if (res != nmsg_res_success)
@@ -2299,7 +2299,7 @@ do_packet(dnsqr_ctx_t *ctx, nmsg_pcap_t pcap, nmsg_message_t *m,
 			res = nmsg_res_success;
 		} else if (ctx->capture_qr == 1 && DNS_FLAG_QR(flags) == true) {
 			/* udp response */
-			dnsqr->type = NMSG__BASE__DNS_QRTYPE__UDP_RESPONSE_ONLY;
+			dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_RESPONSE_ONLY;
 			dnsqr->rcode = DNS_FLAG_RCODE(flags);
 			dnsqr->has_rcode = true;
 
@@ -2322,7 +2322,7 @@ do_packet(dnsqr_ctx_t *ctx, nmsg_pcap_t pcap, nmsg_message_t *m,
 		}
 	} else if (dg.proto_transport == IPPROTO_UDP && DNS_FLAG_QR(flags) == false) {
 		/* message is a query */
-		dnsqr->type = NMSG__BASE__DNS_QRTYPE__UDP_UNANSWERED_QUERY;
+		dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNANSWERED_QUERY;
 		if (is_frag)
 			res = dnsqr_append_frag(dnsqr_append_query_packet, dnsqr, reasm_entry);
 		else
@@ -2350,7 +2350,7 @@ do_packet(dnsqr_ctx_t *ctx, nmsg_pcap_t pcap, nmsg_message_t *m,
 		if (query == NULL) {
 			/* no corresponding query, this is an unsolicited response */
 
-			dnsqr->type = NMSG__BASE__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE;
+			dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE;
 
 			if (do_filter_rd(ctx, flags) || do_filter_query_name(ctx, dnsqr)) {
 				res = nmsg_res_again;
@@ -2367,7 +2367,7 @@ do_packet(dnsqr_ctx_t *ctx, nmsg_pcap_t pcap, nmsg_message_t *m,
 		} else {
 			/* corresponding query, merge query and response */
 
-			dnsqr->type = NMSG__BASE__DNS_QRTYPE__UDP_QUERY_RESPONSE;
+			dnsqr->type = NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_RESPONSE;
 			dnsqr_merge(query, dnsqr);
 
 			if (do_filter(ctx, dnsqr)) {

--- a/nmsg/base/dnsqr.proto
+++ b/nmsg/base/dnsqr.proto
@@ -1,25 +1,25 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum DnsQRType {
-    UDP_INVALID = 0;
-    UDP_QUERY_RESPONSE = 1;
-    UDP_UNANSWERED_QUERY = 2;
-    UDP_UNSOLICITED_RESPONSE = 3;
-    TCP = 4;
-    ICMP = 5;
-    UDP_QUERY_ONLY = 6;
-    UDP_RESPONSE_ONLY = 7;
-}
-
-enum UdpChecksum {
-    ERROR = 0;
-    ABSENT = 1;
-    INCORRECT = 2;
-    CORRECT = 3;
-}
-
 message DnsQR {
+    enum DnsQRType {
+        UDP_INVALID = 0;
+        UDP_QUERY_RESPONSE = 1;
+        UDP_UNANSWERED_QUERY = 2;
+        UDP_UNSOLICITED_RESPONSE = 3;
+        TCP = 4;
+        ICMP = 5;
+        UDP_QUERY_ONLY = 6;
+        UDP_RESPONSE_ONLY = 7;
+    }
+
+    enum UdpChecksum {
+        ERROR = 0;
+        ABSENT = 1;
+        INCORRECT = 2;
+        CORRECT = 3;
+    }
+
     required DnsQRType          type = 1;
 
     // the 9-tuple

--- a/nmsg/base/dnsqr.proto
+++ b/nmsg/base/dnsqr.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum DnsQRType {

--- a/nmsg/base/dnstap.proto
+++ b/nmsg/base/dnstap.proto
@@ -14,6 +14,7 @@
 //
 // <http://creativecommons.org/publicdomain/zero/1.0/>.
 
+syntax = "proto2";
 package dnstap;
 
 // "Dnstap": this is the top-level dnstap type, which is a "union" type that
@@ -105,7 +106,7 @@ message Message {
 
     enum Type {
         // AUTH_QUERY is a DNS query message received from a resolver by an
-        // authoritative name server, from the perspective of the authorative
+        // authoritative name server, from the perspective of the authoritative
         // name server.
         AUTH_QUERY = 1;
 

--- a/nmsg/base/email.proto
+++ b/nmsg/base/email.proto
@@ -1,15 +1,15 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum EmailType {
-    unknown = 0;
-    spamtrap = 1;
-    rej_network = 2;
-    rej_content = 3;
-    rej_user = 4;
-}
-
 message Email {
+    enum EmailType {
+        unknown = 0;
+        spamtrap = 1;
+        rej_network = 2;
+        rej_content = 3;
+        rej_user = 4;
+    }
+
     optional EmailType  type = 8;
     optional bytes      headers = 2;
     optional bytes      srcip = 3;

--- a/nmsg/base/email.proto
+++ b/nmsg/base/email.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum EmailType {

--- a/nmsg/base/encode.proto
+++ b/nmsg/base/encode.proto
@@ -1,15 +1,15 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum EncodeType {
-    TEXT = 0;
-    JSON = 1;
-    YAML = 2;
-    MSGPACK = 3;
-    XML = 4;
-}
 
 message Encode {
+    enum EncodeType {
+        TEXT = 0;
+        JSON = 1;
+        YAML = 2;
+        MSGPACK = 3;
+        XML = 4;
+    }
     required EncodeType type = 1;
     required bytes      payload = 2;
 }

--- a/nmsg/base/encode.proto
+++ b/nmsg/base/encode.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum EncodeType {

--- a/nmsg/base/http.proto
+++ b/nmsg/base/http.proto
@@ -1,12 +1,12 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum HttpType {
-    unknown = 0;
-    sinkhole = 1;
-}
-
 message Http {
+    enum HttpType {
+        unknown = 0;
+        sinkhole = 1;
+    }
+
     required HttpType   type = 1;
     optional bytes      srcip = 2;
     optional bytes      srchost = 3;

--- a/nmsg/base/http.proto
+++ b/nmsg/base/http.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum HttpType {

--- a/nmsg/base/ipconn.proto
+++ b/nmsg/base/ipconn.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 message IPConn {

--- a/nmsg/base/linkpair.proto
+++ b/nmsg/base/linkpair.proto
@@ -1,12 +1,12 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum Linktype {
-    anchor = 0;
-    redirect = 1;
-}
 
 message Linkpair {
+    enum Linktype {
+        anchor = 0;
+        redirect = 1;
+    }
     required Linktype   type = 1;
     required bytes      src = 2;
     required bytes      dst = 3;

--- a/nmsg/base/linkpair.proto
+++ b/nmsg/base/linkpair.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum Linktype {

--- a/nmsg/base/logline.proto
+++ b/nmsg/base/logline.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 message LogLine {

--- a/nmsg/base/ncap.c
+++ b/nmsg/base/ncap.c
@@ -162,7 +162,7 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 
 	/* source and destination IPs */
 	switch (ncap->type) {
-	case NMSG__BASE__NCAP_TYPE__IPV4:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
 		etype = ETHERTYPE_IP;
 		nmsg_ipdg_parse(&p->dg, etype, ncap->payload.len, ncap->payload.data);
 		ip = (const struct nmsg_iphdr *) p->dg.network;
@@ -174,7 +174,7 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 		p->dstip.data = (uint8_t *) &ip->ip_dst;
 		p->proto = ip->ip_p;
 		break;
-	case NMSG__BASE__NCAP_TYPE__IPV6:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 		etype = ETHERTYPE_IPV6;
 		nmsg_ipdg_parse(&p->dg, etype, ncap->payload.len, ncap->payload.data);
 		ip6 = (const struct ip6_hdr *) p->dg.network;
@@ -186,7 +186,7 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 		p->dstip.data = (uint8_t *) &ip6->ip6_dst;
 		p->proto = ip6->ip6_ctlun.ip6_un1.ip6_un1_nxt;
 		break;
-	case NMSG__BASE__NCAP_TYPE__Legacy:
+	case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 		break;
 	default:
 		assert(0); /* unreached */
@@ -194,8 +194,8 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 
 	/* source and destination ports */
 	switch (ncap->type) {
-	case NMSG__BASE__NCAP_TYPE__IPV4:
-	case NMSG__BASE__NCAP_TYPE__IPV6:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 		switch (p->dg.proto_transport) {
 		case IPPROTO_UDP:
 			udp = (const struct nmsg_udphdr *) p->dg.transport;
@@ -206,10 +206,10 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 			break;
 		}
 		break;
-	case NMSG__BASE__NCAP_TYPE__Legacy:
+	case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 		switch (ncap->ltype) {
-		case NMSG__BASE__NCAP_LEGACY_TYPE__UDP:
-		case NMSG__BASE__NCAP_LEGACY_TYPE__TCP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__UDP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__TCP:
 			if (ncap->has_lint0) {
 				p->has_srcport = true;
 				p->srcport = ncap->lint0;
@@ -218,19 +218,19 @@ ncap_msg_load(nmsg_message_t m, void **msg_clos) {
 				p->has_dstport = true;
 				p->dstport = ncap->lint1;
 			}
-		case NMSG__BASE__NCAP_LEGACY_TYPE__ICMP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__ICMP:
 			break;
 		default:
 			assert(0); /* unreached */
 		}
 		switch (ncap->ltype) {
-		case NMSG__BASE__NCAP_LEGACY_TYPE__UDP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__UDP:
 			p->proto = IPPROTO_UDP;
 			break;
-		case NMSG__BASE__NCAP_LEGACY_TYPE__TCP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__TCP:
 			p->proto = IPPROTO_TCP;
 			break;
-		case NMSG__BASE__NCAP_LEGACY_TYPE__ICMP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__ICMP:
 			p->proto = IPPROTO_ICMP;
 			break;
 		default:
@@ -266,13 +266,13 @@ ncap_get_srcip(nmsg_message_t m,
 
 	if (val_idx == 0) {
 		switch (ncap->type) {
-		case NMSG__BASE__NCAP_TYPE__IPV4:
-		case NMSG__BASE__NCAP_TYPE__IPV6:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 			*data = p->srcip.data;
 			if (len)
 				*len = p->srcip.len;
 			break;
-		case NMSG__BASE__NCAP_TYPE__Legacy:
+		case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 			if (ncap->has_srcip) {
 				*data = ncap->srcip.data;
 				if (len)
@@ -304,13 +304,13 @@ ncap_get_dstip(nmsg_message_t m,
 
 	if (val_idx == 0) {
 		switch (ncap->type) {
-		case NMSG__BASE__NCAP_TYPE__IPV4:
-		case NMSG__BASE__NCAP_TYPE__IPV6:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 			*data = p->dstip.data;
 			if (len)
 				*len = p->dstip.len;
 			break;
-		case NMSG__BASE__NCAP_TYPE__Legacy:
+		case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 			if (ncap->has_dstip) {
 				*data = ncap->dstip.data;
 				if (len)
@@ -407,14 +407,14 @@ ncap_get_dns(nmsg_message_t m,
 	    p->dstport == 53 || p->dstport == 5353)
 	{
 		switch (ncap->type) {
-		case NMSG__BASE__NCAP_TYPE__IPV4:
-		case NMSG__BASE__NCAP_TYPE__IPV6:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
+		case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 			*data = (void *) p->dg.payload;
 			if (len)
 				*len = p->dg.len_payload;
 			return (nmsg_res_success);
 			break;
-		case NMSG__BASE__NCAP_TYPE__Legacy:
+		case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 			*data = (void *) ncap->payload.data;
 			if (len)
 				*len = ncap->payload.len;
@@ -514,21 +514,21 @@ ncap_print_payload(nmsg_message_t msg,
 
 	/* parse header fields */
 	switch (ncap->type) {
-	case NMSG__BASE__NCAP_TYPE__IPV4:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
 		etype = ETHERTYPE_IP;
 		nmsg_ipdg_parse(&dg, etype, ncap->payload.len, ncap->payload.data);
 		ip = (const struct nmsg_iphdr *) dg.network;
 		inet_ntop(AF_INET, &ip->ip_src, srcip, sizeof(srcip));
 		inet_ntop(AF_INET, &ip->ip_dst, dstip, sizeof(dstip));
 		break;
-	case NMSG__BASE__NCAP_TYPE__IPV6:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 		etype = ETHERTYPE_IPV6;
 		nmsg_ipdg_parse(&dg, etype, ncap->payload.len, ncap->payload.data);
 		ip6 = (const struct ip6_hdr *) dg.network;
 		inet_ntop(AF_INET6, ip6->ip6_src.s6_addr, srcip, sizeof(srcip));
 		inet_ntop(AF_INET6, ip6->ip6_dst.s6_addr, dstip, sizeof(dstip));
 		break;
-	case NMSG__BASE__NCAP_TYPE__Legacy:
+	case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 		if (ncap->has_srcip == 0) {
 			err_str = "legacy ncap payload missing srcip field";
 			goto err;
@@ -555,8 +555,8 @@ ncap_print_payload(nmsg_message_t msg,
 
 	/* parse payload */
 	switch (ncap->type) {
-	case NMSG__BASE__NCAP_TYPE__IPV4:
-	case NMSG__BASE__NCAP_TYPE__IPV6:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV4:
+	case NMSG__BASE__NCAP__NCAP_TYPE__IPV6:
 		switch (dg.proto_transport) {
 		case IPPROTO_UDP:
 			udp = (const struct nmsg_udphdr *) dg.transport;
@@ -571,9 +571,9 @@ ncap_print_payload(nmsg_message_t msg,
 			break;
 		}
 		break;
-	case NMSG__BASE__NCAP_TYPE__Legacy:
+	case NMSG__BASE__NCAP__NCAP_TYPE__Legacy:
 		switch (ncap->ltype) {
-		case NMSG__BASE__NCAP_LEGACY_TYPE__UDP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__UDP:
 			if (ncap->has_lint0 == 0) {
 				err_str = "legacy ncap payload missing lint0 field";
 				goto err;
@@ -591,8 +591,8 @@ ncap_print_payload(nmsg_message_t msg,
 				goto err;
 			}
 			break;
-		case NMSG__BASE__NCAP_LEGACY_TYPE__TCP:
-		case NMSG__BASE__NCAP_LEGACY_TYPE__ICMP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__TCP:
+		case NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__ICMP:
 			res = nmsg_strbuf_append(sb, "<ERROR: unhandled legacy ncap type %u>%s",
 						 ncap->ltype, endline);
 			return (res);
@@ -632,10 +632,10 @@ ncap_ipdg_to_payload(void *clos __attribute__((unused)),
 	/* set type */
 	switch (dg->proto_network) {
 	case PF_INET:
-		nc.type = NMSG__BASE__NCAP_TYPE__IPV4;
+		nc.type = NMSG__BASE__NCAP__NCAP_TYPE__IPV4;
 		break;
 	case PF_INET6:
-		nc.type = NMSG__BASE__NCAP_TYPE__IPV6;
+		nc.type = NMSG__BASE__NCAP__NCAP_TYPE__IPV6;
 		break;
 	default:
 		return (nmsg_res_parse_error);

--- a/nmsg/base/ncap.proto
+++ b/nmsg/base/ncap.proto
@@ -1,19 +1,19 @@
 syntax = "proto2";
 package nmsg.base;
 
-enum NcapType {
-    IPV4 = 0;
-    IPV6 = 1;
-    Legacy = 2;
-}
-
-enum NcapLegacyType {
-    UDP = 0;
-    TCP = 1;
-    ICMP = 2;
-}
-
 message Ncap {
+    enum NcapType {
+        IPV4 = 0;
+        IPV6 = 1;
+        Legacy = 2;
+    }
+
+    enum NcapLegacyType {
+        UDP = 0;
+        TCP = 1;
+        ICMP = 2;
+    }
+
     required NcapType       type = 1;
     required bytes          payload = 2;
 

--- a/nmsg/base/ncap.proto
+++ b/nmsg/base/ncap.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum NcapType {

--- a/nmsg/base/packet.proto
+++ b/nmsg/base/packet.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 enum PacketType {

--- a/nmsg/base/pkt.proto
+++ b/nmsg/base/pkt.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 message Pkt {

--- a/nmsg/base/xml.proto
+++ b/nmsg/base/xml.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg.base;
 
 message Xml {

--- a/nmsg/compat.h
+++ b/nmsg/compat.h
@@ -1,6 +1,69 @@
 #ifndef NMSG_COMPAT_H
 #define NMSG_COMPAT_H
 
+/*
+ * Protobuf enum refactor compatibility macros.
+ *
+ * Earlier versions of the nmsg.base protobuf schema had package-scope enum
+ * types with overlapping value names. This was incompatible with the C++
+ * protobuf compiler, which generated code with the value names in the scope
+ * of the package rather than prepending the type name to the value as done
+ * by protobuf-c and others.
+ *
+ * To fix this, the enumerated types were moved into the scope of the messages
+ * which used them which changed the protobuf-c generated types and values in
+ * a predicatble manner. These macros allow code to continue to use the previous
+ * protobuf-c generated names for these enum types and values.
+ */
+
+#define Nmsg__Base__DnsQRType					Nmsg__Base__DnsQR__DnsQRType
+#define Nmsg__Base__EmailType					Nmsg__Base__Email__EmailType
+#define Nmsg__Base__EncodeType					Nmsg__Base__Encode__EncodeType
+#define Nmsg__Base__HttpType					Nmsg__Base__Http__HttpType
+#define Nmsg__Base__Linktype					Nmsg__Base__Linkpair__Linktype
+#define Nmsg__Base__NcapLegacyType				Nmsg__Base__Ncap__NcapLegacyType
+#define Nmsg__Base__NcapType					Nmsg__Base__Ncap__NcapType
+#define Nmsg__Base__UdpChecksum					Nmsg__Base__DnsQR__UdpChecksum
+
+#define NMSG__BASE__DNS_QRTYPE__ICMP				NMSG__BASE__DNS_QR__DNS_QRTYPE__ICMP
+#define NMSG__BASE__DNS_QRTYPE__TCP				NMSG__BASE__DNS_QR__DNS_QRTYPE__TCP
+#define NMSG__BASE__DNS_QRTYPE__UDP_INVALID			NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_INVALID
+#define NMSG__BASE__DNS_QRTYPE__UDP_QUERY_ONLY			NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_ONLY
+#define NMSG__BASE__DNS_QRTYPE__UDP_QUERY_RESPONSE		NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_RESPONSE
+#define NMSG__BASE__DNS_QRTYPE__UDP_RESPONSE_ONLY		NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_RESPONSE_ONLY
+#define NMSG__BASE__DNS_QRTYPE__UDP_UNANSWERED_QUERY		NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNANSWERED_QUERY
+#define NMSG__BASE__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE	NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE
+#define NMSG__BASE__EMAIL_TYPE__rej_content			NMSG__BASE__EMAIL__EMAIL_TYPE__rej_content
+#define NMSG__BASE__EMAIL_TYPE__rej_network			NMSG__BASE__EMAIL__EMAIL_TYPE__rej_network
+#define NMSG__BASE__EMAIL_TYPE__rej_user			NMSG__BASE__EMAIL__EMAIL_TYPE__rej_user
+#define NMSG__BASE__EMAIL_TYPE__spamtrap			NMSG__BASE__EMAIL__EMAIL_TYPE__spamtrap
+#define NMSG__BASE__EMAIL_TYPE__unknown				NMSG__BASE__EMAIL__EMAIL_TYPE__unknown
+#define NMSG__BASE__ENCODE_TYPE__JSON				NMSG__BASE__ENCODE__ENCODE_TYPE__JSON
+#define NMSG__BASE__ENCODE_TYPE__MSGPACK			NMSG__BASE__ENCODE__ENCODE_TYPE__MSGPACK
+#define NMSG__BASE__ENCODE_TYPE__TEXT				NMSG__BASE__ENCODE__ENCODE_TYPE__TEXT
+#define NMSG__BASE__ENCODE_TYPE__XML				NMSG__BASE__ENCODE__ENCODE_TYPE__XML
+#define NMSG__BASE__ENCODE_TYPE__YAML				NMSG__BASE__ENCODE__ENCODE_TYPE__YAML
+#define NMSG__BASE__HTTP_TYPE__sinkhole				NMSG__BASE__HTTP__HTTP_TYPE__sinkhole
+#define NMSG__BASE__HTTP_TYPE__unknown				NMSG__BASE__HTTP__HTTP_TYPE__unknown
+#define NMSG__BASE__LINKTYPE__ANCHOR				NMSG__BASE__LINKPAIR__LINKTYPE__ANCHOR
+#define NMSG__BASE__LINKTYPE__REDIRECT				NMSG__BASE__LINKPAIR__LINKTYPE__REDIRECT
+#define NMSG__BASE__LINKTYPE__anchor				NMSG__BASE__LINKPAIR__LINKTYPE__anchor
+#define NMSG__BASE__LINKTYPE__redirect				NMSG__BASE__LINKPAIR__LINKTYPE__redirect
+#define NMSG__BASE__NCAP_LEGACY_TYPE__ICMP			NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__ICMP
+#define NMSG__BASE__NCAP_LEGACY_TYPE__TCP			NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__TCP
+#define NMSG__BASE__NCAP_LEGACY_TYPE__UDP			NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__UDP
+#define NMSG__BASE__NCAP_TYPE__IPV4				NMSG__BASE__NCAP__NCAP_TYPE__IPV4
+#define NMSG__BASE__NCAP_TYPE__IPV6 				NMSG__BASE__NCAP__NCAP_TYPE__IPV6
+#define NMSG__BASE__NCAP_TYPE__Legacy				NMSG__BASE__NCAP__NCAP_TYPE__Legacy
+#define NMSG__BASE__UDP_CHECKSUM__ABSENT			NMSG__BASE__DNS_QR__UDP_CHECKSUM__ABSENT
+#define NMSG__BASE__UDP_CHECKSUM__CORRECT			NMSG__BASE__DNS_QR__UDP_CHECKSUM__CORRECT
+#define NMSG__BASE__UDP_CHECKSUM__ERROR				NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR
+#define NMSG__BASE__UDP_CHECKSUM__INCORRECT			NMSG__BASE__DNS_QR__UDP_CHECKSUM__INCORRECT
+
+/*
+ * isc -> base rename compatibility macros.
+ */
+
 #define NMSG_VENDOR_ISC_NCAP_ID				NMSG_VENDOR_BASE_NCAP_ID
 #define NMSG_VENDOR_ISC_NCAP_NAME			NMSG_VENDOR_BASE_NCAP_NAME
 #define NMSG_VENDOR_ISC_EMAIL_ID			NMSG_VENDOR_BASE_EMAIL_ID
@@ -26,65 +89,65 @@
 
 #define Nmsg__Isc__Dns					Nmsg__Base__Dns
 #define Nmsg__Isc__DnsQR				Nmsg__Base__DnsQR
-#define Nmsg__Isc__DnsQRType				Nmsg__Base__DnsQRType
+#define Nmsg__Isc__DnsQRType				Nmsg__Base__DnsQR__DnsQRType
 #define Nmsg__Isc__Email				Nmsg__Base__Email
-#define Nmsg__Isc__EmailType				Nmsg__Base__EmailType
+#define Nmsg__Isc__EmailType				Nmsg__Base__Email__EmailType
 #define Nmsg__Isc__Encode				Nmsg__Base__Encode
-#define Nmsg__Isc__EncodeType				Nmsg__Base__EncodeType
+#define Nmsg__Isc__EncodeType				Nmsg__Base__Encode__EncodeType
 #define Nmsg__Isc__Http					Nmsg__Base__Http
-#define Nmsg__Isc__HttpType				Nmsg__Base__HttpType
+#define Nmsg__Isc__HttpType				Nmsg__Base__Http__HttpType
 #define Nmsg__Isc__IPConn				Nmsg__Base__IPConn
 #define Nmsg__Isc__Linkpair				Nmsg__Base__Linkpair
-#define Nmsg__Isc__Linktype				Nmsg__Base__Linktype
+#define Nmsg__Isc__Linktype				Nmsg__Base__Linkpair__Linktype
 #define Nmsg__Isc__LogLine				Nmsg__Base__LogLine
 #define Nmsg__Isc__Ncap					Nmsg__Base__Ncap
-#define Nmsg__Isc__NcapLegacyType			Nmsg__Base__NcapLegacyType
-#define Nmsg__Isc__NcapType				Nmsg__Base__NcapType
+#define Nmsg__Isc__NcapLegacyType			Nmsg__Base__Ncap__NcapLegacyType
+#define Nmsg__Isc__NcapType				Nmsg__Base__Ncap__NcapType
 #define Nmsg__Isc__Pkt					Nmsg__Base__Pkt
-#define Nmsg__Isc__UdpChecksum				Nmsg__Base__UdpChecksum
+#define Nmsg__Isc__UdpChecksum				Nmsg__Base__DnsQR__UdpChecksum
 #define Nmsg__Isc__Xml					Nmsg__Base__Xml
 
-#define NMSG__ISC__DNS_QRTYPE__ICMP			NMSG__BASE__DNS_QRTYPE__ICMP
-#define NMSG__ISC__DNS_QRTYPE__TCP			NMSG__BASE__DNS_QRTYPE__TCP
-#define NMSG__ISC__DNS_QRTYPE__UDP_INVALID		NMSG__BASE__DNS_QRTYPE__UDP_INVALID
-#define NMSG__ISC__DNS_QRTYPE__UDP_QUERY_ONLY		NMSG__BASE__DNS_QRTYPE__UDP_QUERY_ONLY
-#define NMSG__ISC__DNS_QRTYPE__UDP_QUERY_RESPONSE	NMSG__BASE__DNS_QRTYPE__UDP_QUERY_RESPONSE
-#define NMSG__ISC__DNS_QRTYPE__UDP_RESPONSE_ONLY	NMSG__BASE__DNS_QRTYPE__UDP_RESPONSE_ONLY
-#define NMSG__ISC__DNS_QRTYPE__UDP_UNANSWERED_QUERY	NMSG__BASE__DNS_QRTYPE__UDP_UNANSWERED_QUERY
-#define NMSG__ISC__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE	NMSG__BASE__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE
-#define NMSG__ISC__EMAIL_TYPE__REJ_CONTENT		NMSG__BASE__EMAIL_TYPE__REJ_CONTENT
-#define NMSG__ISC__EMAIL_TYPE__REJ_NETWORK		NMSG__BASE__EMAIL_TYPE__REJ_NETWORK
-#define NMSG__ISC__EMAIL_TYPE__REJ_USER			NMSG__BASE__EMAIL_TYPE__REJ_USER
-#define NMSG__ISC__EMAIL_TYPE__SPAMTRAP			NMSG__BASE__EMAIL_TYPE__SPAMTRAP
-#define NMSG__ISC__EMAIL_TYPE__UNKNOWN			NMSG__BASE__EMAIL_TYPE__UNKNOWN
-#define NMSG__ISC__EMAIL_TYPE__rej_content		NMSG__BASE__EMAIL_TYPE__rej_content
-#define NMSG__ISC__EMAIL_TYPE__rej_network		NMSG__BASE__EMAIL_TYPE__rej_network
-#define NMSG__ISC__EMAIL_TYPE__rej_user			NMSG__BASE__EMAIL_TYPE__rej_user
-#define NMSG__ISC__EMAIL_TYPE__spamtrap			NMSG__BASE__EMAIL_TYPE__spamtrap
-#define NMSG__ISC__EMAIL_TYPE__unknown			NMSG__BASE__EMAIL_TYPE__unknown
-#define NMSG__ISC__ENCODE_TYPE__JSON			NMSG__BASE__ENCODE_TYPE__JSON
-#define NMSG__ISC__ENCODE_TYPE__MSGPACK			NMSG__BASE__ENCODE_TYPE__MSGPACK
-#define NMSG__ISC__ENCODE_TYPE__TEXT			NMSG__BASE__ENCODE_TYPE__TEXT
-#define NMSG__ISC__ENCODE_TYPE__XML			NMSG__BASE__ENCODE_TYPE__XML
-#define NMSG__ISC__ENCODE_TYPE__YAML			NMSG__BASE__ENCODE_TYPE__YAML
-#define NMSG__ISC__HTTP_TYPE__SINKHOLE			NMSG__BASE__HTTP_TYPE__SINKHOLE
-#define NMSG__ISC__HTTP_TYPE__UNKNOWN			NMSG__BASE__HTTP_TYPE__UNKNOWN
-#define NMSG__ISC__HTTP_TYPE__sinkhole			NMSG__BASE__HTTP_TYPE__sinkhole
-#define NMSG__ISC__HTTP_TYPE__unknown			NMSG__BASE__HTTP_TYPE__unknown
-#define NMSG__ISC__LINKTYPE__ANCHOR			NMSG__BASE__LINKTYPE__ANCHOR
-#define NMSG__ISC__LINKTYPE__REDIRECT			NMSG__BASE__LINKTYPE__REDIRECT
-#define NMSG__ISC__LINKTYPE__anchor			NMSG__BASE__LINKTYPE__anchor
-#define NMSG__ISC__LINKTYPE__redirect			NMSG__BASE__LINKTYPE__redirect
-#define NMSG__ISC__NCAP_LEGACY_TYPE__ICMP		NMSG__BASE__NCAP_LEGACY_TYPE__ICMP
-#define NMSG__ISC__NCAP_LEGACY_TYPE__TCP		NMSG__BASE__NCAP_LEGACY_TYPE__TCP
-#define NMSG__ISC__NCAP_LEGACY_TYPE__UDP		NMSG__BASE__NCAP_LEGACY_TYPE__UDP
-#define NMSG__ISC__NCAP_TYPE__IPV4			NMSG__BASE__NCAP_TYPE__IPV4
-#define NMSG__ISC__NCAP_TYPE__IPV6			NMSG__BASE__NCAP_TYPE__IPV6
-#define NMSG__ISC__NCAP_TYPE__LEGACY			NMSG__BASE__NCAP_TYPE__LEGACY
-#define NMSG__ISC__NCAP_TYPE__Legacy			NMSG__BASE__NCAP_TYPE__Legacy
-#define NMSG__ISC__UDP_CHECKSUM__ABSENT			NMSG__BASE__UDP_CHECKSUM__ABSENT
-#define NMSG__ISC__UDP_CHECKSUM__CORRECT		NMSG__BASE__UDP_CHECKSUM__CORRECT
-#define NMSG__ISC__UDP_CHECKSUM__ERROR			NMSG__BASE__UDP_CHECKSUM__ERROR
-#define NMSG__ISC__UDP_CHECKSUM__INCORRECT		NMSG__BASE__UDP_CHECKSUM__INCORRECT
+#define NMSG__ISC__DNS_QRTYPE__ICMP			NMSG__BASE__DNS_QR__DNS_QRTYPE__ICMP
+#define NMSG__ISC__DNS_QRTYPE__TCP			NMSG__BASE__DNS_QR__DNS_QRTYPE__TCP
+#define NMSG__ISC__DNS_QRTYPE__UDP_INVALID		NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_INVALID
+#define NMSG__ISC__DNS_QRTYPE__UDP_QUERY_ONLY		NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_ONLY
+#define NMSG__ISC__DNS_QRTYPE__UDP_QUERY_RESPONSE	NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_QUERY_RESPONSE
+#define NMSG__ISC__DNS_QRTYPE__UDP_RESPONSE_ONLY	NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_RESPONSE_ONLY
+#define NMSG__ISC__DNS_QRTYPE__UDP_UNANSWERED_QUERY	NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNANSWERED_QUERY
+#define NMSG__ISC__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE	NMSG__BASE__DNS_QR__DNS_QRTYPE__UDP_UNSOLICITED_RESPONSE
+#define NMSG__ISC__EMAIL_TYPE__REJ_CONTENT		NMSG__BASE__EMAIL__EMAIL_TYPE__REJ_CONTENT
+#define NMSG__ISC__EMAIL_TYPE__REJ_NETWORK		NMSG__BASE__EMAIL__EMAIL_TYPE__REJ_NETWORK
+#define NMSG__ISC__EMAIL_TYPE__REJ_USER			NMSG__BASE__EMAIL__EMAIL_TYPE__REJ_USER
+#define NMSG__ISC__EMAIL_TYPE__SPAMTRAP			NMSG__BASE__EMAIL__EMAIL_TYPE__SPAMTRAP
+#define NMSG__ISC__EMAIL_TYPE__UNKNOWN			NMSG__BASE__EMAIL__EMAIL_TYPE__UNKNOWN
+#define NMSG__ISC__EMAIL_TYPE__rej_content		NMSG__BASE__EMAIL__EMAIL_TYPE__rej_content
+#define NMSG__ISC__EMAIL_TYPE__rej_network		NMSG__BASE__EMAIL__EMAIL_TYPE__rej_network
+#define NMSG__ISC__EMAIL_TYPE__rej_user			NMSG__BASE__EMAIL__EMAIL_TYPE__rej_user
+#define NMSG__ISC__EMAIL_TYPE__spamtrap			NMSG__BASE__EMAIL__EMAIL_TYPE__spamtrap
+#define NMSG__ISC__EMAIL_TYPE__unknown			NMSG__BASE__EMAIL__EMAIL_TYPE__unknown
+#define NMSG__ISC__ENCODE_TYPE__JSON			NMSG__BASE__ENCODE__ENCODE_TYPE__JSON
+#define NMSG__ISC__ENCODE_TYPE__MSGPACK			NMSG__BASE__ENCODE__ENCODE_TYPE__MSGPACK
+#define NMSG__ISC__ENCODE_TYPE__TEXT			NMSG__BASE__ENCODE__ENCODE_TYPE__TEXT
+#define NMSG__ISC__ENCODE_TYPE__XML			NMSG__BASE__ENCODE__ENCODE_TYPE__XML
+#define NMSG__ISC__ENCODE_TYPE__YAML			NMSG__BASE__ENCODE__ENCODE_TYPE__YAML
+#define NMSG__ISC__HTTP_TYPE__SINKHOLE			NMSG__BASE__HTTP__HTTP_TYPE__SINKHOLE
+#define NMSG__ISC__HTTP_TYPE__UNKNOWN			NMSG__BASE__HTTP__HTTP_TYPE__UNKNOWN
+#define NMSG__ISC__HTTP_TYPE__sinkhole			NMSG__BASE__HTTP__HTTP_TYPE__sinkhole
+#define NMSG__ISC__HTTP_TYPE__unknown			NMSG__BASE__HTTP__HTTP_TYPE__unknown
+#define NMSG__ISC__LINKTYPE__ANCHOR			NMSG__BASE__LINKPAIR__LINKTYPE__ANCHOR
+#define NMSG__ISC__LINKTYPE__REDIRECT			NMSG__BASE__LINKPAIR__LINKTYPE__REDIRECT
+#define NMSG__ISC__LINKTYPE__anchor			NMSG__BASE__LINKPAIR__LINKTYPE__anchor
+#define NMSG__ISC__LINKTYPE__redirect			NMSG__BASE__LINKPAIR__LINKTYPE__redirect
+#define NMSG__ISC__NCAP_LEGACY_TYPE__ICMP		NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__ICMP
+#define NMSG__ISC__NCAP_LEGACY_TYPE__TCP		NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__TCP
+#define NMSG__ISC__NCAP_LEGACY_TYPE__UDP		NMSG__BASE__NCAP__NCAP_LEGACY_TYPE__UDP
+#define NMSG__ISC__NCAP_TYPE__IPV4			NMSG__BASE__NCAP__NCAP_TYPE__IPV4
+#define NMSG__ISC__NCAP_TYPE__IPV6			NMSG__BASE__NCAP__NCAP_TYPE__IPV6
+#define NMSG__ISC__NCAP_TYPE__LEGACY			NMSG__BASE__NCAP__NCAP_TYPE__LEGACY
+#define NMSG__ISC__NCAP_TYPE__Legacy			NMSG__BASE__NCAP__NCAP_TYPE__Legacy
+#define NMSG__ISC__UDP_CHECKSUM__ABSENT			NMSG__BASE__DNS_QR__UDP_CHECKSUM__ABSENT
+#define NMSG__ISC__UDP_CHECKSUM__CORRECT		NMSG__BASE__DNS_QR__UDP_CHECKSUM__CORRECT
+#define NMSG__ISC__UDP_CHECKSUM__ERROR			NMSG__BASE__DNS_QR__UDP_CHECKSUM__ERROR
+#define NMSG__ISC__UDP_CHECKSUM__INCORRECT		NMSG__BASE__DNS_QR__UDP_CHECKSUM__INCORRECT
 
 #endif /* NMSG_COMPAT_H */

--- a/nmsg/msgmod/transparent_message.c
+++ b/nmsg/msgmod/transparent_message.c
@@ -223,6 +223,10 @@ nmsg_message_get_field_by_idx(nmsg_message_t msg, unsigned field_idx,
 		parray = (char **) PBFIELD(msg->message, field, void);
 		ptr = *parray + (sz * val_idx);
 		break;
+#if PROTOBUF_C_VERSION_NUMBER >= 1003000
+	case PROTOBUF_C_LABEL_NONE:
+		/* FALLTHROUGH */
+#endif
 	case PROTOBUF_C_LABEL_OPTIONAL:
 		if (val_idx >= (unsigned) *qptr)
 			return (nmsg_res_failure);
@@ -366,6 +370,10 @@ nmsg_message_set_field_by_idx(struct nmsg_message *msg, unsigned field_idx,
 		parray = (char **) PBFIELD(msg->message, field, void);
 		ptr = *parray + (sz * val_idx);
 		break;
+#if PROTOBUF_C_VERSION_NUMBER >= 1003000
+	case PROTOBUF_C_LABEL_NONE:
+		/* FALLTHROUGH */
+#endif
 	case PROTOBUF_C_LABEL_OPTIONAL:
 		if (val_idx == 0)
 			*qptr = 1;

--- a/nmsg/nmsg.proto
+++ b/nmsg/nmsg.proto
@@ -1,3 +1,4 @@
+syntax = "proto2";
 package nmsg;
 
 message Nmsg {


### PR DESCRIPTION
This work reorganizes the enum types in the base message module to be compatible with the main protobuf C++ compiler. This results in renaming all protobuf-c generated enum names and types, although the wire format of the messages remains the same.

To address the enum name and type renaming, compatibility definitions have been added to `nmsg/compat.h` to allow existing code to continue using the old names.