### PR TITLE
Remove sync add

### DIFF
--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,7 +714,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
+	io_output->count_nmsg_payload_out += 1;
 
 	pthread_mutex_lock(&io->lock);
 	io->count_nmsg_payload_out += 1;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,7 +714,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	io_output->count_nmsg_payload_out += 1;
+	sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
 
 	pthread_mutex_lock(&io->lock);
 	io->count_nmsg_payload_out += 1;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,7 +714,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
+	__sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
 
 	pthread_mutex_lock(&io->lock);
 	io->count_nmsg_payload_out += 1;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,7 +714,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	__sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
+	sync_fetch_and_add(&(io_output->count_nmsg_payload_out), 1);
 
 	pthread_mutex_lock(&io->lock);
 	io->count_nmsg_payload_out += 1;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,9 +714,9 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	io_output->count_nmsg_payload_out += 1;
 
 	pthread_mutex_lock(&io->lock);
+	io_output->count_nmsg_payload_out += 1;
 	io->count_nmsg_payload_out += 1;
 	pthread_mutex_unlock(&io->lock);
 


### PR DESCRIPTION
This replaces the use of the `__sync_fetch_and_add ` intrinsic to increment of the io output counter with a normal increment inside an already-acquired lock which protects an update to an io level stats counter, avoiding both an unnecessary locked CPU instruction as well as a non-standard (if widely adopted) compiler extension.