### PR TITLE
base.dnsqr: Initialize len in dnsqr_hash to squash code-checker warning.

### DIFF
--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -1458,7 +1458,7 @@ static uint32_t
 dnsqr_hash(Nmsg__Base__DnsQR *dnsqr) {
 	dnsqr_key_t key;
 	dnsqr_key6_t key6;
-	size_t len;
+	size_t len = 0;
 	void *k;
 	uint32_t hash;
 


### PR DESCRIPTION
third-party/nmsg/nmsg/base/dnsqr.c:1477:13: error: variable 'len' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
        } else if (dnsqr->query_ip.len == 16) {
                   ^~~~~~~~~~~~~~~~~~~~~~~~~
third-party/nmsg/nmsg/base/dnsqr.c:1490:26: note: uninitialized use occurs here
        hash = my_hashlittle(k, len, 0);
                                ^~~
third-party/nmsg/nmsg/base/dnsqr.c:1477:9: note: remove the 'if' if its condition is always true
        } else if (dnsqr->query_ip.len == 16) {
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
third-party/nmsg/nmsg/base/dnsqr.c:1461:12: note: initialize the variable 'len' to silence this warning
        size_t len;
                  ^
                   = 0
1 error generated.