### PR TITLE
Add go_package option to all proto message definitions.

### DIFF
--- a/nmsg/base/dns.proto
+++ b/nmsg/base/dns.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Dns {
     optional uint32     section = 6;

--- a/nmsg/base/dnsqr.proto
+++ b/nmsg/base/dnsqr.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message DnsQR {
     enum DnsQRType {

--- a/nmsg/base/dnstap.proto
+++ b/nmsg/base/dnstap.proto
@@ -16,6 +16,7 @@
 
 syntax = "proto2";
 package dnstap;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base/dnstap";
 
 // "Dnstap": this is the top-level dnstap type, which is a "union" type that
 // contains other kinds of dnstap payloads, although currently only one type

--- a/nmsg/base/email.proto
+++ b/nmsg/base/email.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Email {
     enum EmailType {

--- a/nmsg/base/encode.proto
+++ b/nmsg/base/encode.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
-
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Encode {
     enum EncodeType {

--- a/nmsg/base/http.proto
+++ b/nmsg/base/http.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Http {
     enum HttpType {

--- a/nmsg/base/ipconn.proto
+++ b/nmsg/base/ipconn.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message IPConn {
     optional uint32     proto = 1;

--- a/nmsg/base/linkpair.proto
+++ b/nmsg/base/linkpair.proto
@@ -1,6 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
-
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Linkpair {
     enum Linktype {

--- a/nmsg/base/logline.proto
+++ b/nmsg/base/logline.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message LogLine {
     optional bytes      category = 1;

--- a/nmsg/base/ncap.proto
+++ b/nmsg/base/ncap.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Ncap {
     enum NcapType {

--- a/nmsg/base/packet.proto
+++ b/nmsg/base/packet.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 enum PacketType {
     // An IPv4 or IPv6 packet. The packet begins immediately with the IP

--- a/nmsg/base/pkt.proto
+++ b/nmsg/base/pkt.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Pkt {
     required bytes          payload = 1;

--- a/nmsg/base/xml.proto
+++ b/nmsg/base/xml.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg.base;
+option go_package = "github.com/farsightsec/nmsg/nmsg/base";
 
 message Xml {
     required bytes      xmltype = 1;

--- a/nmsg/nmsg.proto
+++ b/nmsg/nmsg.proto
@@ -1,5 +1,6 @@
 syntax = "proto2";
 package nmsg;
+option go_package = "github.com/farsightsec/nmsg/nmsg";
 
 message Nmsg {
     repeated NmsgPayload    payloads = 1;


### PR DESCRIPTION
As of protoc v3.12.3 && protoc-gen-go v1.25.0 errors about:
  2021/01/05 01:30:07 WARNING: Missing 'go_package' option in "http.proto",
  please specify it with the full Go package path as
  a future release of protoc-gen-go will require this be specified.
  See https://developers.google.com/protocol-buffers/docs/reference/go-generated#package for more information.

are emitted from the proto compilation stage. These are warnings today,
but failures 'soon'.

Here's a fix to remove the warning/errors :)