### PR TITLE
nmsg --readpres hang for base email and logline and linkpair

### DIFF
--- a/doc/docbook/nmsgtool.1
+++ b/doc/docbook/nmsgtool.1
@@ -355,17 +355,6 @@ environment variable\&.
 Read NMSG payloads from a file\&.
 .RE
 .PP
-\fB\-f\fR \fIfile\fR, \fB\-\-readpres\fR \fIfile\fR
-.RS 4
-Read presentation format data from a file and convert to NMSG payloads\&. This option is dependent on the
-\fB\-V\fR
-and
-\fB\-T\fR
-options being set in order to select a specific nmsgpb module to perform presentation format to NMSG payload conversion\&. Not all nmsgpb modules necessarily support this conversion method, in which case
-\fBnmsgtool\fR
-will print a "function not implemented" message\&.
-.RE
-.PP
 \fB\-j\fR \fIfile\fR, \fB\-\-readjson\fR \fIfile\fR
 .RS 4
 Read JSON format data from a file\&. See documentation for

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -402,21 +402,6 @@
       </varlistentry>
 
       <varlistentry>
-        <term><option>-f</option> <replaceable>file</replaceable></term>
-        <term><option>--readpres</option> <replaceable>file</replaceable></term>
-        <listitem>
-          <para>Read presentation format data from a file and convert
-          to NMSG payloads. This option is dependent on the
-          <option>-V</option> and <option>-T</option> options being
-          set in order to select a specific nmsgpb module to perform
-          presentation format to NMSG payload conversion. Not all nmsgpb
-          modules necessarily support this conversion method, in which
-          case <command>nmsgtool</command> will print a "function not
-          implemented" message.</para>
-        </listitem>
-      </varlistentry>
-
-      <varlistentry>
         <term><option>-j</option> <replaceable>file</replaceable></term>
         <term><option>--readjson</option> <replaceable>file</replaceable></term>
         <listitem>

