### PR TITLE
test-misc: Fix type of count parameters

### DIFF
--- a/tests/test-misc.c
+++ b/tests/test-misc.c
@@ -969,7 +969,7 @@ test_seq(void)
 	 */
 	while (n < 3) {
 		nmsg_input_t i;
-		size_t cr, cd;
+		uint64_t cr, cd;
 
 		check_return(socketpair(AF_LOCAL, SOCK_STREAM, 0, sfds) != -1);
 


### PR DESCRIPTION
size_t -> uint64_t, fixes compiler warnings on MacOS