### PR TITLE
Extend Blocking SIGINT Fix to JSON and Presentation Inputs

### DIFF
--- a/nmsg/input.c
+++ b/nmsg/input.c
@@ -471,6 +471,26 @@ nmsg_input_get_count_container_dropped(nmsg_input_t input, uint64_t *count) {
 	return (nmsg_res_failure);
 }
 
+/*
+ * Check that an fd is valid (the file is open and can be read from).  Returns:
+ *  - nmsg_res_success: The fd is valid and data is ready to be read from the input.
+ *  - nmsg_res_again: The fd is valid but no data is present.
+ *  - nmsg_res_failure: The fd is not valid.
+ */
+nmsg_res
+_input_can_read(int fd) {
+	int poll_res;
+	struct pollfd pfd = { .fd = fd, .events = POLLIN };
+
+	while ((poll_res = poll(&pfd, 1, NMSG_RBUF_TIMEOUT)) != 1) {
+		if (poll_res < 0 && errno != EINTR)
+			return (nmsg_res_read_failure);
+		return (nmsg_res_again);
+	}
+
+	return (nmsg_res_success);
+}
+
 /* Private functions. */
 
 static nmsg_input_t

--- a/nmsg/input_json.c
+++ b/nmsg/input_json.c
@@ -57,6 +57,10 @@ _input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
 	struct nmsg_strbuf_storage sbs;
 	struct nmsg_strbuf *sb = _nmsg_strbuf_init(&sbs);
 
+	nmsg_res poll_res = _input_can_read(fileno(input->json->fp));
+	if (poll_res != nmsg_res_success)
+		return (poll_res);
+
 	while (fgets(line, sizeof(line), input->json->fp) != NULL) {
 		res = nmsg_strbuf_append_str(sb, line, strlen(line));
 		if (res != nmsg_res_success)
@@ -79,7 +83,7 @@ _input_json_read(nmsg_input_t input, nmsg_message_t *msg) {
 				fprintf(stderr, "JSON parse error: \"%s\"\n", sb->data);
 			}
 			nmsg_strbuf_reset(sb);
-			continue;
+			return (nmsg_res_again);
 		}
 
 		_nmsg_strbuf_destroy(&sbs);

--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -592,14 +592,9 @@ do_read_file(nmsg_input_t input, ssize_t bytes_needed, ssize_t bytes_max) {
 	assert((buf->end + bytes_max) <= (buf->data + NMSG_RBUFSZ));
 
 	while (bytes_needed > 0) {
-		/* make sure our input is valid and that we have nothing to read */
-		struct pollfd pfd = { .fd = buf->fd, .events = POLLIN };
-		int poll_res;
-		while ((poll_res = poll(&pfd, 1, NMSG_RBUF_TIMEOUT)) != 1) {
-			if (poll_res < 0 && errno != EINTR)
-				return (nmsg_res_read_failure);
-			return (nmsg_res_again);
-		}
+		nmsg_res poll_res = _input_can_read(buf->fd);
+		if (poll_res != nmsg_res_success)
+			return (poll_res);
 
 		bytes_read = read(buf->fd, buf->end, bytes_max);
 		if (bytes_read < 0)

--- a/nmsg/input_pres.c
+++ b/nmsg/input_pres.c
@@ -28,6 +28,10 @@ _input_pres_read(nmsg_input_t input, nmsg_message_t *msg) {
 	struct timespec ts;
 	uint8_t *pbuf;
 
+	nmsg_res poll_res = _input_can_read(fileno(input->pres->fp));
+	if (poll_res != nmsg_res_success)
+		return (poll_res);
+
 	while (fgets(line, sizeof(line), input->pres->fp) != NULL) {
 		res = nmsg_msgmod_pres_to_payload(input->msgmod, input->clos,
 						  line);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -580,6 +580,7 @@ size_t			_input_seqsrc_update(nmsg_input_t, struct nmsg_seqsrc *, Nmsg__Nmsg *);
 
 /* from input.c */
 nmsg_input_t 		_input_open_kafka(void *s);
+nmsg_res		_input_can_read(int fd);
 
 /* from output.c */
 void			_output_stop(nmsg_output_t);

--- a/tests/test-io.c
+++ b/tests/test-io.c
@@ -354,7 +354,14 @@ test_dummy(void)
 	c = nmsg_container_init(8192);
 	check_return(c != NULL);
 
-	while ((res = nmsg_input_read(ij, &m)) == nmsg_res_success) {
+	while (1) {
+		res = nmsg_input_read(ij, &m);
+
+		if (res == nmsg_res_again)
+			continue;
+		if (res != nmsg_res_success)
+			break;
+
 		n_ms++;
 		check_return(nmsg_container_add(c, m) == nmsg_res_success);
 	}


### PR DESCRIPTION
In MR #156, a bugfix was added to prevent NMSG inputs from blocking on SIGINT; this fix did not extend to JSON and Presentation inputs.  That has been fixed here, and the same reviewers of that MR have also been added here.

I have also verified that this bug does not occur with PCAP, ZMQ, and socket inputs.

**Note**: The original unit test `test-io/test_dummy()` would fail if the value returned from `nmsg_input_read()` (and by extension `_input_read_json()`) was not `nmsg_res_success` or `nmsg_res_eof`.  The ideal solution to this, as discussed by Stephen and I, is to adjust the unit test to call `nmsg_input_read()` again when `nmsg_res_again` is returned.  The intention is that this is a backwards-compatible change that conveys more information to the caller of `nmsg_input_read()`.