--- a/nmsg/strbuf.c
+++ b/nmsg/strbuf.c
@@ -69,10 +69,9 @@ _nmsg_strbuf_expand(struct nmsg_strbuf *sb, size_t len) {
 	ssize_t avail = _nmsg_strbuf_avail(sb);
 	assert(avail >= 0);
 
-	/* increase buffer size if necessary */
 	if (needed > avail) {
 		size_t offset = sb->pos - sb->data;
-		ssize_t new_bufsz = 2 * sb->bufsz;
+		ssize_t new_bufsz = 2 * (sb->bufsz == 0 ? 1 : sb->bufsz);
 		void *ptr;
 
 		while (new_bufsz - (ssize_t) sb->bufsz < needed) {

--- a/src/io.c
+++ b/src/io.c
@@ -693,24 +693,6 @@ add_pcapif_input(nmsgtool_ctx *c, nmsg_msgmod_t mod, const char *arg) {
 }
 
 void
-add_pres_input(nmsgtool_ctx *c, nmsg_msgmod_t mod, const char *fname) {
-	nmsg_input_t input;
-	nmsg_res res;
-
-	input = nmsg_input_open_pres(open_rfile(fname), mod);
-	res = nmsg_io_add_input(c->io, input, NULL);
-	if (res != nmsg_res_success) {
-		fprintf(stderr, "%s: nmsg_io_add_input() failed\n",
-			argv_program);
-		exit(1);
-	}
-	if (c->debug >= 2)
-		fprintf(stderr, "%s: nmsg pres input: %s\n", argv_program,
-			fname);
-	c->n_inputs += 1;
-}
-
-void
 add_pres_output(nmsgtool_ctx *c, const char *fname) {
 	nmsg_output_t output;
 	nmsg_res res;

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -78,12 +78,6 @@ static argv_t args[] = {
 		"endline",
 		"continuation separator" },
 
-	{ 'f', "readpres",
-		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
-		&ctx.r_pres,
-		"file",
-		"read pres format data from file" },
-
 	{ 'F',	"filter",
 		ARGV_CHAR_P | ARGV_FLAG_ARRAY,
 		&ctx.filters,

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -53,7 +53,7 @@ VECTOR_GENERATE(statsmod_vec, nmsg_statsmod_t)
 typedef struct {
 	/* parameters */
 	argv_array_t	filters, statsmods;
-	argv_array_t	r_nmsg, r_pres, r_kafka, r_sock, r_zsock, r_channel, r_zchannel, r_json;
+	argv_array_t	r_nmsg, r_kafka, r_sock, r_zsock, r_channel, r_zchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_kafka, w_zsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
@@ -125,7 +125,6 @@ void add_file_input(nmsgtool_ctx *, const char *);
 void add_file_output(nmsgtool_ctx *, const char *);
 void add_pcapfile_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
 void add_pcapif_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
-void add_pres_input(nmsgtool_ctx *, nmsg_msgmod_t, const char *);
 void add_pres_output(nmsgtool_ctx *, const char *);
 void add_json_input(nmsgtool_ctx *, const char *);
 void add_json_output(nmsgtool_ctx *, const char *);

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -263,13 +263,11 @@ process_args(nmsgtool_ctx *c) {
 	}
 
 	/* -V, -T sanity check */
-	if (ARGV_ARRAY_COUNT(c->r_pres) > 0 ||
-	    ARGV_ARRAY_COUNT(c->r_pcapfile) > 0 ||
+	if (ARGV_ARRAY_COUNT(c->r_pcapfile) > 0 ||
 	    ARGV_ARRAY_COUNT(c->r_pcapif) > 0)
 	{
 		if (c->vname == NULL || c->mname == NULL)
-			usage("reading presentation or pcap data requires "
-			      "-V, -T");
+			usage("reading pcap data requires -V, -T");
 		mod = nmsg_msgmod_lookup(c->vid, c->msgtype);
 		if (mod == NULL)
 			usage("unknown msgmod");
@@ -368,8 +366,7 @@ process_args(nmsgtool_ctx *c) {
 		nmsg_chalias_free(&alias);
 	}
 
-	/* pres inputs and outputs */
-	process_args_loop_mod(c->r_pres, add_pres_input, mod);
+	/* pres outputs */
 	process_args_loop(c->w_pres, add_pres_output);
 
 	/* json inputs and outputs */

--- a/tests/nmsg-dns-tests/test.sh.in
+++ b/tests/nmsg-dns-tests/test.sh.in
@@ -76,8 +76,6 @@ check read json base:dns and create json output
 cmp -s @abs_top_srcdir@/tests/nmsg-dns-tests/test2-dns.json @abs_top_builddir@/tests/nmsg-dns-tests/test2-dns.json.json.out
 check json-to-json
 
-# NOTE: --readpres is not fully implemented for base:dns so aborts
-
 # JSON input mistakes should result in no output
 $NMSGTOOL -dd -j @abs_top_srcdir@/tests/nmsg-dns-tests/test3-dns.json --writepres @abs_top_builddir@/tests/nmsg-dns-tests/test3-dns.json.pres.out 2>@abs_top_builddir@/tests/nmsg-dns-tests/test3-dns.json.pres.stderr.out
 check read broken json base:dns and create empty output

--- a/tests/nmsg-dnsobs-tests/test.sh.in
+++ b/tests/nmsg-dnsobs-tests/test.sh.in
@@ -54,6 +54,4 @@ check read json base:dnsobs and create base:dnsobs json output
 cmp -s ${SOURCE}.json ${OUTPUT}.json.json.out
 check json-to-json
 
-# NOTE: --readpres is not fully implemented for base:dnsobs
-
 exit $status

--- a/tests/nmsg-dnsqr-tests/test.sh.in
+++ b/tests/nmsg-dnsqr-tests/test.sh.in
@@ -84,6 +84,4 @@ check read nmsg base:dnsqr and generate pcap output using example
 cmp -s ${SOURCE}.pcap ${OUTPUT}.nmsg.pcap.out
 check example-nmsg-to-pcap
 
-# NOTE: --readpres is not fully implemented for base:dnsqr so aborts
-
 exit $status

--- a/tests/nmsg-dnstap-tests/test.sh.in
+++ b/tests/nmsg-dnstap-tests/test.sh.in
@@ -57,6 +57,5 @@ cmp -s ${SOURCE}.json ${OUTPUT}.nmsg.json.out
 check nmsg-to-json
 
 # NOTE: --readjson for base:dnstap is incomplete
-# NOTE: --readpres is not fully implemented for base:dnstap
 
 exit $status

--- a/tests/nmsg-http-tests/test.sh.in
+++ b/tests/nmsg-http-tests/test.sh.in
@@ -136,6 +136,4 @@ check read json base:http and create base:http json output
 cmp -s ${SOURCE}/test4-http-no-request.json ${OUTPUT}/test4-http.json.json.out
 check json-to-json
 
-# NOTE: --readpres is not implemented for base:http
-
 exit $status


### PR DESCRIPTION
This PR removes the `readpres` option.