### PR TITLE
code.google.com is retired/gone. Let's use the direct github link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ nmsg has the following external dependencies:
 
 * [pcap](http://www.tcpdump.org/)
 
-* [protobuf](https://code.google.com/p/protobuf/)
+* [protobuf](https://github.com/protocolbuffers/protobuf)
 
 * [protobuf-c](https://github.com/protobuf-c/protobuf-c), version 1.0.1 or
   higher. Previous versions WILL NOT WORK.


### PR DESCRIPTION
code.google.com IS redirecting, but it's probably nicer for everyone
to point at the proper destination.