### PR TITLE
0.15.1 release

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+nmsg (0.15.1)
+
+  * Fix output stats collection.
+
+  * Plugins now found by default at $libdir/nmsg instead of lib/nmsg.
+    This fixes problem where plugins were not found with recent Debian
+    packages built with --libdir configure option (used to install
+    libraries in architecture specific directory). And
+    ./configure --with-plugindir renamed to --with-pluginsdir.
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Thu, 23 Jan 2020 13:20:13 +0000
+
 nmsg (0.15.0)
 
   * Add compile-time and runtime version info to API: NMSG_LIBRARY_VERSION

--- a/ChangeLog
+++ b/ChangeLog
@@ -8,6 +8,9 @@ nmsg (0.15.1)
     libraries in architecture specific directory). And
     ./configure --with-plugindir renamed to --with-pluginsdir.
 
+  * pkgconfig also depend on libprotobuf-c headers (for third-party
+    uses of libnmsg with pkgconfig).
+
  -- Farsight Security, Inc. <software@farsightsecurity.com>  Thu, 23 Jan 2020 13:20:13 +0000
 
 nmsg (0.15.0)

--- a/Makefile.am
+++ b/Makefile.am
@@ -205,7 +205,7 @@ CLEANFILES += $(nodist_nmsg_libnmsg_la_SOURCES)
 
 MSG_LIBTOOL_FLAGS = -module -avoid-version -shared -export-symbols-regex "^(nmsg_msgmod_ctx|nmsg_msgmod_ctx_array)$$"
 
-moduledir = $(libdir)/nmsg
+moduledir = $(NMSG_PLUGINSDIR)
 protodir = $(pkgdatadir)/base
 
 nobase_include_HEADERS += \

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Building external modules
 
 `nmsg` can be extended at runtime with new message types by installing message
 modules into the `libnmsg` module directory, which defaults to
-`$PREFIX/lib/nmsg`. This location is configurable by passing the
-`--with-plugindir` parameter to the `configure` script.
+`$libdir/nmsg`. This location is configurable by passing the
+`--with-pluginsdir` parameter to the `configure` script.
 
 Message module plugins are `.so` files which export either a symbol named
 `nmsg_msgmod_ctx` or a symbol named `nmsg_msgmod_ctx_array`. If

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@ AC_PREREQ(2.64)
 
 m4_define(nmsg_major_version, 0)
 m4_define(nmsg_minor_version, 15)
