### PR TITLE
fix timestamp for seconds in the kickfile filename

### DIFF
--- a/src/kickfile.c
+++ b/src/kickfile.c
@@ -47,7 +47,7 @@ kickfile_time(void) {
 	nmsg_timespec_get(&ts);
 	t = (time_t) ts.tv_sec;
 	gmtime_r(&t, &tm);
-	strftime(when, sizeof(when), "%Y%m%d.%H%M.%s", &tm);
+	strftime(when, sizeof(when), "%Y%m%d.%H%M.%S", &tm);
 	nmsg_asprintf(&kt, "%s.%09ld", when, ts.tv_nsec);
 	assert(kt != NULL);
 


### PR DESCRIPTION
It was epoch so had larger time unit times repeated but in epoch format. It had hour, minute, epoch, nanosecond, but meant to be hour, minute, second, nanosecond. This was detected by compiler check: ISO C does not support the `%s' gnu_strftime format.
So use %S instead.