### PR TITLE
Adjust debug log levels for Kafka

### DIFF
--- a/doc/docbook/nmsgtool.1
+++ b/doc/docbook/nmsgtool.1
@@ -143,6 +143,9 @@ Increment debugging level\&.
 is verbose and
 \fB\-dddd\fR
 is very verbose\&.
+If the
+\fBNMSG_KAFKA_LOG_LEVEL\fR
+environment variable is set and a Kafka input/output is used, Kafka will log non-errors at the specified logging level\&.
 .RE
 .PP
 \fB\-v\fR \fIversion\fR

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -111,7 +111,10 @@
         <term><option>--debug</option></term>
         <listitem>
           <para>Increment debugging level. <option>-dd</option> is
-          verbose and <option>-dddd</option> is very verbose.</para>
+          verbose and <option>-dddd</option> is very verbose. If
+          the <envar>NMSG_KAFKA_LOG_LEVEL</envar> environment
+          variable is set and a Kafka input/output is used, Kafka will
+          log non-errors at the specified logging level</para>.
         </listitem>
       </varlistentry>
 


### PR DESCRIPTION
- Adjust debug log levels for Kafka to improve debug-ability.
- Add `NMSG_KAFKA_FULL_LOGGING` to log all messages sent to the Kafka logging callback.
- Recommend `-d` for deployed `nmsgtool` instances.