-m4_define(nmsg_patchlevel_version, 0)
+m4_define(nmsg_patchlevel_version, 1)
 m4_define(nmsg_version,
 	  nmsg_major_version.nmsg_minor_version.nmsg_patchlevel_version)
 m4_define(nmsg_version_number,

--- a/configure.ac
+++ b/configure.ac
@@ -183,16 +183,12 @@ fi
 AX_DEFINE_DIR([NMSG_ETCDIR], ["sysconfdir"], [nmsg etc directory])
 
 AC_ARG_WITH(
-    [plugindir],
-    AC_HELP_STRING([--with-plugindir=DIR], [libnmsg plugin directory]),
-    [ AX_DEFINE_DIR([NMSG_LIBDIR], ["withval"], [nmsg lib directory]) ],
+    [pluginsdir],
+    AC_HELP_STRING([--with-pluginsdir=DIR], [nmsg plugins directory]),
+    [ AX_DEFINE_DIR([NMSG_PLUGINSDIR], ["withval"], [nmsg plugins directory]) ],
     [
-        if test x_$prefix = x_NONE; then
-            nmsg_libdir=$ac_default_prefix/lib/nmsg
-        else
-            nmsg_libdir=$prefix/lib/nmsg
-        fi
-        AX_DEFINE_DIR([NMSG_LIBDIR], ["nmsg_libdir"], [nmsg lib directory])
+        nmsg_pluginsdir=$libdir/nmsg
+        AX_DEFINE_DIR([NMSG_PLUGINSDIR], ["nmsg_pluginsdir"], [nmsg plugins directory])
     ]
 )
 
@@ -211,7 +207,7 @@ AC_MSG_RESULT([
         includedir:             ${includedir}
         pkgconfigdir:           ${pkgconfigdir}
 
-        plugin directory:       ${NMSG_LIBDIR}
+        plugins directory:      ${NMSG_PLUGINSDIR}
 
         bigendian:              ${ac_cv_c_bigendian}
         libxs support:          ${use_libxs}

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,9 @@ nmsg (0.15.1-1) debian-fsi; urgency=medium
     libraries in architecture specific directory). And
     ./configure --with-plugindir renamed to --with-pluginsdir.
 
+  * pkgconfig also depend on libprotobuf-c headers (for third-party
+    uses of libnmsg with pkgconfig).
+
  -- Farsight Security, Inc. <software@farsightsecurity.com>  Thu, 23 Jan 2020 13:20:13 +0000
 
 nmsg (0.15.0-1) debian-fsi; urgency=medium

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+nmsg (0.15.1-1) debian-fsi; urgency=medium
+
+  * Fix output stats collection.
+
+  * Plugins now found by default at $libdir/nmsg instead of lib/nmsg.
+    This fixes problem where plugins were not found with recent Debian
+    packages built with --libdir configure option (used to install
+    libraries in architecture specific directory). And
+    ./configure --with-plugindir renamed to --with-pluginsdir.
+
+ -- Farsight Security, Inc. <software@farsightsecurity.com>  Thu, 23 Jan 2020 13:20:13 +0000
+
 nmsg (0.15.0-1) debian-fsi; urgency=medium
 
   * Add compile-time and runtime version info to API: NMSG_LIBRARY_VERSION

--- a/nmsg/fltmod.c
+++ b/nmsg/fltmod.c
@@ -89,7 +89,7 @@ nmsg_fltmod_init(const char *name, const void *param, const size_t len_param)
 		/* Expand the short name into a full path name. */
 		ubuf *u = ubuf_init(64);
 		ubuf_add_fmt(u, "%s/%s_%s%s",
-			     NMSG_LIBDIR,
+			     NMSG_PLUGINSDIR,
 			     NMSG_FLT_MODULE_PREFIX,
 			     name,
 			     NMSG_MODULE_SUFFIX);

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -714,9 +714,9 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	io_output->count_nmsg_payload_out += 1;
 
 	pthread_mutex_lock(&io->lock);
+	io_output->count_nmsg_payload_out += 1;
 	io->count_nmsg_payload_out += 1;
 	pthread_mutex_unlock(&io->lock);
 

--- a/nmsg/libnmsg.pc.in
+++ b/nmsg/libnmsg.pc.in
@@ -9,3 +9,4 @@ Version: @VERSION@
 Libs: -L${libdir} -lnmsg
 Libs.private:
 Cflags: -I${includedir}
+Requires.private: libprotobuf-c

--- a/nmsg/nmsg.c
+++ b/nmsg/nmsg.c
@@ -44,7 +44,7 @@ nmsg_init(void) {
 
 	msgmod_dir = getenv("NMSG_MSGMOD_DIR");
 	if (msgmod_dir == NULL)
-		msgmod_dir = NMSG_LIBDIR;
+		msgmod_dir = NMSG_PLUGINSDIR;
 
 	_nmsg_global_msgmodset = _nmsg_msgmodset_init(msgmod_dir);
 	if (_nmsg_global_msgmodset == NULL)


### PR DESCRIPTION
  * Fix output stats collection.

  * Plugins now found by default at $libdir/nmsg instead of lib/nmsg.
    This fixes problem where plugins were not found with recent Debian
    packages built with --libdir configure option (used to install
    libraries in architecture specific directory). And
    ./configure --with-plugindir renamed to --with-pluginsdir.

  * pkgconfig also depend on libprotobuf-c headers (for third-party
    uses of libnmsg with pkgconfig).
