### PR TITLE
Rte 1760 fix null operator

### DIFF
--- a/nmsg/msgmod/message.c
+++ b/nmsg/msgmod/message.c
@@ -491,12 +491,12 @@ nmsg_message_to_pres(struct nmsg_message *msg, char **pres, const char *endline)
 }
 
 nmsg_res
-_nmsg_message_to_json(nmsg_message_t msg, struct nmsg_strbuf *sb) {
+_nmsg_message_to_json(nmsg_output_t output, nmsg_message_t msg, struct nmsg_strbuf *sb) {
 	if (msg->mod == NULL)
 		return (nmsg_res_failure);
 	switch (msg->mod->plugin->type) {
 	case nmsg_msgmod_type_transparent:
-		return (_nmsg_message_payload_to_json(msg, sb));
+		return (_nmsg_message_payload_to_json(output, msg, sb));
 	case nmsg_msgmod_type_opaque:
 		return (nmsg_res_notimpl);
 	default:
@@ -510,7 +510,7 @@ nmsg_message_to_json(nmsg_message_t msg, char **json) {
 	struct nmsg_strbuf_storage sbs;
 	struct nmsg_strbuf *sb = _nmsg_strbuf_init(&sbs);
 
-	res = _nmsg_message_to_json(msg, sb);
+	res = _nmsg_message_to_json(NULL, msg, sb);
 	if (res == nmsg_res_success) {
 		*json = _nmsg_strbuf_detach(sb);
 	}

--- a/nmsg/msgmod/transparent.h
+++ b/nmsg/msgmod/transparent.h
@@ -65,7 +65,7 @@ _nmsg_msgmod_pres_to_payload_finalize(struct nmsg_msgmod *mod, void *cl,
 				      uint8_t **pbuf, size_t *sz);
 
 nmsg_res
-_nmsg_message_payload_to_json(struct nmsg_message *msg, struct nmsg_strbuf *sb);
+_nmsg_message_payload_to_json(nmsg_output_t output, struct nmsg_message *msg, struct nmsg_strbuf *sb);
 
 nmsg_res
 _nmsg_message_payload_to_json_load(struct nmsg_message *msg,

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -291,20 +291,53 @@ nmsg_output_set_endline(nmsg_output_t output, const char *endline) {
 
 void
 nmsg_output_set_source(nmsg_output_t output, unsigned source) {
-	if (output->type == nmsg_output_type_stream)
+	switch(output->type) {
+	case nmsg_output_type_stream:
 		output->stream->source = source;
+		break;
+	case nmsg_output_type_pres:
+		output->pres->source = source;
+		break;
+	case nmsg_output_type_json:
+		output->json->source = source;
+		break;
+	default:
+		break;
+	}
 }
 
 void
 nmsg_output_set_operator(nmsg_output_t output, unsigned operator) {
-	if (output->type == nmsg_output_type_stream)
+	switch(output->type) {
+	case nmsg_output_type_stream:
 		output->stream->operator = operator;
+		break;
+	case nmsg_output_type_pres:
+		output->pres->operator = operator;
+		break;
+	case nmsg_output_type_json:
+		output->json->operator = operator;
+		break;
+	default:
+		break;
+	}
 }
 
 void
 nmsg_output_set_group(nmsg_output_t output, unsigned group) {
-	if (output->type == nmsg_output_type_stream)
+	switch(output->type) {
+	case nmsg_output_type_stream:
 		output->stream->group = group;
+		break;
+	case nmsg_output_type_pres:
+		output->pres->group = group;
+		break;
+	case nmsg_output_type_json:
+		output->json->group = group;
+		break;
+	default:
+		break;
+	}
 }
 
 void

--- a/nmsg/output_json.c
+++ b/nmsg/output_json.c
@@ -27,7 +27,7 @@ _output_json_write(nmsg_output_t output, nmsg_message_t msg) {
 	struct nmsg_strbuf_storage sbs;
 	struct nmsg_strbuf *sb = _nmsg_strbuf_init(&sbs);
 
-	res = _nmsg_message_to_json(msg, sb);
+	res = _nmsg_message_to_json(output, msg, sb);
 	if (res != nmsg_res_success)
 		goto out;
 

--- a/nmsg/output_pres.c
+++ b/nmsg/output_pres.c
@@ -23,10 +23,11 @@
 nmsg_res
 _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 	Nmsg__NmsgPayload *np;
-	const char *vname = NULL;
-	const char *mname = NULL;
-	char *pres_data;
+	char op_buf[sizeof("4294967295")] = {0}, group_buf[sizeof("4294967295")] = {0};
+	const char *op_str = op_buf, *group_str = group_buf;
+	const char *vname = NULL, *mname = NULL;
 	char when[32];
+	char *pres_data;
 	nmsg_msgmod_t mod;
 	nmsg_res res;
 	struct tm tm;
@@ -52,6 +53,25 @@ _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 	}
 	vname = nmsg_msgmod_vid_to_vname(np->vid);
 	mname = nmsg_msgmod_msgtype_to_mname(np->vid, np->msgtype);
+
+	if (np->has_operator_) {
+		op_str = nmsg_alias_by_key(nmsg_alias_operator, np->operator_);
+
+		if (op_str == NULL) {
+			snprintf(op_buf, sizeof(op_buf), "%"PRIu32, np->operator_);
+			op_str = op_buf;
+		}
+	}
+
+	if (np->has_group) {
+		group_str = nmsg_alias_by_key(nmsg_alias_group, np->group);
+
+		if (group_str == NULL) {
+			snprintf(group_buf, sizeof(group_buf), "%"PRIu32, np->group);
+			group_str = group_buf;
+		}
+	}
+
 	fprintf(output->pres->fp, "[%zu] [%s.%09u] [%d:%d %s %s] "
 		"[%08x] [%s] [%s] %s%s",
 		np->has_payload ? np->payload.len : 0,
@@ -60,15 +80,8 @@ _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 		vname ? vname : "(unknown)",
 		mname ? mname : "(unknown)",
 		np->has_source ? np->source : 0,
-
-		np->has_operator_ ?
-			nmsg_alias_by_key(nmsg_alias_operator, np->operator_)
-			: "",
-
-		np->has_group ?
-			nmsg_alias_by_key(nmsg_alias_group, np->group)
-			: "",
-
+		op_str,
+		group_str,
 		output->pres->endline, pres_data);
 	fputs("\n", output->pres->fp);
 	if (output->pres->flush)

--- a/nmsg/output_pres.c
+++ b/nmsg/output_pres.c
@@ -28,6 +28,7 @@ _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 	const char *vname = NULL, *mname = NULL;
 	char when[32];
 	char *pres_data;
+	uint32_t oper_val = 0, group_val = 0, source_val = 0;
 	nmsg_msgmod_t mod;
 	nmsg_res res;
 	struct tm tm;
@@ -54,23 +55,38 @@ _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 	vname = nmsg_msgmod_vid_to_vname(np->vid);
 	mname = nmsg_msgmod_msgtype_to_mname(np->vid, np->msgtype);
 
-	if (np->has_operator_) {
-		op_str = nmsg_alias_by_key(nmsg_alias_operator, np->operator_);
+	if (output->pres->operator != 0)
+		oper_val = output->pres->operator;
+	else if (np->has_operator_)
+		oper_val = np->operator_;
+
+	if (oper_val != 0) {
+		op_str = nmsg_alias_by_key(nmsg_alias_operator, oper_val);
 
 		if (op_str == NULL) {
-			snprintf(op_buf, sizeof(op_buf), "%"PRIu32, np->operator_);
+			snprintf(op_buf, sizeof(op_buf), "%"PRIu32, oper_val);
 			op_str = op_buf;
 		}
 	}
 
-	if (np->has_group) {
-		group_str = nmsg_alias_by_key(nmsg_alias_group, np->group);
+	if (output->pres->group != 0)
+		group_val = output->pres->group;
+	else if (np->has_group)
+		group_val = np->group;
+
+	if (group_val != 0) {
+		group_str = nmsg_alias_by_key(nmsg_alias_group, group_val);
 
 		if (group_str == NULL) {
-			snprintf(group_buf, sizeof(group_buf), "%"PRIu32, np->group);
+			snprintf(group_buf, sizeof(group_buf), "%"PRIu32, group_val);
 			group_str = group_buf;
 		}
 	}
+
+	if (output->pres->source != 0)
+		source_val = output->pres->source;
+	else if (np->has_source)
+		source_val = np->source;
 
 	fprintf(output->pres->fp, "[%zu] [%s.%09u] [%d:%d %s %s] "
 		"[%08x] [%s] [%s] %s%s",
@@ -79,7 +95,7 @@ _output_pres_write(nmsg_output_t output, nmsg_message_t msg) {
 		np->vid, np->msgtype,
 		vname ? vname : "(unknown)",
 		mname ? mname : "(unknown)",
-		np->has_source ? np->source : 0,
+		source_val,
 		op_str,
 		group_str,
 		output->pres->endline, pres_data);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -232,6 +232,9 @@ struct nmsg_pres {
 	FILE			*fp;
 	bool			flush;
 	char			*endline;
+	unsigned		source;
+	unsigned		operator;
+	unsigned		group;
 };
 
 /* nmsg_json: used by nmsg_input and nmsg_output */
@@ -242,6 +245,9 @@ struct nmsg_json {
 	FILE			*fp;
 	int			orig_fd;
 	bool			flush;
+	unsigned		source;
+	unsigned		operator;
+	unsigned		group;
 };
 
 /* nmsg_stream_input: used by nmsg_input */
@@ -469,7 +475,7 @@ nmsg_res		_nmsg_message_serialize(struct nmsg_message *msg);
 nmsg_message_t		_nmsg_message_from_payload(Nmsg__NmsgPayload *np);
 nmsg_message_t		_nmsg_message_dup(struct nmsg_message *msg);
 nmsg_res		_nmsg_message_dup_protobuf(const struct nmsg_message *msg, ProtobufCMessage **dst);
-nmsg_res		_nmsg_message_to_json(nmsg_message_t msg, struct nmsg_strbuf *sb);
+nmsg_res		_nmsg_message_to_json(nmsg_output_t output, nmsg_message_t msg, struct nmsg_strbuf *sb);
 
 /* from msgmodset.c */
 

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -384,7 +384,8 @@ usage(const char *msg) {
 	if (msg)
 		fprintf(stderr, "%s: usage error: %s\n", argv_program, msg);
 	nmsg_io_destroy(&ctx.io);
-	exit(argv_usage(args, ARGV_USAGE_DEFAULT));
+	argv_usage(args, ARGV_USAGE_DEFAULT);
+	exit(msg == NULL ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
 void


### PR DESCRIPTION
Apply source/operator/group values to messages displayed in presentation/json format when set in output.
In presentation/json output, display numerical group and operator values that cannot be resolved by alias.
Allow numerical group/operator values to be specified on the nmsgtool command line.