### PR TITLE
Test cleanup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -436,7 +436,8 @@ src_nmsgtool_SOURCES = \
 ##
 #
 
-TESTS_ENVIRONMENT = NMSG_MSGMOD_DIR=$(top_builddir)/nmsg/base/.libs
+TESTS_ENVIRONMENT = NMSG_MSGMOD_DIR=$(abs_top_builddir)/nmsg/base/.libs
+TESTS_ENVIRONMENT += abs_top_builddir='$(abs_top_builddir)' abs_top_srcdir='$(abs_top_srcdir)'
 
 EXTRA_DIST += tests/errors.h
 EXTRA_DIST += tests/generic-tests/dedupe.json
@@ -566,6 +567,7 @@ DISTCLEANFILES += tests/nmsg-dnsobs-tests/test*.out
 DISTCLEANFILES += tests/nmsg-dnsqr-tests/test*.out
 DISTCLEANFILES += tests/nmsg-dnstap-tests/test*.out
 DISTCLEANFILES += tests/nmsg-http-tests/test*.out
+DISTCLEANFILES += tests/testzmq.json
 
 #
 ##

--- a/tests/test-daemon.sh
+++ b/tests/test-daemon.sh
@@ -4,11 +4,10 @@
 # equivalent to the input file.  It also tests the PID functionality present
 # in daemon.c.
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-infile=$script_dir/generic-tests/lorem.nmsg
-outfile=/tmp/testdaemon.nmsg
-pidfile=/tmp/testdaemon.pid
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+infile=$abs_top_srcdir/tests/generic-tests/lorem.nmsg
+outfile=$abs_top_builddir/tests/testdaemon.nmsg
+pidfile=$abs_top_builddir/tests/testdaemon.pid
 retval=0
 
 check() {

--- a/tests/test-kicker.sh
+++ b/tests/test-kicker.sh
@@ -2,15 +2,15 @@
 
 # This test exercises the kicker script functionality by reading in sample data
 # containing 15 (defanged) ch202 entries and writing them each to a separate file
-# in a temporary directory.  For each file, we echo its name into test-kicker-json.out
+# in a temporary directory.  For each file, we echo its name into test-kicker.out
 # (followed by a newline), and remove it.  Once all files have been kicked
-# (resulting in 15 lines in test-kicker-json.out) the total line count must equal 15.
+# (resulting in 15 lines in test-kicker.out) the total line count must equal 15.
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-infile=$script_dir/generic-tests/lorem.json
-outdir=/tmp/test-kicker/ # This directory will get rm -rf'd; be careful!
-outfile=$outdir/test-kicker-json.out
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+infile=$abs_top_srcdir/tests/generic-tests/lorem.json
+outdir=$abs_top_builddir/tests/test-kicker/ # This directory will get rm -rf'd; be careful!
+outfile=$outdir/test-kicker.out
+# by using echo as the kicker the filenames are output one at a time to stdout
 kicker="echo"
 retval=0
 
@@ -27,8 +27,7 @@ echo "Testing kicker: "
 
 mkdir $outdir
 cd $outdir
-# If we don't set this, make check will be unable to find this directory!
-NMSG_MSGMOD_DIR=$script_dir/../nmsg/base/.libs
+NMSG_MSGMOD_DIR=${NMSG_MSGMOD_DIR:-$abs_top_builddir/nmsg/base/.libs}
 
 # Read input data with our kicked nmsgtools.
 $nmsgtool_test -ddddd -j $infile -c 1 -k "$kicker" > $outfile
@@ -36,8 +35,8 @@ $nmsgtool_test -ddddd -j $infile -c 1 -k "$kicker" > $outfile
 # Compare echo'd file count and actual file count with the desired file count.
 file_count=$(wc -l $outfile | awk '{print $1}')
 true_file_count=$(ls -1 $outdir | wc -l)
-[ "$file_count" -eq "15" ] && [ "$true_file_count" -eq "16" ] # 16 to account for json output file.
-check "comparison of kicked json output files"
+[ "$file_count" -eq "15" ] && [ "$true_file_count" -eq "16" ] # 16 to account for output file.
+check "comparison of kicked output files"
 
 # Remove kicked files from $outdir.
 while IFS= read -r line; do
@@ -47,7 +46,7 @@ done < $outfile
 # If every kicked filename was correctly written to the kicker file, then only
 # one file will be left in $outdir.
 file_count=$(ls -1 $outdir | wc -l)
-[ "$file_count" -eq "1" ] # 1 to account for the json kicker output file.
+[ "$file_count" -eq "1" ] # 1 to account for the kicker output file.
 check "file names in kicker output file match actual output filenames"
 
 # Clean-up!

--- a/tests/test-misc.c
+++ b/tests/test-misc.c
@@ -443,7 +443,7 @@ test_pcap_dnsqr(void)
 	io = nmsg_io_init();
 	check_return(io != NULL);
 
-	phandle = pcap_open_offline("./tests/generic-tests/dig_response.pcap", errbuf);
+	phandle = pcap_open_offline(SRCDIR "/tests/generic-tests/dig_response.pcap", errbuf);
 	check_return(phandle != NULL);
 
 	pcap = nmsg_pcap_input_open(phandle);
@@ -477,7 +477,7 @@ test_pcap(void)
 	io = nmsg_io_init();
 	check_return(io != NULL);
 
-	phandle = pcap_open_offline("./tests/generic-tests/http_response.pcap", errbuf);
+	phandle = pcap_open_offline(SRCDIR "/tests/generic-tests/http_response.pcap", errbuf);
 	check_return(phandle != NULL);
 
 	pcap = nmsg_pcap_input_open(phandle);
@@ -538,7 +538,7 @@ test_pcap_raw(void)
 	io = nmsg_io_init();
 	check_return(io != NULL);
 
-	phandle = pcap_open_offline("./tests/generic-tests/http_response.pcap", errbuf);
+	phandle = pcap_open_offline(SRCDIR "/tests/generic-tests/http_response.pcap", errbuf);
 	check_return(phandle != NULL);
 
 	pcap = nmsg_pcap_input_open(phandle);

--- a/tests/test-msgmod.sh
+++ b/tests/test-msgmod.sh
@@ -3,10 +3,10 @@
 # This test exercises various base message modules by writing them out to .json
 # files and comparing the number of entries.
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-indir=$script_dir/generic-tests/
-outdir=/tmp/test-msgmod/
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+indir=$abs_top_srcdir/tests/generic-tests/
+# this directory is created and removed:
+outdir=$abs_top_builddir/tests/test-msgmod/
 retval=0
 
 check() {
@@ -42,7 +42,7 @@ run_nmsgtools dnsqr dig_response.pcap 0
 export DNSQR_ZERO_RESOLVER_ADDRESS="1"
 export DNSQR_FILTER_QNAMES_INCLUDE="docusign.com."
 run_nmsgtools dnsqr dig_response.pcap 6
-zeroed_resolver_addresses=$(grep -o "\"resolver_address_zeroed\":true" /tmp/test-msgmod/test-dnsqr.json | wc -l)
+zeroed_resolver_addresses=$(grep -o "\"resolver_address_zeroed\":true" $abs_top_builddir/tests/test-msgmod/test-dnsqr.json | wc -l)
 [ "$zeroed_resolver_addresses" -eq "6" ]
 check "zeroed DNSQR resolver addresses"
 

--- a/tests/test-sample.sh
+++ b/tests/test-sample.sh
@@ -4,10 +4,12 @@
 # entries (see $file_entry_count), and we want 5 entries (see $desired_entry_count),
 # so we set $sample_entry_count to 3.  We then check to make sure 5 entries were output.
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-infile=$script_dir/generic-tests/lorem.json
-outfile=/tmp/testsample.json
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+infile=$abs_top_srcdir/tests/generic-tests/lorem.json
+outfile=$abs_top_builddir/tests/testsample.json
+NMSG_FLTMOD_VERSION=`awk '/^\#define NMSG_FLTMOD_VERSION/ { print $NF}' < $abs_top_srcdir/nmsg/fltmod_plugin.h`
+NMSG_MODULE_SUFFIX=`awk '/^\#define NMSG_MODULE_SUFFIX/ { print $NF}' < $abs_top_srcdir/nmsg/private.h | tr -d '"'`
+MODULE_PATHNAME=$abs_top_builddir/fltmod/.libs/nmsg_flt${NMSG_FLTMOD_VERSION}_sample${NMSG_MODULE_SUFFIX}
 retval=0
 
 # Our input file has 15 entries, and we want 5 entries to be output.  The sample
@@ -29,7 +31,7 @@ check() {
 echo "Testing sample filter: "
 
 # Create a listener and a writer on the same socket.
-$nmsgtool_test -ddddd -F sample,"count=$sample_entry_count" -j $infile -J $outfile
+$nmsgtool_test -ddddd -F ${MODULE_PATHNAME},"count=$sample_entry_count" -j $infile -J $outfile
 
 # Verify that the number of entries output is correct.
 line_count=$(wc -l $outfile | awk '{print $1}')

--- a/tests/test-socket-frag.sh
+++ b/tests/test-socket-frag.sh
@@ -5,11 +5,10 @@
 # DNSSEC query/response over the socket.  If fragmentation is successful, we will
 # have an identical file on the other side!
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-infile=$script_dir/generic-tests/dnssec.pcap
-outfile_frag=/tmp/testfrag.sock.pres
-outfile=/tmp/testfrag.pres
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+infile=$abs_top_srcdir/tests/generic-tests/dnssec.pcap
+outfile_frag=$abs_top_builddir/tests/testfrag.sock.pres
+outfile=$abs_top_builddir/tests/testfrag.pres
 sockaddr=127.0.0.1/8080
 entry_count=1
 retval=0

--- a/tests/test-zmq-endpoints.sh
+++ b/tests/test-zmq-endpoints.sh
@@ -5,11 +5,10 @@
 # is listening on.  If, at the end of the test, we do not have the correct
 # number of entries in the listener's output file, then we fail.
 
-script_dir=$(cd $(dirname "$0") && pwd) # Will be [somedir]/nmsg/tests/
-nmsgtool_test=$script_dir/../src/nmsgtool
-infile=$script_dir/generic-tests/lorem.nmsg
-outfile=/tmp/testzmq.json
-sock=/tmp/testzmq.sock
+nmsgtool_test=$abs_top_builddir/src/nmsgtool
+infile=$abs_top_srcdir/tests/generic-tests/lorem.nmsg
+outfile=$abs_top_builddir/tests/testzmq.json
+sock=$abs_top_builddir/tests/testzmq.sock
 entry_count=15
 retval=0
 
@@ -27,7 +26,7 @@ echo "Testing ZMQ socket connection: "
 # Create a listener and a writer on the same socket.
 $nmsgtool_test -ddddd --unbuffered -J $outfile -L ipc://$sock,pushpull,connect &
 listener_pid=$!
-$nmsgtool_test -ddddd --unbuffered -r $infile -S ipc:///tmp/testzmq.sock,pushpull,accept &
+$nmsgtool_test -ddddd --unbuffered -r $infile -S ipc://$sock,pushpull,accept &
 writer_pid=$!
 echo Listening PID: $listener_pid, writing PID: $writer_pid
 


### PR DESCRIPTION
Fix newer tests that were using /tmp and relative code references to instead use absolute srcdir and builddir.