### PR TITLE
Handle fragmented containers in zmq, kafka inputs

### DIFF
--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -390,7 +390,7 @@ _input_process_buffer_into_container(nmsg_input_t input, Nmsg__Nmsg **nmsg, uint
 	/* expire old outstanding fragments */
 	_input_frag_gc(input->stream);
 
-	return nmsg_res_success;
+	return (res);
 }
 #endif /* defined(HAVE_LIBRDKAFKA) || defined(HAVE_LIBZMQ) */
 


### PR DESCRIPTION
Fixes a segfault when consuming NMSG container data over kafka.

The function `_input_process_buffer_into_container` can return `nmsg_res_success` with a NULL `nmsg`, later dereferenced based on the `nmsg_res_success` return value.  This PR propagates a non-success return from `_input_nmsg_unpack_container`, `nmsg_res_again` in the case of fragmentation.

