### PR TITLE
building using nmsg headers also uses libprotobuf-c headers

### DIFF
--- a/nmsg/libnmsg.pc.in
+++ b/nmsg/libnmsg.pc.in
@@ -9,3 +9,4 @@ Version: @VERSION@
 Libs: -L${libdir} -lnmsg
 Libs.private:
 Cflags: -I${includedir}
+Requires.private: libprotobuf-c


### PR DESCRIPTION
pkgconfig pc configuration also refer to the required pkgconfig package providing other header.

For example when configuring to build dnstable-convert:

configure:5277: checking nmsg/sie/dnsdedupe.pb-c.h usability
configure:5277: cc -c -g -O2 -I/var/lib/jenkins/INSTALL/nmsg-master/include   conftest.c >&5
In file included from conftest.c:59:
/var/lib/jenkins/INSTALL/nmsg-master/include/nmsg/sie/dnsdedupe.pb-c.h:7:10: fatal error: 'protobuf-c/protobuf-c.h' file not found
#include <protobuf-c/protobuf-c.h>
