### PR TITLE
Add optional coverage reporting.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.gcda
+*.gcno
 *.la
 *.lo
 *.loT
@@ -15,6 +17,7 @@ Makefile
 Makefile.in
 TAGS
 aclocal.m4
+all.coverage
 autom4te.cache
 autoscan.log
 build-aux
@@ -27,6 +30,7 @@ config.status
 config.sub
 configure
 configure.scan
+coverage-html
 cscope.out
 depcomp
 doc/doxygen/Doxyfile
@@ -50,6 +54,7 @@ nmsg/base/*.pb-c.[ch]
 nmsg/libnmsg.pc
 nmsg/version.h
 libmy/crc32c_test
+report.coverage
 src/nmsgtool
 stamp-h1
 stamp-h2

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,6 +22,42 @@ AM_CFLAGS = \
 	$(json_c_CFLAGS)
 AM_LDFLAGS =
 
+#
+##
+### code coverage
+##
+#
+
+USE_LCOV=@USE_LCOV@
+LCOV=@LCOV@
+GENHTML=@GENHTML@
+
+clean-coverage:
+	@if [ $(USE_LCOV) = yes ] ; then \
+		$(LCOV) --directory . --zerocounters ; \
+		echo "Removing coverage info files and generated $(abs_top_builddir)/coverage-html/ directory" ; \
+		rm -rf all.coverage report.coverage ; \
+		rm -rf $(abs_top_builddir)/coverage-html/ ; \
+	else \
+		echo "Code coverage not enabled at configuration time." ; \
+		echo "Use: ./configure --with-coverage" ; \
+fi
+
+report-coverage:
+	@if [ $(USE_LCOV) = yes ] ; then \
+		$(LCOV) --capture --directory . --output-file all.coverage ; \
+		$(LCOV) --remove all.coverage \
+			$(abs_top_srcdir)/t/\* \
+			/usr/include/\* \
+			--output report.coverage ; \
+		$(GENHTML) --legend -o $(abs_top_builddir)/coverage-html report.coverage ; \
+		echo "Generated Code Coverage report in HTML at $(abs_top_builddir)/coverage-html" ; \
+	else \
+		echo "Code coverage not enabled at configuration time." ; \
+		echo "Use: ./configure --with-coverage" ; \
+fi
+
+
 EXTRA_DIST += ChangeLog
 EXTRA_DIST += COPYRIGHT
 EXTRA_DIST += README.md

--- a/configure.ac
+++ b/configure.ac
@@ -217,6 +217,39 @@ AC_ARG_WITH(
     ]
 )
 
+###
+### coverage reporting
+###
+
+AC_ARG_WITH(coverage,
+[ --with-coverage[=PROGRAM] enable gtest and coverage target using the specified lcov], lcov="$withval", lcov="no")
+
+USE_LCOV="no"
+if test "$lcov" != "no"; then
+	if test "$lcov" != "yes"; then
+		LCOV=$lcov
+	else
+		AC_PATH_PROG([LCOV], [lcov])
+	fi
+	if test -x "${LCOV}"; then
+		USE_LCOV="yes"
+	else
+		AC_MSG_ERROR([Cannot find lcov.])
+	fi
+	# is genhtml always in the same directory?
+	GENHTML=`echo "$LCOV" | ${SED} s/lcov$/genhtml/`
+	if test ! -x $GENHTML; then
+		AC_MSG_ERROR([genhtml not found, needed for lcov])
+	fi
+	CFLAGS="$CFLAGS --coverage"
+	LIBS=" $LIBS -lgcov"
+	AC_SUBST(CPPFLAGS)
+	AC_SUBST(LIBS)
+	AC_SUBST(LCOV)
+	AC_SUBST(GENHTML)
+fi
+AC_SUBST(USE_LCOV)
+
 AC_OUTPUT
 AC_MSG_RESULT([
     $PACKAGE $VERSION
@@ -241,4 +274,6 @@ AC_MSG_RESULT([
 
         building html docs:     ${DOC_HTML_MSG}
         building manpage docs:  ${DOC_MAN_MSG}
+
+        code coverage enabled:  ${USE_LCOV}
 ])


### PR DESCRIPTION
Repeats our common `--with-coverage` configure step.