### PR TITLE
Use stdatomic functions for thread-safe operations.

### DIFF
--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -1839,7 +1839,7 @@ dnsqr_trim(dnsqr_ctx_t *ctx) {
 		assert(he->dnsqr->n_query_time_sec > 0);
 		assert(he->dnsqr->n_query_time_nsec > 0);
 		if (ctx->count > ctx->max_values ||
-		    atomic_load(&ctx->stop) ||
+		    atomic_load_explicit(&ctx->stop, memory_order_relaxed) ||
 		    ctx->now.tv_sec - he->dnsqr->query_time_sec[0] > ctx->query_timeout)
 		{
 			dnsqr = he->dnsqr;
@@ -2661,7 +2661,7 @@ dnsqr_pkt_to_payload(void *clos, nmsg_pcap_t pcap, nmsg_message_t *m) {
 			return (nmsg_res_success);
 		}
 	} else {
-		if (atomic_load(&ctx->stop))
+		if (atomic_load_explicit(&ctx->stop, memory_order_relaxed))
 			return (nmsg_res_eof);
 	}
 
@@ -2669,7 +2669,7 @@ dnsqr_pkt_to_payload(void *clos, nmsg_pcap_t pcap, nmsg_message_t *m) {
 	if (res == nmsg_res_success) {
 		return (do_packet(ctx, pcap, m, pkt_data, pkt_hdr, &ts));
 	} else if (res == nmsg_res_eof) {
-		atomic_store(&ctx->stop, true);
+		atomic_store_explicit(&ctx->stop, true, memory_order_relaxed);
 		return (nmsg_res_again);
 	}
 

--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -79,7 +79,7 @@ typedef struct {
 
 	size_t				len_table;
 
-	_Atomic bool			stop;
+	atomic_bool			stop;
 	int				capture_qr;
 	int				capture_rd;
 	bool				zero_resolver_address;
@@ -1839,7 +1839,7 @@ dnsqr_trim(dnsqr_ctx_t *ctx) {
 		assert(he->dnsqr->n_query_time_sec > 0);
 		assert(he->dnsqr->n_query_time_nsec > 0);
 		if (ctx->count > ctx->max_values ||
-		    atomic_load(&ctx->stop) == true ||
+		    atomic_load(&ctx->stop) ||
 		    ctx->now.tv_sec - he->dnsqr->query_time_sec[0] > ctx->query_timeout)
 		{
 			dnsqr = he->dnsqr;
@@ -2661,7 +2661,7 @@ dnsqr_pkt_to_payload(void *clos, nmsg_pcap_t pcap, nmsg_message_t *m) {
 			return (nmsg_res_success);
 		}
 	} else {
-		if (atomic_load(&ctx->stop) == true)
+		if (atomic_load(&ctx->stop))
 			return (nmsg_res_eof);
 	}
 

--- a/nmsg/base/dnsqr.c
+++ b/nmsg/base/dnsqr.c
@@ -27,6 +27,7 @@
 #include <ctype.h>
 #include <pthread.h>
 #include <stdlib.h>
+#include <stdatomic.h>
 #include <string.h>
 
 #include <pcap.h>
@@ -78,7 +79,7 @@ typedef struct {
 
 	size_t				len_table;
 
-	bool				stop;
+	_Atomic bool			stop;
 	int				capture_qr;
 	int				capture_rd;
 	bool				zero_resolver_address;
@@ -1838,7 +1839,7 @@ dnsqr_trim(dnsqr_ctx_t *ctx) {
 		assert(he->dnsqr->n_query_time_sec > 0);
 		assert(he->dnsqr->n_query_time_nsec > 0);
 		if (ctx->count > ctx->max_values ||
-		    ctx->stop == true ||
+		    atomic_load(&ctx->stop) == true ||
 		    ctx->now.tv_sec - he->dnsqr->query_time_sec[0] > ctx->query_timeout)
 		{
 			dnsqr = he->dnsqr;
@@ -2660,13 +2661,7 @@ dnsqr_pkt_to_payload(void *clos, nmsg_pcap_t pcap, nmsg_message_t *m) {
 			return (nmsg_res_success);
 		}
 	} else {
-		bool stop;
-
-		pthread_mutex_lock(&ctx->lock);
-		stop = ctx->stop;
-		pthread_mutex_unlock(&ctx->lock);
-
-		if (stop == true)
+		if (atomic_load(&ctx->stop) == true)
 			return (nmsg_res_eof);
 	}
 
@@ -2674,9 +2669,7 @@ dnsqr_pkt_to_payload(void *clos, nmsg_pcap_t pcap, nmsg_message_t *m) {
 	if (res == nmsg_res_success) {
 		return (do_packet(ctx, pcap, m, pkt_data, pkt_hdr, &ts));
 	} else if (res == nmsg_res_eof) {
-		pthread_mutex_lock(&ctx->lock);
-		ctx->stop = true;
-		pthread_mutex_unlock(&ctx->lock);
+		atomic_store(&ctx->stop, true);
 		return (nmsg_res_again);
 	}
 

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -74,7 +74,7 @@ struct nmsg_io {
 	nmsg_io_close_fp		close_fp;
 	nmsg_io_output_mode		output_mode;
 	pthread_mutex_t			lock;
-	_Atomic uint64_t		io_count_nmsg_payload_out;
+	atomic_uint_fast64_t		io_count_nmsg_payload_out;
 	unsigned			count, interval, interval_offset;
 	bool                            interval_randomized;
 	volatile bool			stop;

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -74,7 +74,7 @@ struct nmsg_io {
 	nmsg_io_close_fp		close_fp;
 	nmsg_io_output_mode		output_mode;
 	pthread_mutex_t			lock;
-	uint64_t			count_nmsg_payload_out;
+	_Atomic uint64_t		io_count_nmsg_payload_out;
 	unsigned			count, interval, interval_offset;
 	bool                            interval_randomized;
 	volatile bool			stop;
@@ -167,7 +167,7 @@ nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
 		*container_recvs += recvs;
 	}
 
-	*sum_out = io->count_nmsg_payload_out;
+	*sum_out = atomic_load(&io->io_count_nmsg_payload_out);
 
 	return nmsg_res_success;
 }
@@ -315,11 +315,14 @@ nmsg_io_destroy(nmsg_io_t *io) {
 	nmsg_io_filter_vec_destroy(&(*io)->filters);
 
 	/* print statistics */
-	if ((*io)->debug >= 2 && (*io)->count_nmsg_payload_out > 0)
-		_nmsg_dprintfv((*io)->debug, 2, "nmsg_io: io=%p"
-			       " count_nmsg_payload_out=%" PRIu64 "\n",
-			       (void *)(*io),
-			       (*io)->count_nmsg_payload_out);
+	if ((*io)->debug >= 2) {
+		uint64_t pl_out = atomic_load(&(*io)->io_count_nmsg_payload_out);
+
+		if (pl_out > 0)
+			_nmsg_dprintfv((*io)->debug, 2, "nmsg_io: io=%p"
+				       " count_nmsg_payload_out=%" PRIu64 "\n",
+				       (void *)(*io), pl_out);
+	}
 	free(*io);
 	*io = NULL;
 }
@@ -725,9 +728,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	pthread_mutex_lock(&io->lock);
-	io->count_nmsg_payload_out += 1;
-	pthread_mutex_unlock(&io->lock);
+	atomic_fetch_add(&io->io_count_nmsg_payload_out, 1);
 
 	return (res);
 }

--- a/nmsg/io.c
+++ b/nmsg/io.c
@@ -167,7 +167,7 @@ nmsg_io_get_stats(nmsg_io_t io, uint64_t *sum_in, uint64_t *sum_out,
 		*container_recvs += recvs;
 	}
 
-	*sum_out = atomic_load(&io->io_count_nmsg_payload_out);
+	*sum_out = atomic_load_explicit(&io->io_count_nmsg_payload_out, memory_order_relaxed);
 
 	return nmsg_res_success;
 }
@@ -316,7 +316,7 @@ nmsg_io_destroy(nmsg_io_t *io) {
 
 	/* print statistics */
 	if ((*io)->debug >= 2) {
-		uint64_t pl_out = atomic_load(&(*io)->io_count_nmsg_payload_out);
+		uint64_t pl_out = atomic_load_explicit(&(*io)->io_count_nmsg_payload_out, memory_order_relaxed);
 
 		if (pl_out > 0)
 			_nmsg_dprintfv((*io)->debug, 2, "nmsg_io: io=%p"
@@ -728,7 +728,7 @@ io_write(struct nmsg_io_thr *iothr, struct nmsg_io_output *io_output,
 	if (res != nmsg_res_success)
 		return (res);
 
-	atomic_fetch_add(&io->io_count_nmsg_payload_out, 1);
+	atomic_fetch_add_explicit(&io->io_count_nmsg_payload_out, 1, memory_order_relaxed);
 
 	return (res);
 }

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -151,7 +151,7 @@ container_write(nmsg_output_t output, nmsg_container_t *co)
 	uint8_t *buf;
 
 	/* Multiple threads can enter here at once. */
-	seq = atomic_fetch_add(&output->stream->so_sequence_num, 1);
+	seq = atomic_fetch_add_explicit(&output->stream->so_sequence_num, 1, memory_order_relaxed);
 
 	res = nmsg_container_serialize(*co, &buf, &buf_len, true, /* do_header */
 					output->stream->do_zlib, seq, output->stream->sequence_id);
@@ -328,7 +328,7 @@ frag_write(nmsg_output_t output, nmsg_container_t co)
 	max_fragsz = ostr->bufsz - 32;
 
 	/* Multiple threads can enter here at once. */
-	seq = atomic_fetch_add(&ostr->so_sequence_num, 1);
+	seq = atomic_fetch_add_explicit(&ostr->so_sequence_num, 1, memory_order_relaxed);
 
 	res = nmsg_container_serialize(co, &packed, &len, false, /* do_header */
 				       ostr->do_zlib, seq, ostr->sequence_id);

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -151,9 +151,7 @@ container_write(nmsg_output_t output, nmsg_container_t *co)
 	uint8_t *buf;
 
 	/* Multiple threads can enter here at once. */
-	pthread_mutex_lock(&output->stream->w_lock);
-	seq = output->stream->sequence++; /* TODO: Replace with "atomic fetch and add". */
-	pthread_mutex_unlock(&output->stream->w_lock);
+	seq = atomic_fetch_add(&output->stream->so_sequence_num, 1);
 
 	res = nmsg_container_serialize(*co, &buf, &buf_len, true, /* do_header */
 					output->stream->do_zlib, seq, output->stream->sequence_id);
@@ -330,9 +328,7 @@ frag_write(nmsg_output_t output, nmsg_container_t co)
 	max_fragsz = ostr->bufsz - 32;
 
 	/* Multiple threads can enter here at once. */
-	pthread_mutex_lock(&ostr->w_lock);
-	seq = ostr->sequence++;	/* TODO: Replace with "atomic fetch and add". */
-	pthread_mutex_unlock(&ostr->w_lock);
+	seq = atomic_fetch_add(&ostr->so_sequence_num, 1);
 
 	res = nmsg_container_serialize(co, &packed, &len, false, /* do_header */
 				       ostr->do_zlib, seq, ostr->sequence_id);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -302,7 +302,7 @@ struct nmsg_stream_output {
 	unsigned		group;
 	bool			do_zlib;
 	bool			do_sequence;
-	_Atomic uint32_t	so_sequence_num;
+	atomic_uint_fast32_t	so_sequence_num;
 	uint64_t		sequence_id;
 };
 

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -42,6 +42,7 @@
 #include <poll.h>
 #include <signal.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -301,7 +302,7 @@ struct nmsg_stream_output {
 	unsigned		group;
 	bool			do_zlib;
 	bool			do_sequence;
-	uint32_t		sequence;
+	_Atomic uint32_t	so_sequence_num;
 	uint64_t		sequence_id;
 };
 


### PR DESCRIPTION
Use stdatomic functions instead of an explicit mutex to protect operations.