### PR TITLE
cgo-nmsg sometimes segfaults during automated package build/testing

### DIFF
--- a/nmsg/input_nmsg.c
+++ b/nmsg/input_nmsg.c
@@ -390,7 +390,7 @@ _input_process_buffer_into_container(nmsg_input_t input, Nmsg__Nmsg **nmsg, uint
 	/* expire old outstanding fragments */
 	_input_frag_gc(input->stream);
 
-	return nmsg_res_success;
+	return res;
 }
 #endif /* defined(HAVE_LIBRDKAFKA) || defined(HAVE_LIBZMQ) */
 


### PR DESCRIPTION
I found this small issue while investigating the cgo-nmsg segfault we've been seeing in unit tests. The issue is that `_input_frag_read()` was returning `nmsg_res_again`, but that return value was being over written with `nmsg_res_success`, instead of being propagated back through the stack.