### PR TITLE
feat: better compression bandwidth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,5 +72,3 @@ tests/testzmq.json
 tests/testzmq.sock
 tests/*/*.out
 tests/*/test.sh
-.clang-format
-.clangd

--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ tests/test-io
 tests/test-misc
 tests/test-parse
 tests/test-private
+tests/test-zpool-cull
 tests/test-zpool-mt
 tests/test-zpool-order
 tests/testzmq.json

--- a/.gitignore
+++ b/.gitignore
@@ -65,5 +65,11 @@ tests/test-io
 tests/test-misc
 tests/test-parse
 tests/test-private
+tests/test-zpool-mt
+tests/test-zpool-order
+tests/testzmq.json
+tests/testzmq.sock
 tests/*/*.out
 tests/*/test.sh
+.clang-format
+.clangd

--- a/Makefile.am
+++ b/Makefile.am
@@ -579,8 +579,12 @@ tests_test_zpool_order_SOURCES = tests/test-zpool-order.c
 
 TESTS += tests/test-zpool-mt
 check_PROGRAMS += tests/test-zpool-mt
+tests_test_zpool_mt_LDFLAGS = -rdynamic
+tests_test_zpool_mt_LDADD = \
+	$(PRIVATE_TEST_MODULES) \
+	nmsg/nmsg.pb-c.o \
+	$(LIBNMSG_LIB_DEPS)
 tests_test_zpool_mt_SOURCES = tests/test-zpool-mt.c
-tests_test_zpool_mt_LDADD = nmsg/libnmsg.la
 
 TESTS += tests/test-zpool-cull
 check_PROGRAMS += tests/test-zpool-cull

--- a/Makefile.am
+++ b/Makefile.am
@@ -216,8 +216,8 @@ LIBNMSG_LIB_MODULES = \
 	nmsg/msgmodset.c \
 	nmsg/nmsg.c \
 	nmsg/output.c \
-	nmsg/output_json.c \
 	nmsg/output_async.c \
+	nmsg/output_json.c \
 	nmsg/output_nmsg.c \
 	nmsg/output_pres.c \
 	nmsg/payload.c \
@@ -245,6 +245,7 @@ LIBNMSG_LIB_MODULES = \
 nmsg_libnmsg_la_SOURCES = \
 	libmy/crc32c.h \
 	libmy/list.h \
+	libmy/my_cpu.h \
 	libmy/my_time.h \
 	libmy/my_rate.h \
 	libmy/tree.h \
@@ -420,6 +421,7 @@ src_nmsgtool_SOURCES = \
 	libmy/argv.c \
 	libmy/argv.h \
 	libmy/argv_loc.h \
+	libmy/my_cpu.h \
 	src/daemon.c \
 	src/getsock.c \
 	src/io.c \
@@ -436,6 +438,11 @@ src_nmsgtool_SOURCES = \
 ### Tests
 ##
 #
+
+# Tests that reach private symbols link the objects: libnmsg.la exports
+# nmsg_* only, and the dlopened base msgmod resolves its own from the
+# executable, which is what -rdynamic is for.
+PRIVATE_TEST_MODULES = $(LIBNMSG_LIB_MODULES:.c=.o)
 
 TESTS_ENVIRONMENT = NMSG_MSGMOD_DIR=$(abs_top_builddir)/nmsg/base/.libs
 TESTS_ENVIRONMENT += abs_top_builddir='$(abs_top_builddir)' abs_top_srcdir='$(abs_top_srcdir)'
@@ -538,7 +545,6 @@ TESTS += tests/test-private
 check_PROGRAMS += tests/test-private
 tests_test_private_LDFLAGS = -rdynamic
 tests_test_private_CPPFLAGS = -DSRCDIR="\"$(abs_srcdir)\"" $(AM_CPPFLAGS)
-PRIVATE_TEST_MODULES = $(LIBNMSG_LIB_MODULES:.c=.o)
 tests_test_private_LDADD = \
 	$(PRIVATE_TEST_MODULES) \
 	nmsg/nmsg.pb-c.o \
@@ -564,8 +570,12 @@ tests_test_nmsg_output_set_rate_LDADD = nmsg/libnmsg.la
 
 TESTS += tests/test-zpool-order
 check_PROGRAMS += tests/test-zpool-order
+tests_test_zpool_order_LDFLAGS = -rdynamic
+tests_test_zpool_order_LDADD = \
+	$(PRIVATE_TEST_MODULES) \
+	nmsg/nmsg.pb-c.o \
+	$(LIBNMSG_LIB_DEPS)
 tests_test_zpool_order_SOURCES = tests/test-zpool-order.c
-tests_test_zpool_order_LDADD = nmsg/libnmsg.la
 
 TESTS += tests/test-zpool-mt
 check_PROGRAMS += tests/test-zpool-mt
@@ -575,7 +585,6 @@ tests_test_zpool_mt_LDADD = nmsg/libnmsg.la
 TESTS += tests/test-zpool-cull
 check_PROGRAMS += tests/test-zpool-cull
 tests_test_zpool_cull_LDFLAGS = -rdynamic
-tests_test_zpool_cull_CPPFLAGS = -DSRCDIR="\"$(abs_srcdir)\"" $(AM_CPPFLAGS)
 tests_test_zpool_cull_LDADD = \
 	$(PRIVATE_TEST_MODULES) \
 	nmsg/nmsg.pb-c.o \

--- a/Makefile.am
+++ b/Makefile.am
@@ -572,6 +572,16 @@ check_PROGRAMS += tests/test-zpool-mt
 tests_test_zpool_mt_SOURCES = tests/test-zpool-mt.c
 tests_test_zpool_mt_LDADD = nmsg/libnmsg.la
 
+TESTS += tests/test-zpool-cull
+check_PROGRAMS += tests/test-zpool-cull
+tests_test_zpool_cull_LDFLAGS = -rdynamic
+tests_test_zpool_cull_CPPFLAGS = -DSRCDIR="\"$(abs_srcdir)\"" $(AM_CPPFLAGS)
+tests_test_zpool_cull_LDADD = \
+	$(PRIVATE_TEST_MODULES) \
+	nmsg/nmsg.pb-c.o \
+	$(LIBNMSG_LIB_DEPS)
+tests_test_zpool_cull_SOURCES = tests/test-zpool-cull.c
+
 DISTCLEANFILES += tests/group-operator-source-tests/test*.out
 DISTCLEANFILES += tests/nmsg-dns-tests/test*.out
 DISTCLEANFILES += tests/nmsg-dnsobs-tests/test*.out

--- a/Makefile.am
+++ b/Makefile.am
@@ -217,6 +217,7 @@ LIBNMSG_LIB_MODULES = \
 	nmsg/nmsg.c \
 	nmsg/output.c \
 	nmsg/output_json.c \
+	nmsg/output_async.c \
 	nmsg/output_nmsg.c \
 	nmsg/output_pres.c \
 	nmsg/payload.c \
@@ -560,6 +561,16 @@ TESTS += tests/test-nmsg_output_set_rate
 check_PROGRAMS += tests/test-nmsg_output_set_rate
 tests_test_nmsg_output_set_rate_SOURCES = tests/test-nmsg_output_set_rate.c
 tests_test_nmsg_output_set_rate_LDADD = nmsg/libnmsg.la
+
+TESTS += tests/test-zpool-order
+check_PROGRAMS += tests/test-zpool-order
+tests_test_zpool_order_SOURCES = tests/test-zpool-order.c
+tests_test_zpool_order_LDADD = nmsg/libnmsg.la
+
+TESTS += tests/test-zpool-mt
+check_PROGRAMS += tests/test-zpool-mt
+tests_test_zpool_mt_SOURCES = tests/test-zpool-mt.c
+tests_test_zpool_mt_LDADD = nmsg/libnmsg.la
 
 DISTCLEANFILES += tests/group-operator-source-tests/test*.out
 DISTCLEANFILES += tests/nmsg-dns-tests/test*.out

--- a/configure.ac
+++ b/configure.ac
@@ -96,6 +96,9 @@ AC_CHECK_FUNCS([clock_gettime])
 AC_SEARCH_LIBS([clock_nanosleep], [rt])
 AC_CHECK_FUNCS([clock_nanosleep])
 
+AC_SEARCH_LIBS([pthread_condattr_setclock], [pthread])
+AC_CHECK_FUNCS([pthread_condattr_setclock])
+
 AC_SEARCH_LIBS([dlopen], [dl])
 AC_CHECK_FUNCS([dlopen])
 

--- a/debian/libnmsg8.symbols
+++ b/debian/libnmsg8.symbols
@@ -148,6 +148,7 @@ libnmsg.so.8 libnmsg8 #MINVER#
  nmsg_output_set_operator@Base 0.5.0
  nmsg_output_set_rate@Base 0.5.0
  nmsg_output_set_source@Base 0.5.0
+ nmsg_output_set_zlib_cull@Base 1.4.0
  nmsg_output_set_zlib_workers@Base 1.4.0
  nmsg_output_set_zlibout@Base 0.5.0
  nmsg_output_write@Base 0.11.1

--- a/debian/libnmsg8.symbols
+++ b/debian/libnmsg8.symbols
@@ -148,8 +148,7 @@ libnmsg.so.8 libnmsg8 #MINVER#
  nmsg_output_set_operator@Base 0.5.0
  nmsg_output_set_rate@Base 0.5.0
  nmsg_output_set_source@Base 0.5.0
- nmsg_output_set_zlib_async@Base 0.5.0
- nmsg_output_set_zlib_workers@Base 0.5.0
+ nmsg_output_set_zlib_workers@Base 1.4.0
  nmsg_output_set_zlibout@Base 0.5.0
  nmsg_output_write@Base 0.11.1
  nmsg_pcap_filter@Base 0.6.5

--- a/debian/libnmsg8.symbols
+++ b/debian/libnmsg8.symbols
@@ -148,6 +148,8 @@ libnmsg.so.8 libnmsg8 #MINVER#
  nmsg_output_set_operator@Base 0.5.0
  nmsg_output_set_rate@Base 0.5.0
  nmsg_output_set_source@Base 0.5.0
+ nmsg_output_set_zlib_async@Base 0.5.0
+ nmsg_output_set_zlib_workers@Base 0.5.0
  nmsg_output_set_zlibout@Base 0.5.0
  nmsg_output_write@Base 0.11.1
  nmsg_pcap_filter@Base 0.6.5

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -657,6 +657,46 @@
       </varlistentry>
 
       <varlistentry>
+        <term><option>--zasync</option> <replaceable>n</replaceable></term>
+        <listitem>
+          <para>Compress written NMSG containers on
+          <replaceable>n</replaceable> separate threads rather than on
+          the thread that filled them. A thread that is compressing is
+          not reading its socket, and on a high volume channel that
+          pause is long enough for the kernel receive queue to
+          overflow; handing the container to a compressor lets the
+          reader carry straight on.</para>
+
+          <para>A value of <option>-1</option> chooses a thread count:
+          two per input socket, since a reader thread can saturate
+          roughly one core compressing, bounded by the cores the
+          readers leave spare and never fewer than four, because a
+          single socket can carry several cores' worth on its own.
+          Sizing it exactly is not important, because
+          a reader that finds every compressor busy compresses the
+          container itself, exactly as it would with this option
+          unset. Too small a pool therefore degrades to the behaviour
+          of no pool at all rather than stalling, and neither setting
+          is slower than leaving the option off.</para>
+
+          <para>This is worth using when a single input socket carries
+          more data than one core can compress. A channel spread over
+          a range of ports already compresses on every reader thread
+          and gains little; it also costs a little output size there,
+          because readers that never pause interleave their sources
+          more finely within a container, which compresses slightly
+          worse. With a single input socket the output is byte for
+          byte identical to compressing inline, whatever
+          <replaceable>n</replaceable> is.</para>
+
+          <para>Containers are always written in the order they were
+          filled. Applies to file (<option>-w</option>) outputs only,
+          and has no effect with
+          <option>--unbuffered</option>.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
         <term><option>--mirror</option></term>
         <listitem>
           <para>Mirror NMSG payloads across data outputs. By default

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -670,9 +670,11 @@
           <para><replaceable>n</replaceable> is a ceiling rather than
           a thread count: compressors are started only as load calls
           for them, so an output that never saturates never pays for
-          them. Values above twice the number of cores available to
-          the process are rejected, and a further internal limit
-          applies.</para>
+          them. Compression is CPU-bound, so a thread per core is as
+          far as it can help: values above the number of cores
+          available to the process are rejected, and libnmsg applies
+          the same rule slightly tighter, since the buffer that feeds
+          the compressors is sized from their number.</para>
 
           <para>A value of <option>-1</option> chooses the ceiling:
           two per input, since a reader thread can saturate roughly

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -667,28 +667,29 @@
           overflow; handing the container to a compressor lets the
           reader carry straight on.</para>
 
-          <para><replaceable>n</replaceable> is a ceiling rather than
-          a thread count: compressors are started only as load calls
-          for them, and given back once they go idle, so an output
-          that never saturates never pays for them. See
-          <option>--zcull</option> and <option>--zmin</option>. Compression is CPU-bound, so a thread per core is as
-          far as it can help: values above the number of cores
-          available to the process are rejected, and libnmsg applies
-          the same rule slightly tighter, since the buffer that feeds
-          the compressors is sized from their number.</para>
+          <para>Off by default. <replaceable>n</replaceable> is a
+          ceiling rather than a thread count: compressors start only as
+          load calls for them and are given back once idle, so an
+          output that never saturates never pays for them. See
+          <option>--zcull</option> and <option>--zmin</option>.
+          Compression is CPU-bound, so a thread per core is as far as
+          it can help; values above the cores available to the process
+          are rejected.</para>
 
-          <para>A value of <option>-1</option> chooses the ceiling:
-          two per input, since a reader thread can saturate roughly
-          one core compressing, bounded by the cores the readers leave
-          spare, never fewer than four because a single input can
-          carry several cores' worth on its own, and then divided
-          across the file outputs, which each get their own pool and
-          share the same cores. Sizing it exactly is not important,
-          because a reader that finds every compressor busy compresses
-          the container itself, exactly as it would with this option
-          unset. Too small a pool therefore degrades to the behaviour
-          of no pool at all rather than stalling, and neither setting
-          is slower than leaving the option off.</para>
+          <para>A value of <option>-1</option> chooses the ceiling: two
+          per input, split across the file outputs, which each get
+          their own pool and share the same cores, then bounded by the
+          cores the readers leave spare. An output gets at least four
+          regardless, since a single input can carry several cores'
+          worth on its own, and never more than the core count. Sizing
+          it exactly is not important: a reader that finds every
+          compressor busy compresses the container itself, so too small
+          a pool costs nothing beyond the pool being idle.</para>
+
+          <para>The cores counted are those in the process affinity
+          mask, which does not reflect a cgroup CPU quota; under a
+          container runtime that caps CPU rather than pinning it, pass
+          <replaceable>n</replaceable> explicitly.</para>
 
           <para>This is worth using when a single input carries more
           data than one core can compress, and on file-to-file work
@@ -701,9 +702,15 @@
           identical to compressing inline, whatever
           <replaceable>n</replaceable> is.</para>
 
+          <para>Compression itself still needs <option>-z</option>;
+          without it a compressor only takes the serializing off the
+          reader. A pool holds a serialized container per queued
+          ticket, so it can add tens of megabytes of buffering to an
+          output.</para>
+
           <para>Containers are always written in the order they were
           filled. Applies to file (<option>-w</option>) outputs only,
-          and has no effect with
+          and cannot be combined with
           <option>--unbuffered</option>.</para>
         </listitem>
       </varlistentry>
@@ -716,12 +723,12 @@
           value of <option>0</option> never gives one up, leaving a
           pool at the largest it ever needed to be.</para>
 
-          <para>Containers go to the compressor used most recently, so
-          a pool that grew for a burst keeps the front of that order
-          busy and lets the rest fall quiet. The pool grows again on
-          demand, exactly as it did the first time, and a compressor
-          only ever leaves when it is holding nothing, so the output
-          is unaffected either way.</para>
+          <para>Containers always go to the lowest-numbered free
+          compressor, so a pool that grew for a burst keeps the first
+          few busy and lets the rest fall quiet. The pool grows again
+          on demand, exactly as it did the first time, and a
+          compressor only ever leaves when it is holding nothing, so
+          the output is unaffected either way.</para>
 
           <para>This matters mainly for a long-running output that is
           not being rotated: an output closed by <option>-t</option>
@@ -742,8 +749,9 @@
           number of threads to start: compressors are still started
           only on demand, so an output that has never been busy is
           running none of them whatever this is set to. A value above
-          the ceiling in force is lowered to it, which is reported at
-          <option>-dd</option>.</para>
+          an explicit <option>--zasync</option> is rejected; under
+          <option>--zasync -1</option> it is lowered to the ceiling
+          chosen, which is reported at <option>-dd</option>.</para>
 
           <para>One thread per file output is not culled in any case:
           the thread that does the writing is not a compressor.</para>

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -667,26 +667,35 @@
           overflow; handing the container to a compressor lets the
           reader carry straight on.</para>
 
-          <para>A value of <option>-1</option> chooses a thread count:
-          two per input socket, since a reader thread can saturate
-          roughly one core compressing, bounded by the cores the
-          readers leave spare and never fewer than four, because a
-          single socket can carry several cores' worth on its own.
-          Sizing it exactly is not important, because
-          a reader that finds every compressor busy compresses the
-          container itself, exactly as it would with this option
+          <para><replaceable>n</replaceable> is a ceiling rather than
+          a thread count: compressors are started only as load calls
+          for them, so an output that never saturates never pays for
+          them. Values above twice the number of cores available to
+          the process are rejected, and a further internal limit
+          applies.</para>
+
+          <para>A value of <option>-1</option> chooses the ceiling:
+          two per input, since a reader thread can saturate roughly
+          one core compressing, bounded by the cores the readers leave
+          spare, never fewer than four because a single input can
+          carry several cores' worth on its own, and then divided
+          across the file outputs, which each get their own pool and
+          share the same cores. Sizing it exactly is not important,
+          because a reader that finds every compressor busy compresses
+          the container itself, exactly as it would with this option
           unset. Too small a pool therefore degrades to the behaviour
           of no pool at all rather than stalling, and neither setting
           is slower than leaving the option off.</para>
 
-          <para>This is worth using when a single input socket carries
-          more data than one core can compress. A channel spread over
-          a range of ports already compresses on every reader thread
-          and gains little; it also costs a little output size there,
+          <para>This is worth using when a single input carries more
+          data than one core can compress, and on file-to-file work
+          such as recompressing a capture. A channel spread over a
+          range of ports already compresses on every reader thread and
+          gains little; it also costs a little output size there,
           because readers that never pause interleave their sources
           more finely within a container, which compresses slightly
-          worse. With a single input socket the output is byte for
-          byte identical to compressing inline, whatever
+          worse. With a single input the output is byte for byte
+          identical to compressing inline, whatever
           <replaceable>n</replaceable> is.</para>
 
           <para>Containers are always written in the order they were

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -669,8 +669,9 @@
 
           <para><replaceable>n</replaceable> is a ceiling rather than
           a thread count: compressors are started only as load calls
-          for them, so an output that never saturates never pays for
-          them. Compression is CPU-bound, so a thread per core is as
+          for them, and given back once they go idle, so an output
+          that never saturates never pays for them. See
+          <option>--zcull</option> and <option>--zmin</option>. Compression is CPU-bound, so a thread per core is as
           far as it can help: values above the number of cores
           available to the process are rejected, and libnmsg applies
           the same rule slightly tighter, since the buffer that feeds
@@ -704,6 +705,48 @@
           filled. Applies to file (<option>-w</option>) outputs only,
           and has no effect with
           <option>--unbuffered</option>.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--zcull</option> <replaceable>secs</replaceable></term>
+        <listitem>
+          <para>Give up a compressor thread that has been idle for
+          <replaceable>secs</replaceable> seconds, 300 by default. A
+          value of <option>0</option> never gives one up, leaving a
+          pool at the largest it ever needed to be.</para>
+
+          <para>Containers go to the compressor used most recently, so
+          a pool that grew for a burst keeps the front of that order
+          busy and lets the rest fall quiet. The pool grows again on
+          demand, exactly as it did the first time, and a compressor
+          only ever leaves when it is holding nothing, so the output
+          is unaffected either way.</para>
+
+          <para>This matters mainly for a long-running output that is
+          not being rotated: an output closed by <option>-t</option>
+          or <option>-k</option> gives its whole pool back at every
+          close regardless.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>--zmin</option> <replaceable>n</replaceable></term>
+        <listitem>
+          <para>Never let <option>--zcull</option> take an output
+          below <replaceable>n</replaceable> compressor threads, 1 by
+          default. A value of <option>0</option> lets the pool empty
+          completely.</para>
+
+          <para>This is a floor on what culling may take away, not a
+          number of threads to start: compressors are still started
+          only on demand, so an output that has never been busy is
+          running none of them whatever this is set to. A value above
+          the ceiling in force is lowered to it, which is reported at
+          <option>-dd</option>.</para>
+
+          <para>One thread per file output is not culled in any case:
+          the thread that does the writing is not a compressor.</para>
         </listitem>
       </varlistentry>
 

--- a/doc/docbook/nmsgtool.docbook
+++ b/doc/docbook/nmsgtool.docbook
@@ -664,54 +664,36 @@
           the thread that filled them. A thread that is compressing is
           not reading its socket, and on a high volume channel that
           pause is long enough for the kernel receive queue to
-          overflow; handing the container to a compressor lets the
-          reader carry straight on.</para>
+          overflow.</para>
 
           <para>Off by default. <replaceable>n</replaceable> is a
           ceiling rather than a thread count: compressors start only as
           load calls for them and are given back once idle, so an
           output that never saturates never pays for them. See
           <option>--zcull</option> and <option>--zmin</option>.
-          Compression is CPU-bound, so a thread per core is as far as
-          it can help; values above the cores available to the process
-          are rejected.</para>
+          Compression is CPU-bound, so values above the cores available
+          to the process are rejected.</para>
 
           <para>A value of <option>-1</option> chooses the ceiling: two
-          per input, split across the file outputs, which each get
-          their own pool and share the same cores, then bounded by the
-          cores the readers leave spare. An output gets at least four
-          regardless, since a single input can carry several cores'
-          worth on its own, and never more than the core count. Sizing
-          it exactly is not important: a reader that finds every
-          compressor busy compresses the container itself, so too small
-          a pool costs nothing beyond the pool being idle.</para>
+          per input, divided across the file outputs but not under
+          <option>--mirror</option>, bounded by the cores the readers
+          leave spare, then never fewer than four nor more than the
+          core count. The cores counted are those in the process
+          affinity mask, which does not reflect a cgroup CPU quota.
+          Sizing it exactly does not matter, since a reader that finds
+          every compressor busy compresses the container itself. It
+          helps most where one input outruns a single core; a channel
+          spread over many ports already compresses on every reader
+          thread.</para>
 
-          <para>The cores counted are those in the process affinity
-          mask, which does not reflect a cgroup CPU quota; under a
-          container runtime that caps CPU rather than pinning it, pass
-          <replaceable>n</replaceable> explicitly.</para>
-
-          <para>This is worth using when a single input carries more
-          data than one core can compress, and on file-to-file work
-          such as recompressing a capture. A channel spread over a
-          range of ports already compresses on every reader thread and
-          gains little; it also costs a little output size there,
-          because readers that never pause interleave their sources
-          more finely within a container, which compresses slightly
-          worse. With a single input the output is byte for byte
-          identical to compressing inline, whatever
-          <replaceable>n</replaceable> is.</para>
-
-          <para>Compression itself still needs <option>-z</option>;
-          without it a compressor only takes the serializing off the
-          reader. A pool holds a serialized container per queued
-          ticket, so it can add tens of megabytes of buffering to an
-          output.</para>
-
-          <para>Containers are always written in the order they were
-          filled. Applies to file (<option>-w</option>) outputs only,
-          and cannot be combined with
-          <option>--unbuffered</option>.</para>
+          <para>Compression itself still needs <option>-z</option>, and
+          a pool holds a serialized container per queued ticket, so it
+          can add tens of megabytes of buffering. Containers are always
+          written in the order they were filled; with a single input
+          the output is byte for byte identical to compressing inline,
+          whatever <replaceable>n</replaceable> is. File
+          (<option>-w</option>) outputs only, and cannot be combined
+          with <option>--unbuffered</option>.</para>
         </listitem>
       </varlistentry>
 
@@ -725,15 +707,13 @@
 
           <para>Containers always go to the lowest-numbered free
           compressor, so a pool that grew for a burst keeps the first
-          few busy and lets the rest fall quiet. The pool grows again
-          on demand, exactly as it did the first time, and a
-          compressor only ever leaves when it is holding nothing, so
-          the output is unaffected either way.</para>
-
-          <para>This matters mainly for a long-running output that is
-          not being rotated: an output closed by <option>-t</option>
-          or <option>-k</option> gives its whole pool back at every
-          close regardless.</para>
+          few busy and lets the rest fall quiet. A compressor only ever
+          leaves when it is holding nothing, and the pool grows again
+          on demand, so the output is unaffected either way. This
+          matters mainly for a long-running output that is not being
+          rotated: one closed by <option>-t</option> or
+          <option>-k</option> gives its whole pool back at every close
+          regardless.</para>
         </listitem>
       </varlistentry>
 
@@ -745,16 +725,13 @@
           default. A value of <option>0</option> lets the pool empty
           completely.</para>
 
-          <para>This is a floor on what culling may take away, not a
-          number of threads to start: compressors are still started
-          only on demand, so an output that has never been busy is
-          running none of them whatever this is set to. A value above
-          an explicit <option>--zasync</option> is rejected; under
-          <option>--zasync -1</option> it is lowered to the ceiling
-          chosen, which is reported at <option>-dd</option>.</para>
-
-          <para>One thread per file output is not culled in any case:
-          the thread that does the writing is not a compressor.</para>
+          <para>A floor on what culling may take away, not a number of
+          threads to start: compressors are still started only on
+          demand, so an output that has never been busy is running none
+          of them whatever this is set to. A value above an explicit
+          <option>--zasync</option> is rejected; under <option>--zasync
+          -1</option> it is lowered to the ceiling chosen, which is
+          reported at <option>-dd</option>.</para>
         </listitem>
       </varlistentry>
 

--- a/libmy/my_cpu.h
+++ b/libmy/my_cpu.h
@@ -1,0 +1,31 @@
+#ifndef MY_CPU_H
+#define MY_CPU_H
+
+#include <unistd.h>
+
+#ifdef __linux__
+# include <sched.h>
+#endif /* __linux__ */
+
+/* Cores this process may actually run on. Never less than one. */
+static inline long
+my_ncpu(void)
+{
+	long ncpu = -1;
+
+#ifdef __linux__
+	cpu_set_t set;
+
+	if (sched_getaffinity(0, sizeof(set), &set) == 0)
+		ncpu = CPU_COUNT(&set);
+#endif /* __linux__ */
+
+	if (ncpu < 1)
+		ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+	if (ncpu < 1)
+		ncpu = 1;
+
+	return (ncpu);
+}
+
+#endif /* MY_CPU_H */

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -420,6 +420,11 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout) {
 
 void
 nmsg_output_set_zlib_async(nmsg_output_t output, bool async) {
+	nmsg_output_set_zlib_workers(output, async ? 1 : 0);
+}
+
+void
+nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 	nmsg_res res;
 
 	/*
@@ -433,19 +438,30 @@ nmsg_output_set_zlib_async(nmsg_output_t output, bool async) {
 		return;
 
 	/*
-	 * Nothing to return an error through, so both paths are logged. Failing
-	 * to start the compressor is survivable, but disabling it after writing
-	 * can strand an error the worker had recorded.
+	 * Unbuffered output flushes a container per message, so a pool would
+	 * spend a ticket, a condvar signal and a wakeup per message to compress
+	 * a single payload.
 	 */
-	if (async) {
-		res = _output_nmsg_async_init(output);
+	if (workers > 0 && !output->stream->buffered) {
+		_nmsg_dprintf(1, "%s: ignored: not available on unbuffered output\n",
+			      __func__);
+		return;
+	}
+
+	/*
+	 * Nothing to return an error through, so both paths are logged. Failing
+	 * to start the pool is survivable, but disabling it after writing can
+	 * strand an error a worker had recorded.
+	 */
+	if (workers > 0) {
+		res = _output_nmsg_async_init(output, workers);
 		if (res != nmsg_res_success)
 			_nmsg_dprintf(1, "%s: could not start compressor: %s\n",
 				      __func__, nmsg_res_lookup(res));
 	} else {
 		res = _output_nmsg_async_destroy(output);
 		if (res != nmsg_res_success)
-			_nmsg_dprintf(1, "%s: discarding pending write error: %s\n",
+			_nmsg_dprintf(1, "%s: compressor reported: %s\n",
 				      __func__, nmsg_res_lookup(res));
 	}
 }

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -460,6 +460,42 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 }
 
 void
+nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers, unsigned idle_secs) {
+	struct nmsg_stream_output *ostr;
+	struct nmsg_ostr_async *pool;
+
+	/* Type test first, for the reason nmsg_output_set_zlib_workers() gives. */
+	if (output->type != nmsg_output_type_stream)
+		return;
+	if (output->stream->type != nmsg_stream_type_file)
+		return;
+
+	ostr = output->stream;
+
+	/*
+	 * Kept on the stream, not just in the pool: a ceiling change replaces
+	 * the pool, and this way the two setters may be called in any order.
+	 * Nothing is logged when there is no pool -- nmsgtool sets a policy on
+	 * every output, so it would fire on a plain '--unbuffered -w'.
+	 */
+	pthread_mutex_lock(&ostr->c_lock);
+	ostr->so_zmin = min_workers;
+	ostr->so_zcull = idle_secs;
+
+	/*
+	 * Taken under c_lock so a teardown cannot free the pool underneath.
+	 * Lock order is c_lock then pool->lock; nothing takes them the other way.
+	 */
+	pool = _output_async_ref(ostr);
+	pthread_mutex_unlock(&ostr->c_lock);
+
+	if (pool != NULL) {
+		_output_async_set_cull(pool, min_workers, idle_secs);
+		_output_async_unref(ostr);
+	}
+}
+
+void
 nmsg_output_set_endline(nmsg_output_t output, const char *endline) {
 	if (output->type == nmsg_output_type_pres) {
 		char *ptr = strdup(endline);
@@ -585,6 +621,8 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 	}
 	output->stream->type = type;
 	output->stream->buffered = true;
+	output->stream->so_zmin = NMSG_ZCULL_MIN_WORKERS_DEFAULT;
+	output->stream->so_zcull = NMSG_ZCULL_SECS_DEFAULT;
 
 	/* seed the rng, needed for fragment and sequence IDs */
 	output->stream->random = nmsg_random_init();

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -291,7 +291,7 @@ nmsg_output_close(nmsg_output_t *output) {
 		 * Before random, fd and the locks below, all of which the
 		 * compressor thread uses.
 		 */
-		async_res = _output_nmsg_async_destroy(*output);
+		async_res = _output_async_destroy(*output);
 		if (res == nmsg_res_success)
 			res = async_res;
 
@@ -316,6 +316,7 @@ nmsg_output_close(nmsg_output_t *output) {
 				close((*output)->stream->fd);
 		}
 		nmsg_container_destroy(&(*output)->stream->c);
+		pthread_cond_destroy(&(*output)->stream->c_drained);
 		pthread_mutex_destroy(&(*output)->stream->c_lock);
 		pthread_mutex_destroy(&(*output)->stream->w_lock);
 		free((*output)->stream);
@@ -419,11 +420,6 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout) {
 }
 
 void
-nmsg_output_set_zlib_async(nmsg_output_t output, bool async) {
-	nmsg_output_set_zlib_workers(output, async ? 1 : 0);
-}
-
-void
 nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 	nmsg_res res;
 
@@ -454,12 +450,12 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 	 * strand an error a worker had recorded.
 	 */
 	if (workers > 0) {
-		res = _output_nmsg_async_init(output, workers);
+		res = _output_async_init(output, workers);
 		if (res != nmsg_res_success)
 			_nmsg_dprintf(1, "%s: could not start compressor: %s\n",
 				      __func__, nmsg_res_lookup(res));
 	} else {
-		res = _output_nmsg_async_destroy(output);
+		res = _output_async_destroy(output);
 		if (res != nmsg_res_success)
 			_nmsg_dprintf(1, "%s: compressor reported: %s\n",
 				      __func__, nmsg_res_lookup(res));
@@ -603,6 +599,7 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 
 	pthread_mutex_init(&output->stream->c_lock, NULL);
 	pthread_mutex_init(&output->stream->w_lock, NULL);
+	pthread_cond_init(&output->stream->c_drained, NULL);
 
 	/* enable container sequencing */
 	if (output->stream->type == nmsg_stream_type_sock ||
@@ -627,6 +624,7 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 	output->stream->c = nmsg_container_init(bufsz);
 	if (output->stream->c == NULL) {
 		nmsg_random_destroy(&output->stream->random);
+		pthread_cond_destroy(&output->stream->c_drained);
 		pthread_mutex_destroy(&output->stream->c_lock);
 		pthread_mutex_destroy(&output->stream->w_lock);
 		free(output->stream);

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -419,48 +419,36 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout) {
 	output->stream->do_zlib = zlibout;
 }
 
-void
-nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
-	nmsg_res res;
-
+nmsg_res
+nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers)
+{
 	/*
 	 * Type test first: 'stream' is a union member, so reading stream->type
 	 * on a pres or json output would reinterpret another struct's bytes.
 	 */
 	if (output->type != nmsg_output_type_stream)
-		return;
+		return (nmsg_res_success);
 	if (output->stream->type != nmsg_stream_type_file)
-		return;
+		return (nmsg_res_success);
 
 	/*
 	 * Unbuffered flushes a container per message, so a pool would spend a
 	 * ticket and a wakeup per message to compress a single payload.
 	 */
-	if (workers > 0 && !output->stream->buffered) {
-		_nmsg_dprintf(1, "%s: ignored: not available on unbuffered output\n",
-			      __func__);
-		return;
-	}
+	if (workers > 0 && !output->stream->buffered)
+		return (nmsg_res_failure);
 
-	/*
-	 * Nothing to return an error through, so both paths log: disabling a
-	 * pool after writing can strand an error a worker recorded.
-	 */
-	if (workers > 0) {
-		res = _output_async_init(output, workers);
-		if (res != nmsg_res_success)
-			_nmsg_dprintf(1, "%s: could not start compressor: %s\n",
-				      __func__, nmsg_res_lookup(res));
-	} else {
-		res = _output_async_destroy(output);
-		if (res != nmsg_res_success)
-			_nmsg_dprintf(1, "%s: compressor reported: %s\n",
-				      __func__, nmsg_res_lookup(res));
-	}
+	if (workers > 0)
+		return (_output_async_init(output, workers));
+
+	/* Turning a pool off can strand an error a worker recorded. */
+	return (_output_async_destroy(output));
 }
 
 void
-nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers, unsigned idle_secs) {
+nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers,
+			  unsigned idle_secs)
+{
 	struct nmsg_stream_output *ostr;
 	struct nmsg_ostr_async *pool;
 
@@ -634,7 +622,14 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 
 	pthread_mutex_init(&output->stream->c_lock, NULL);
 	pthread_mutex_init(&output->stream->w_lock, NULL);
-	pthread_cond_init(&output->stream->c_drained, NULL);
+	if (pthread_cond_init(&output->stream->c_drained, NULL) != 0) {
+		nmsg_random_destroy(&output->stream->random);
+		pthread_mutex_destroy(&output->stream->c_lock);
+		pthread_mutex_destroy(&output->stream->w_lock);
+		free(output->stream);
+		free(output);
+		return (NULL);
+	}
 
 	/*
 	 * Enable container sequencing. Sock and zmq only, which is what lets

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -280,12 +280,21 @@ nmsg_output_write(nmsg_output_t output, nmsg_message_t msg) {
 
 nmsg_res
 nmsg_output_close(nmsg_output_t *output) {
-	nmsg_res res;
+	nmsg_res res, async_res;
 
 	res = nmsg_res_success;
 	switch ((*output)->type) {
 	case nmsg_output_type_stream:
 		res = _output_nmsg_flush(*output);
+
+		/*
+		 * Before random, fd and the locks below, all of which the
+		 * compressor thread uses.
+		 */
+		async_res = _output_nmsg_async_destroy(*output);
+		if (res == nmsg_res_success)
+			res = async_res;
+
 		if ((*output)->stream->random != NULL)
 			nmsg_random_destroy(&((*output)->stream->random));
 #ifdef HAVE_LIBRDKAFKA
@@ -407,6 +416,38 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout) {
 	if (output->type != nmsg_output_type_stream)
 		return;
 	output->stream->do_zlib = zlibout;
+}
+
+void
+nmsg_output_set_zlib_async(nmsg_output_t output, bool async) {
+	nmsg_res res;
+
+	/*
+	 * The type test comes first because 'stream' is a union member: on a
+	 * pres or json output, reading stream->type would reinterpret the
+	 * bytes of a different struct rather than fail.
+	 */
+	if (output->type != nmsg_output_type_stream)
+		return;
+	if (output->stream->type != nmsg_stream_type_file)
+		return;
+
+	/*
+	 * Nothing to return an error through, so both paths are logged. Failing
+	 * to start the compressor is survivable, but disabling it after writing
+	 * can strand an error the worker had recorded.
+	 */
+	if (async) {
+		res = _output_nmsg_async_init(output);
+		if (res != nmsg_res_success)
+			_nmsg_dprintf(1, "%s: could not start compressor: %s\n",
+				      __func__, nmsg_res_lookup(res));
+	} else {
+		res = _output_nmsg_async_destroy(output);
+		if (res != nmsg_res_success)
+			_nmsg_dprintf(1, "%s: discarding pending write error: %s\n",
+				      __func__, nmsg_res_lookup(res));
+	}
 }
 
 void

--- a/nmsg/output.c
+++ b/nmsg/output.c
@@ -424,9 +424,8 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 	nmsg_res res;
 
 	/*
-	 * The type test comes first because 'stream' is a union member: on a
-	 * pres or json output, reading stream->type would reinterpret the
-	 * bytes of a different struct rather than fail.
+	 * Type test first: 'stream' is a union member, so reading stream->type
+	 * on a pres or json output would reinterpret another struct's bytes.
 	 */
 	if (output->type != nmsg_output_type_stream)
 		return;
@@ -434,9 +433,8 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 		return;
 
 	/*
-	 * Unbuffered output flushes a container per message, so a pool would
-	 * spend a ticket, a condvar signal and a wakeup per message to compress
-	 * a single payload.
+	 * Unbuffered flushes a container per message, so a pool would spend a
+	 * ticket and a wakeup per message to compress a single payload.
 	 */
 	if (workers > 0 && !output->stream->buffered) {
 		_nmsg_dprintf(1, "%s: ignored: not available on unbuffered output\n",
@@ -445,9 +443,8 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers) {
 	}
 
 	/*
-	 * Nothing to return an error through, so both paths are logged. Failing
-	 * to start the pool is survivable, but disabling it after writing can
-	 * strand an error a worker had recorded.
+	 * Nothing to return an error through, so both paths log: disabling a
+	 * pool after writing can strand an error a worker recorded.
 	 */
 	if (workers > 0) {
 		res = _output_async_init(output, workers);
@@ -601,7 +598,12 @@ output_open_stream_base(nmsg_stream_type type, size_t bufsz) {
 	pthread_mutex_init(&output->stream->w_lock, NULL);
 	pthread_cond_init(&output->stream->c_drained, NULL);
 
-	/* enable container sequencing */
+	/*
+	 * Enable container sequencing. Sock and zmq only, which is what lets
+	 * the async compressor number containers in compression order;
+	 * widening this test needs _output_nmsg_container_compress() looked
+	 * at.
+	 */
 	if (output->stream->type == nmsg_stream_type_sock ||
 	    output->stream->type == nmsg_stream_type_zmq)
 	{

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -401,10 +401,12 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
  * \param[in] output nmsg_output_t object.
  *
  * \param[in] workers Maximum number of compressor threads, or 0 to compress
- *	inline (the default).
+ *	inline (the default). Capped at the cores available to the process.
  *
- * \return #nmsg_res_success, or #nmsg_res_failure on an unbuffered output.
- *	Setting 0 returns any write error the pool had yet to report.
+ * \return #nmsg_res_success, or #nmsg_res_failure on an unbuffered output;
+ *	#nmsg_res_memfail or #nmsg_res_failure if the pool cannot be built, and
+ *	success without a pool on an output this does not apply to. Setting 0
+ *	returns any write error the pool had yet to report.
  */
 nmsg_res
 nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -392,8 +392,9 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
  * the container itself, exactly as it would with no pool, so this is never
  * slower than leaving it off.
  *
- * Writes stay in the order the containers were filled, so the output is
- * byte-identical whatever \a workers is set to.
+ * Containers are written in the order they were filled, whatever \a workers is
+ * set to. With a single writing thread that makes the output byte-identical to
+ * compressing inline; with several, only the write order is guaranteed.
  *
  * \a workers is a ceiling rather than an allocation: threads are started as
  * load calls for them, so an output that never saturates never pays for them.

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -405,4 +405,28 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
 void
 nmsg_output_set_zlib_async(nmsg_output_t output, bool async);
 
+/**
+ * Compress containers on a pool of worker threads instead of on the thread
+ * that filled them.
+ *
+ * A reader that compresses is not reading, and on a busy channel that pause is
+ * long enough for the socket to overflow. With a pool the reader hands the
+ * container over and returns to reading; if every worker is busy it compresses
+ * the container itself, exactly as it would with no pool, so this is never
+ * slower than leaving it off.
+ *
+ * Writes stay in the order the containers were filled, so the output is
+ * byte-identical whatever \a workers is set to.
+ *
+ * File outputs only, and only when buffered. Call before the first write.
+ *
+ * \param[in] output nmsg_output_t object.
+ *
+ * \param[in] workers Number of compressor threads, or 0 to compress inline
+ *	(the default). More than one is only useful when a single output is
+ *	offered more data than one core can compress.
+ */
+void
+nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);
+
 #endif /* NMSG_OUTPUT_H */

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -383,29 +383,6 @@ void
 nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
 
 /**
- * Compress and write containers on a dedicated thread instead of on the thread
- * calling nmsg_output_write(). Only affects file outputs.
- *
- * One container may be in flight at a time. A writer that finishes a container
- * while the previous one is still being compressed blocks until it completes.
- *
- * Because a container is written after nmsg_output_write() returns, a write
- * error is reported by a later nmsg_output_write(), or by nmsg_output_flush()
- * or nmsg_output_close(), rather than by the call that supplied the data.
- *
- * Call before the first write. Enabling this later is harmless, but disabling
- * it after writing discards any error already recorded for a container that
- * has not yet been reported.
- *
- * \param[in] output nmsg_output_t object.
- *
- * \param[in] async True (compress on a separate thread) or false (compress
- *	inline, the default).
- */
-void
-nmsg_output_set_zlib_async(nmsg_output_t output, bool async);
-
-/**
  * Compress containers on a pool of worker threads instead of on the thread
  * that filled them.
  *
@@ -418,13 +395,25 @@ nmsg_output_set_zlib_async(nmsg_output_t output, bool async);
  * Writes stay in the order the containers were filled, so the output is
  * byte-identical whatever \a workers is set to.
  *
- * File outputs only, and only when buffered. Call before the first write.
+ * \a workers is a ceiling rather than an allocation: threads are started as
+ * load calls for them, so an output that never saturates never pays for them.
+ * The count is capped at an internal limit.
+ *
+ * Because a container is written after nmsg_output_write() returns, a write
+ * error is reported by a later nmsg_output_write(), or by nmsg_output_flush()
+ * or nmsg_output_close(), rather than by the call that supplied the data.
+ *
+ * File outputs only, and only when buffered.
+ *
+ * Not thread-safe against a concurrent nmsg_output_write() on the same output:
+ * call it before the first write, or while no write is in flight. Under
+ * nmsg_io that is guaranteed, since a close event excludes writers.
  *
  * \param[in] output nmsg_output_t object.
  *
- * \param[in] workers Number of compressor threads, or 0 to compress inline
- *	(the default). More than one is only useful when a single output is
- *	offered more data than one core can compress.
+ * \param[in] workers Maximum number of compressor threads, or 0 to compress
+ *	inline (the default). More than one is only useful when a single output
+ *	is offered more data than one core can compress.
  */
 void
 nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -393,23 +393,29 @@ nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
  * this is never slower than leaving it off.
  *
  * A write error surfaces on a later nmsg_output_write(), nmsg_output_flush() or
- * nmsg_output_close(). File outputs only, and only when buffered. Not
- * thread-safe against a concurrent write on the same output.
+ * nmsg_output_close(). File outputs only, and only when buffered.
+ *
+ * Not thread-safe against a concurrent write on the same output: turning a pool
+ * on or off while another thread is writing can reorder containers.
  *
  * \param[in] output nmsg_output_t object.
  *
  * \param[in] workers Maximum number of compressor threads, or 0 to compress
  *	inline (the default).
+ *
+ * \return #nmsg_res_success, or #nmsg_res_failure on an unbuffered output.
+ *	Setting 0 returns any write error the pool had yet to report.
  */
-void
+nmsg_res
 nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);
 
 /**
  * Set when the compressor pool gives threads back.
  *
- * Work goes to the most recently used compressor, so the rest of a pool that
- * grew for a burst falls quiet and is culled. Write order is unaffected. May be
- * called before or after nmsg_output_set_zlib_workers(). File outputs only.
+ * Work always goes to the lowest-numbered free compressor, so the rest of a
+ * pool that grew for a burst falls quiet and is culled. Write order is
+ * unaffected. May be called before or after nmsg_output_set_zlib_workers().
+ * File outputs only.
  *
  * \param[in] output nmsg_output_t object.
  *
@@ -420,6 +426,7 @@ nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);
  *	default. 0 disables culling.
  */
 void
-nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers, unsigned idle_secs);
+nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers,
+			  unsigned idle_secs);
 
 #endif /* NMSG_OUTPUT_H */

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -383,40 +383,43 @@ void
 nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
 
 /**
- * Compress containers on a pool of worker threads instead of on the thread
- * that filled them.
+ * Compress containers on worker threads rather than on the thread that filled
+ * them: a reader that compresses is not reading, and on a busy channel that
+ * pause is long enough for the socket to overflow.
  *
- * A reader that compresses is not reading, and on a busy channel that pause is
- * long enough for the socket to overflow. With a pool the reader hands the
- * container over and returns to reading; if every worker is busy it compresses
- * the container itself, exactly as it would with no pool, so this is never
- * slower than leaving it off.
+ * workers is a ceiling, not an allocation: threads start on demand and are
+ * given back once idle, see nmsg_output_set_zlib_cull(). Write order is
+ * unchanged, and a producer that finds every worker busy compresses inline, so
+ * this is never slower than leaving it off.
  *
- * Containers are written in the order they were filled, whatever \a workers is
- * set to. With a single writing thread that makes the output byte-identical to
- * compressing inline; with several, only the write order is guaranteed.
- *
- * \a workers is a ceiling rather than an allocation: threads are started as
- * load calls for them, so an output that never saturates never pays for them.
- * The count is capped at an internal limit.
- *
- * Because a container is written after nmsg_output_write() returns, a write
- * error is reported by a later nmsg_output_write(), or by nmsg_output_flush()
- * or nmsg_output_close(), rather than by the call that supplied the data.
- *
- * File outputs only, and only when buffered.
- *
- * Not thread-safe against a concurrent nmsg_output_write() on the same output:
- * call it before the first write, or while no write is in flight. Under
- * nmsg_io that is guaranteed, since a close event excludes writers.
+ * A write error surfaces on a later nmsg_output_write(), nmsg_output_flush() or
+ * nmsg_output_close(). File outputs only, and only when buffered. Not
+ * thread-safe against a concurrent write on the same output.
  *
  * \param[in] output nmsg_output_t object.
  *
  * \param[in] workers Maximum number of compressor threads, or 0 to compress
- *	inline (the default). More than one is only useful when a single output
- *	is offered more data than one core can compress.
+ *	inline (the default).
  */
 void
 nmsg_output_set_zlib_workers(nmsg_output_t output, unsigned workers);
+
+/**
+ * Set when the compressor pool gives threads back.
+ *
+ * Work goes to the most recently used compressor, so the rest of a pool that
+ * grew for a burst falls quiet and is culled. Write order is unaffected. May be
+ * called before or after nmsg_output_set_zlib_workers(). File outputs only.
+ *
+ * \param[in] output nmsg_output_t object.
+ *
+ * \param[in] min_workers Compressors culling leaves alone, 1 by default; 0 lets
+ *	the pool empty. A floor on culling, not a number of threads to start.
+ *
+ * \param[in] idle_secs Idle seconds that cost a compressor its place, 300 by
+ *	default. 0 disables culling.
+ */
+void
+nmsg_output_set_zlib_cull(nmsg_output_t output, unsigned min_workers, unsigned idle_secs);
 
 #endif /* NMSG_OUTPUT_H */

--- a/nmsg/output.h
+++ b/nmsg/output.h
@@ -382,4 +382,27 @@ nmsg_output_set_group(nmsg_output_t output, unsigned group);
 void
 nmsg_output_set_zlibout(nmsg_output_t output, bool zlibout);
 
+/**
+ * Compress and write containers on a dedicated thread instead of on the thread
+ * calling nmsg_output_write(). Only affects file outputs.
+ *
+ * One container may be in flight at a time. A writer that finishes a container
+ * while the previous one is still being compressed blocks until it completes.
+ *
+ * Because a container is written after nmsg_output_write() returns, a write
+ * error is reported by a later nmsg_output_write(), or by nmsg_output_flush()
+ * or nmsg_output_close(), rather than by the call that supplied the data.
+ *
+ * Call before the first write. Enabling this later is harmless, but disabling
+ * it after writing discards any error already recorded for a container that
+ * has not yet been reported.
+ *
+ * \param[in] output nmsg_output_t object.
+ *
+ * \param[in] async True (compress on a separate thread) or false (compress
+ *	inline, the default).
+ */
+void
+nmsg_output_set_zlib_async(nmsg_output_t output, bool async);
+
 #endif /* NMSG_OUTPUT_H */

--- a/nmsg/output_async.c
+++ b/nmsg/output_async.c
@@ -43,9 +43,9 @@
  */
 
 /*
- * Slots kept free for producers to deposit inline-compressed containers into
- * while every worker is busy. Without it a saturated pool would have nowhere
- * left to put anything.
+ * Slots beyond one per worker, so a producer can run ahead of the compressors
+ * instead of waiting on its own ticket's slot. Headroom, not a requirement:
+ * depth == nworkers would still make progress.
  */
 #define ASYNC_REORDER_MARGIN 8
 
@@ -365,8 +365,6 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 	pool->depth = depth;
 	pool->nworkers = nworkers;
 	pool->cull_clock = cull_clock;
-	pool->min_workers = async_min_workers_for(nworkers, zmin);
-	pool->cull_secs = zcull;
 	pool->output = output;
 
 	/* A no-op under c_lock if there is nothing to replace. */
@@ -374,17 +372,12 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 
 	pthread_mutex_lock(&ostr->c_lock);
 
+	pool->min_workers = async_min_workers_for(nworkers, ostr->so_zmin);
+	pool->cull_secs = ostr->so_zcull;
+
 	/*
 	 * Tickets span the stream, not the pool, so a pool built mid-stream
-	 * must start where the stream got to. Seeded and published in one
-	 * c_lock hold, so a ticket either predates the pool or is at or above
-	 * commit_next, never below, where the committer would wait for it
-	 * forever.
-	 *
-	 * That settles the pool's own liveness, not the byte order: a container
-	 * from a ticket just before this may still be waiting to go out inline,
-	 * and nothing holds this pool back for it. See
-	 * nmsg_output_set_zlib_workers().
+	 * must start where the stream got to.
 	 */
 	pool->commit_next = pool->issued = ostr->so_ticket;
 
@@ -583,7 +576,8 @@ async_worker(void *arg)
 			if (pool->shutdown)
 				break;
 
-			if (timed_out && pool->nlive > pool->min_workers) {
+			if (timed_out && pool->cull_secs > 0 &&
+			    pool->nlive > pool->min_workers) {
 				pool->n_culled++;
 				break;
 			}
@@ -598,8 +592,10 @@ async_worker(void *arg)
 			 * tied to particular threads: grow again and the
 			 * workers added on top are the ones that time out.
 			 */
-			if (pool->cull_secs == 0 ||
-			    pool->nlive <= pool->min_workers ||
+			bool park_indefinitely = pool->cull_secs == 0 ||
+						 pool->nlive <= pool->min_workers;
+
+			if (park_indefinitely ||
 			    !async_cull_deadline(pool, &deadline)) {
 				pthread_cond_wait(&self->ready, &pool->lock);
 			} else {
@@ -761,9 +757,11 @@ async_start(struct nmsg_ostr_async *pool)
 		/*
 		 * Nothing can be written without a committer, so abandon the
 		 * pool and compress inline. Nothing has been deposited yet to
-		 * unwind.
+		 * unwind, but a flush may already be waiting on a ticket that
+		 * will now never be committed.
 		 */
 		pool->failed = true;
+		pthread_cond_broadcast(&pool->slot_free);
 		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
 			      strerror(pthread_res));
 		return;
@@ -898,31 +896,31 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	if (ticket >= pool->issued)
 		pool->issued = ticket + 1;
 
-	/* An idle compressor, or a new one if the pool may still grow. */
-	if (!is_frag) {
-		worker = async_idle_take(pool);
-		if (worker == NULL)
-			worker = async_spawn_worker(pool);
-	}
-
 	if (is_frag) {
 		/* Only the committer fragments; see async_committer(). */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_frag;
 		pthread_cond_broadcast(&pool->commit_ready);
-	} else if (worker != NULL) {
-		/* Hand the container over and get back to reading. */
-		slot->co = *co;
-		*co = NULL;
-		slot->state = slot_work;
-		worker->slot = slot;
-		pthread_cond_signal(&worker->ready);
 	} else {
-		/* Everyone busy and at the ceiling: compress here. */
-		slot->state = slot_taken;
-		pool->n_inline++;
-		inline_compress = true;
+		/* An idle compressor, or a new one if the pool may still grow. */
+		worker = async_idle_take(pool);
+		if (worker == NULL)
+			worker = async_spawn_worker(pool);
+
+		if (worker != NULL) {
+			/* Hand the container over and get back to reading. */
+			slot->co = *co;
+			*co = NULL;
+			slot->state = slot_work;
+			worker->slot = slot;
+			pthread_cond_signal(&worker->ready);
+		} else {
+			/* Everyone busy and at the ceiling: compress here. */
+			slot->state = slot_taken;
+			pool->n_inline++;
+			inline_compress = true;
+		}
 	}
 
 	/*

--- a/nmsg/output_async.c
+++ b/nmsg/output_async.c
@@ -15,55 +15,46 @@
  */
 
 /*
- * The compressor pool for a stream output.
- *
- * Everything here is private to this unit: the ring, its slot states and the
- * threads that walk it. output_nmsg.c hands a sealed container over with
- * _output_async_submit() and gets the bytes written for it, and calls back
- * into that file for the actual compressing and writing.
+ * The compressor pool for a stream output. The reorder buffer, its slot states
+ * and the threads that walk it are private here; output_nmsg.c submits sealed
+ * containers and supplies the compress and write callbacks.
  */
 
 /* Import. */
 
 #include "private.h"
 
+#ifdef __linux__
+#include <sched.h>
+#endif /* __linux__ */
+
 /* Data structures. */
 
 /*
- * A compressor pool: a ring of slots, up to nworkers compressor threads and
- * one committer thread.
+ * A compressor pool: a ticket reorder buffer, up to nworkers compressor
+ * threads and one committer thread.
  *
- * A container is given a ticket when it is sealed, under c_lock, so tickets
- * follow the order the containers were closed in. Slot i serves every ticket
- * with (ticket % depth) == i, so the producer of ticket T waits only for
- * ticket T - depth to have been written.
+ * Containers are ticketed under c_lock as they are sealed. Compression runs on
+ * whichever thread is free, but only the committer writes and only in ticket
+ * order, so the byte stream matches the synchronous path.
  *
- * Compression runs on whichever thread is free. Only the committer writes, and
- * only in ticket order, so the byte stream is identical to the synchronous
- * path however many workers are running.
- *
- * A producer that finds every worker busy compresses the container itself
- * rather than waiting. That is exactly what the synchronous path does, so the
- * pool is never slower than no pool at all.
- *
- * Workers are spawned on demand rather than up front, so 'nworkers' is a
- * ceiling and not an allocation. Once spawned a worker lives until the pool is destroyed.
+ * A producer that finds every worker busy compresses inline rather than wait,
+ * so the pool is never slower than no pool. Workers spawn on demand, making
+ * 'nworkers' a ceiling rather than an allocation.
  */
 
 /*
- * Ring size, independent of the worker ceiling. A slot itself is tiny; what it
- * costs is the container it points at while a ticket is in flight, so the depth
- * bounds worst-case backlog rather than resident memory. The margin keeps slots
- * available for producers to deposit into while every worker is busy, and
- * capping the ceiling at depth - margin stops the pool having more compressors
- * than places to put their output.
+ * Slots kept free for producers to deposit inline-compressed containers into
+ * while every worker is busy. Without it a saturated pool would have nowhere
+ * left to put anything.
  */
-#define ASYNC_RING_DEPTH	32
-#define ASYNC_RING_MARGIN	8
-#define ASYNC_MAX_WORKERS	(ASYNC_RING_DEPTH - ASYNC_RING_MARGIN)
+#define ASYNC_REORDER_MARGIN 8
+
+/* Smallest reorder buffer worth allocating. */
+#define ASYNC_DEPTH_MIN 16
 
 typedef enum {
-	slot_empty = 0,	/* Free. */
+	slot_empty = 0, /* Free. */
 	slot_work,	/* Container waiting for a compressor. */
 	slot_taken,	/* A worker or a producer is compressing it. */
 	slot_done,	/* Compressed, waiting its turn to be written. */
@@ -71,35 +62,40 @@ typedef enum {
 } async_slot_state;
 
 struct async_slot {
-	async_slot_state	state;
-	nmsg_container_t	co;		/* slot_work, slot_frag */
-	uint8_t			*buf;		/* slot_done */
-	size_t			buf_len;
-	nmsg_res		res;
+	async_slot_state state;
+	nmsg_container_t co;  /* slot_work, slot_frag */
+	uint8_t		*buf; /* slot_done */
+	size_t		 buf_len;
+	nmsg_res	 res;
 };
 
 struct nmsg_ostr_async {
-	pthread_mutex_t		lock;
-	pthread_cond_t		work_ready;	/* A slot became slot_work. */
-	pthread_cond_t		commit_ready;	/* The committer's slot is ready. */
-	pthread_cond_t		slot_free;	/* A slot became slot_empty. */
-	struct async_slot	*slots;
-	unsigned		depth;
-	unsigned		nworkers;	/* Ceiling; workers start on demand. */
-	unsigned		nstarted;	/* Workers that exist and must be joined. */
-	unsigned		busy;		/* Containers assigned to workers. */
-	uint64_t		issued;		/* Highest ticket claimed, plus one. */
-	uint64_t		commit_next;	/* Ticket allowed to write now. */
-	bool			shutdown;
-	bool			started;	/* Committer exists; must be joined. */
-	bool			failed;		/* No committer; stay inline. */
-	bool			spawn_failed;	/* Worker spawn failed; logged once. */
-	pthread_t		*workers;
-	pthread_t		committer;
-	nmsg_res		first_error;	/* Sticky; surfaced by flush. */
-	nmsg_output_t		output;
-	uint64_t		n_inline;	/* Containers a producer compressed. */
-	uint64_t		n_waited;	/* Producers that waited for a slot. */
+	pthread_mutex_t lock;
+	pthread_cond_t	work_ready;   /* A slot became slot_work. */
+	pthread_cond_t	commit_ready; /* The committer's slot is ready. */
+	pthread_cond_t	slot_free;    /* A slot became slot_empty. */
+	/*
+	 * The ticket reorder buffer. Slot i serves every ticket with (ticket %
+	 * depth) == i, so a producer runs at most 'depth' tickets ahead of
+	 * commit_next and waits only for ticket T - depth to be written.
+	 */
+	struct async_slot *slots;
+	unsigned	   depth;
+	unsigned	   nworkers;	/* Ceiling; workers start on demand. */
+	unsigned	   nstarted;	/* Workers that exist and must be joined. */
+	unsigned	   busy;	/* Containers assigned to workers. */
+	uint64_t	   issued;	/* Highest ticket claimed, plus one. */
+	uint64_t	   commit_next; /* Ticket allowed to write now. */
+	bool		   shutdown;
+	bool		   started;	 /* Committer exists; must be joined. */
+	bool		   failed;	 /* No committer; stay inline. */
+	bool		   spawn_failed; /* Worker spawn failed; logged once. */
+	pthread_t	  *workers;
+	pthread_t	   committer;
+	nmsg_res	   first_error; /* Sticky; surfaced by flush. */
+	nmsg_output_t	   output;
+	uint64_t	   n_inline; /* Containers a producer compressed. */
+	uint64_t	   n_waited; /* Producers that waited for a slot. */
 };
 
 /*
@@ -118,8 +114,7 @@ _output_async_ref(struct nmsg_stream_output *ostr)
 }
 
 /* Drop a reference taken by _output_async_ref() and wake any waiting teardown. */
-void
-_output_async_unref(struct nmsg_stream_output *ostr)
+void _output_async_unref(struct nmsg_stream_output *ostr)
 {
 	pthread_mutex_lock(&ostr->c_lock);
 	assert(ostr->so_inflight > 0);
@@ -128,25 +123,94 @@ _output_async_unref(struct nmsg_stream_output *ostr)
 	pthread_mutex_unlock(&ostr->c_lock);
 }
 
+/*
+ * How many slots a pool of this size needs.
+ *
+ * One slot per worker covers everything that can be in flight, and the margin
+ * leaves room to deposit into. Past that, more depth only defers backpressure,
+ * and what it would be covering for is a slow write -- which is single-threaded
+ * on the committer, and no amount of depth helps.
+ *
+ * Sized here rather than fixed because the worker count spans an order of
+ * magnitude across the boxes this runs on, and a buffer sized for the largest
+ * is megabytes that a two-worker output never touches.
+ */
+static unsigned
+async_depth_for(unsigned nworkers)
+{
+	unsigned depth = nworkers + ASYNC_REORDER_MARGIN;
+
+	return (depth < ASYNC_DEPTH_MIN ? ASYNC_DEPTH_MIN : depth);
+}
+
+/*
+ * Cores this process may run on. nmsgtool computes the same thing for its own
+ * sizing, but sees only the public header and cannot reach this one.
+ */
+static long
+async_ncpu(void)
+{
+	long ncpu = -1;
+#ifdef __linux__
+	cpu_set_t set;
+
+	if (sched_getaffinity(0, sizeof(set), &set) == 0)
+		ncpu = CPU_COUNT(&set);
+#endif /* __linux__ */
+
+	if (ncpu < 1)
+		ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+	if (ncpu < 1)
+		ncpu = 1;
+
+	return (ncpu);
+}
+
+/*
+ * Compressor threads one output may have. Compression is CPU-bound, so more
+ * than one thread per core cannot help; past that they only add context
+ * switches and reorder buffer.
+ *
+ * This is a backstop for callers passing an arbitrary count. nmsgtool sizes
+ * its own request against the readers it is actually running.
+ */
+static unsigned
+async_max_workers(void)
+{
+	long ncpu = async_ncpu();
+
+	if (ncpu < ASYNC_DEPTH_MIN)
+		ncpu = ASYNC_DEPTH_MIN;
+
+	return ((unsigned)(ncpu - ASYNC_REORDER_MARGIN));
+}
+
 nmsg_res
-_output_async_init(nmsg_output_t output, unsigned nworkers) {
+_output_async_init(nmsg_output_t output, unsigned nworkers)
+{
 	struct nmsg_stream_output *ostr = output->stream;
-	struct nmsg_ostr_async *pool;
-	nmsg_res res, old_res = nmsg_res_success;
+	struct nmsg_ostr_async	  *pool;
+	nmsg_res		   res, old_res = nmsg_res_success;
+	unsigned		   depth, max_workers;
+	bool			   same_ceiling;
 
 	if (nworkers == 0)
 		return (nmsg_res_success);
 
-	if (nworkers > ASYNC_MAX_WORKERS)
-		nworkers = ASYNC_MAX_WORKERS;
+	max_workers = async_max_workers();
+	if (nworkers > max_workers)
+		nworkers = max_workers;
+
+	depth = async_depth_for(nworkers);
 
 	/*
-	 * An existing pool's ceiling cannot be changed in place, since its
-	 * worker array and ring are already sized, so a different count means
-	 * building a replacement. Do that before tearing the old one down: if
-	 * the allocation fails there is still a working pool to keep.
+	 * A pool's ceiling cannot change in place, so a different count means
+	 * a replacement. Build it before tearing the old one down, so a failed
+	 * allocation leaves the working pool in place.
 	 */
-	if (ostr->so_pool != NULL && ostr->so_pool->nworkers == nworkers)
+	same_ceiling = ostr->so_pool != NULL &&
+		       ostr->so_pool->nworkers == nworkers;
+	if (same_ceiling)
 		return (nmsg_res_success);
 
 	pool = calloc(1, sizeof(*pool));
@@ -155,7 +219,7 @@ _output_async_init(nmsg_output_t output, unsigned nworkers) {
 
 	res = nmsg_res_memfail;
 
-	pool->slots = calloc(ASYNC_RING_DEPTH, sizeof(*pool->slots));
+	pool->slots = calloc(depth, sizeof(*pool->slots));
 	if (pool->slots == NULL)
 		goto fail_slots;
 
@@ -174,7 +238,7 @@ _output_async_init(nmsg_output_t output, unsigned nworkers) {
 	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
 		goto fail_slot_free;
 
-	pool->depth = ASYNC_RING_DEPTH;
+	pool->depth = depth;
 	pool->nworkers = nworkers;
 	pool->output = output;
 
@@ -184,19 +248,15 @@ _output_async_init(nmsg_output_t output, unsigned nworkers) {
 	pthread_mutex_lock(&ostr->c_lock);
 
 	/*
-	 * Tickets count for the life of the stream, not the life of the pool,
-	 * so a pool built after the first write must start where the stream has
-	 * got to. Seeded under c_lock, and the pool is published in the same
-	 * hold, so a ticket either predates the pool and is compressed inline or
-	 * belongs to it and is at or above commit_next -- never below, where the
-	 * committer would wait for it forever.
+	 * Tickets span the stream, not the pool, so a pool built mid-stream
+	 * must start where the stream got to. Seeded and published in one
+	 * c_lock hold, so a ticket either predates the pool or is at or above
+	 * commit_next -- never below, where the committer would wait for it
+	 * forever.
 	 */
 	pool->commit_next = pool->issued = ostr->so_ticket;
 
-	/*
-	 * Carry any error the previous pool recorded but had not yet reported,
-	 * so replacing a pool does not swallow a failed write.
-	 */
+	/* Carry the old pool's unreported error rather than swallow it. */
 	pool->first_error = old_res;
 
 	ostr->so_pool = pool;
@@ -222,26 +282,25 @@ fail_slots:
 }
 
 /*
- * Stop the pool and reclaim it. Everything still queued is written first.
- * Must run before the stream's fd, random and locks go away, since the threads
- * use all of them.
+ * Stop the pool and reclaim it, writing everything still queued. Must run
+ * before the stream's fd, random and locks go away; the threads use all three.
  */
 nmsg_res
-_output_async_destroy(nmsg_output_t output) {
+_output_async_destroy(nmsg_output_t output)
+{
 	struct nmsg_stream_output *ostr = output->stream;
-	struct nmsg_ostr_async *pool = ostr->so_pool;
-	nmsg_res res;
-	bool started;
-	unsigned i, nstarted;
+	struct nmsg_ostr_async	  *pool = ostr->so_pool;
+	nmsg_res		   res;
+	bool			   started;
+	unsigned		   i, nstarted;
 
 	if (pool == NULL)
 		return (nmsg_res_success);
 
 	/*
-	 * Stop handing tickets to the pool, then wait for the ones already
-	 * handed out to arrive. Both happen under c_lock, which is what orders
-	 * them against ticket issuance: once this returns, no producer is still
-	 * on its way here holding a ticket the committer will wait for.
+	 * Stop issuing tickets to the pool, then wait for the outstanding ones
+	 * to arrive. Both under c_lock, which orders them against issuance:
+	 * once this returns, no producer is still en route with a ticket.
 	 */
 	pthread_mutex_lock(&ostr->c_lock);
 	ostr->so_pool_closing = true;
@@ -250,27 +309,22 @@ _output_async_destroy(nmsg_output_t output) {
 	pthread_mutex_unlock(&ostr->c_lock);
 
 	pthread_mutex_lock(&pool->lock);
-	pool->shutdown = true;		/* Set under the lock: a thread about */
-	started = pool->started;	/* to wait would miss the wakeup. */
+	pool->shutdown = true;	 /* Set under the lock: a thread about */
+	started = pool->started; /* to wait would miss the wakeup. */
 	nstarted = pool->nstarted;
 	pthread_cond_broadcast(&pool->work_ready);
 	pthread_cond_broadcast(&pool->commit_ready);
 	pthread_cond_broadcast(&pool->slot_free);
 	pthread_mutex_unlock(&pool->lock);
 
-	/*
-	 * Workers and committer are joined on their own counters.
-	 */
 	for (i = 0; i < nstarted; i++)
 		pthread_join(pool->workers[i], NULL);
 	if (started)
 		pthread_join(pool->committer, NULL);
 
 	if (pool->n_inline > 0 || pool->n_waited > 0)
-		_nmsg_dprintf(2, "%s: %u of %u worker(s) started; %" PRIu64
-			      " container(s) compressed by the reader, %" PRIu64
-			      " wait(s) for a free slot\n", __func__, nstarted,
-			      pool->nworkers, pool->n_inline, pool->n_waited);
+		_nmsg_dprintf(2, "%s: %u of %u worker(s) started, %u slot(s); %" PRIu64 " container(s) compressed by the reader, %" PRIu64 " wait(s) for a free slot\n", __func__, nstarted,
+			      pool->nworkers, pool->depth, pool->n_inline, pool->n_waited);
 
 	/* Read after the joins; the threads write it until they exit. */
 	res = pool->first_error;
@@ -300,24 +354,42 @@ async_record_error(struct nmsg_ostr_async *pool, nmsg_res res)
 }
 
 /*
- * Compressor thread. Takes any slot that needs compressing, in whatever order
- * they become ready: compression order does not matter, only write order does,
- * and the committer enforces that.
+ * The slot this ticket owns is still held by the ticket 'depth' earlier.
+ * Caller holds pool->lock.
+ */
+static bool
+async_slot_busy(const struct nmsg_ostr_async *pool, uint64_t ticket)
+{
+	return (ticket >= pool->commit_next + pool->depth);
+}
+
+/*
+ * Every ticket the pool was given has been written. Caller holds pool->lock.
+ */
+static bool
+async_all_written(const struct nmsg_ostr_async *pool)
+{
+	return (pool->commit_next >= pool->issued);
+}
+
+/*
+ * Compressor thread. Takes any slot needing work, in any order: only write
+ * order matters, and the committer enforces that.
  */
 static void *
 async_worker(void *arg)
 {
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *)arg;
 
 	pthread_mutex_lock(&pool->lock);
 
 	for (;;) {
 		struct async_slot *slot = NULL;
-		nmsg_container_t co;
-		uint8_t *buf;
-		size_t buf_len;
-		nmsg_res res;
-		unsigned i;
+		nmsg_container_t   co;
+		uint8_t		  *buf;
+		size_t		   buf_len;
+		nmsg_res	   res;
+		unsigned	   i;
 
 		for (i = 0; i < pool->depth; i++) {
 			if (pool->slots[i].state == slot_work) {
@@ -328,10 +400,9 @@ async_worker(void *arg)
 
 		if (slot == NULL) {
 			/*
-			 * Nothing to compress. Exit only once the producers
-			 * have stopped, so a container queued just before
-			 * shutdown is still compressed and written; that
-			 * happens on every clean SIGTERM.
+			 * Exit only once producers have stopped, so a
+			 * container queued just before shutdown is still
+			 * written. Happens on every clean SIGTERM.
 			 */
 			if (pool->shutdown)
 				break;
@@ -347,7 +418,7 @@ async_worker(void *arg)
 		res = _output_nmsg_container_compress(pool->output, &co, &buf, &buf_len);
 
 		pthread_mutex_lock(&pool->lock);
-		pool->busy--;		/* Counted at deposit; see container_submit(). */
+		pool->busy--; /* Counted at deposit; see container_submit(). */
 		slot->buf = buf;
 		slot->buf_len = buf_len;
 		slot->res = res;
@@ -361,25 +432,23 @@ async_worker(void *arg)
 }
 
 /*
- * The only thread that writes. It takes tickets strictly in order, so the file
- * is byte-identical to what the synchronous path would have produced no matter
- * how many workers compressed in parallel.
- *
- * It is also the only caller of _output_nmsg_frag_write().
+ * The only thread that writes, and the only caller of
+ * _output_nmsg_frag_write(). Takes tickets strictly in order, so the file
+ * matches what the synchronous path would have produced.
  */
 static void *
 async_committer(void *arg)
 {
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *)arg;
 
 	pthread_mutex_lock(&pool->lock);
 
 	for (;;) {
 		struct async_slot *slot = &pool->slots[pool->commit_next % pool->depth];
-		uint8_t *buf;
-		size_t buf_len;
-		nmsg_container_t co;
-		nmsg_res res = nmsg_res_success;
+		uint8_t		  *buf;
+		size_t		   buf_len;
+		nmsg_container_t   co;
+		nmsg_res	   res = nmsg_res_success;
 
 		switch (slot->state) {
 		case slot_done:
@@ -390,9 +459,8 @@ async_committer(void *arg)
 			pthread_mutex_unlock(&pool->lock);
 
 			/*
-			 * _output_nmsg_send_buffer() frees buf. It is not called when the
-			 * compression failed, but then buf is NULL anyway; see
-			 * _output_nmsg_container_compress().
+			 * _output_nmsg_send_buffer() frees buf; not called on
+			 * a compression failure, where buf is NULL anyway.
 			 */
 			if (res == nmsg_res_success)
 				res = _output_nmsg_send_buffer(pool->output, buf, buf_len);
@@ -405,7 +473,7 @@ async_committer(void *arg)
 			slot->co = NULL;
 			pthread_mutex_unlock(&pool->lock);
 
-			/* _output_nmsg_frag_write() takes the container by value and destroys it. */
+			/* Takes the container by value and destroys it. */
 			res = _output_nmsg_frag_write(pool->output, co);
 
 			pthread_mutex_lock(&pool->lock);
@@ -415,11 +483,10 @@ async_committer(void *arg)
 		case slot_work:
 		case slot_taken:
 			/*
-			 * The next ticket is not ready. Exit only when the
-			 * producers have stopped and every ticket they issued
-			 * has been written.
+			 * Not ready. Exit only once producers have stopped and
+			 * every ticket they issued has been written.
 			 */
-			if (pool->shutdown && pool->commit_next >= pool->issued)
+			if (pool->shutdown && async_all_written(pool))
 				goto out;
 			pthread_cond_wait(&pool->commit_ready, &pool->lock);
 			continue;
@@ -438,14 +505,10 @@ out:
 }
 
 /*
- * Start the committer. Called under pool->lock on first submit rather than when
- * the output is configured, because nmsgtool creates its outputs before it
- * daemonizes, and daemonize() is a bare fork() which no thread survives.
- * Starting on first write puts the threads in whichever process does the
- * writing.
- *
- * Only the committer starts here. Workers are added by async_spawn_worker() as
- * load calls for them.
+ * Start the committer, under pool->lock on first submit rather than at
+ * configure time: nmsgtool creates its outputs before daemonize(), which is a
+ * bare fork() no thread survives. Workers are added later by
+ * async_spawn_worker().
  */
 static void
 async_start(struct nmsg_ostr_async *pool)
@@ -455,10 +518,9 @@ async_start(struct nmsg_ostr_async *pool)
 	pthread_res = pthread_create(&pool->committer, NULL, async_committer, pool);
 	if (pthread_res != 0) {
 		/*
-		 * Nothing can be written without a committer, so give up on the
-		 * pool entirely and compress inline from here on. No worker has
-		 * been created yet and no container has been deposited, so there
-		 * is nothing to unwind.
+		 * Nothing can be written without a committer, so abandon the
+		 * pool and compress inline. Nothing has been deposited yet to
+		 * unwind.
 		 */
 		pool->failed = true;
 		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
@@ -471,12 +533,10 @@ async_start(struct nmsg_ostr_async *pool)
 
 /*
  * Add a compressor thread, up to the ceiling. Called under pool->lock when a
- * producer finds every existing worker busy, so the pool grows to the load it
- * actually sees instead of to the configured ceiling.
+ * producer finds every worker busy, so the pool grows to the load it sees.
  *
- * Returns false if the thread could not be created, which is not fatal: the
- * caller compresses that container itself and the pool keeps running with the
- * workers it has.
+ * Returns false if the thread could not be created: not fatal, the caller
+ * compresses that container itself.
  */
 static bool
 async_spawn_worker(struct nmsg_ostr_async *pool)
@@ -503,10 +563,9 @@ async_spawn_worker(struct nmsg_ostr_async *pool)
 /*
  * Wait until every ticket issued so far has been written, and take any error
  * the pool recorded. Under nmsg_io this cannot starve: check_close_event()
- * holds io_output->refcount across the write and call_close_fp() waits for it
- * to drop, so no other thread is inside nmsg_output_write() while a close runs.
- * A caller driving nmsg_output_flush() directly from several threads has no
- * such guarantee.
+ * holds io_output->refcount across the write, so no writer is inside
+ * nmsg_output_write() while a close runs. Callers driving nmsg_output_flush()
+ * from several threads have no such guarantee.
  */
 nmsg_res
 _output_async_drain(struct nmsg_ostr_async *pool)
@@ -517,7 +576,7 @@ _output_async_drain(struct nmsg_ostr_async *pool)
 		return (nmsg_res_success);
 
 	pthread_mutex_lock(&pool->lock);
-	while (!pool->failed && pool->commit_next < pool->issued)
+	while (!pool->failed && !async_all_written(pool))
 		pthread_cond_wait(&pool->slot_free, &pool->lock);
 	res = pool->first_error;
 	pool->first_error = nmsg_res_success;
@@ -528,35 +587,37 @@ _output_async_drain(struct nmsg_ostr_async *pool)
 
 /*
  * Hand a sealed container to the pool, consuming it only if the pool takes it.
- * Returns false if it does not, and the caller writes the container itself.
- * The pool reference is released either way.
+ * Returns false if it does not, leaving it for the caller to write. The pool
+ * reference is released either way.
  *
- * On success *res_out carries the error from an EARLIER container, since the
- * one just handed over has not been written yet.
+ * *res_out carries an EARLIER container's error; this one is not written yet.
  */
-bool
-_output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
-		     nmsg_container_t *co, bool is_frag, uint64_t ticket,
-		     nmsg_res *res_out)
+bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
+			  nmsg_container_t *co, bool is_frag, uint64_t ticket,
+			  nmsg_res *res_out)
 {
 	struct nmsg_stream_output *ostr = output->stream;
-	struct async_slot *slot;
-	nmsg_res res = nmsg_res_success;
-	uint8_t *buf;
-	size_t buf_len;
-	bool inline_compress = false;
+	struct async_slot	  *slot;
+	nmsg_res		   res = nmsg_res_success;
+	uint8_t			  *buf;
+	size_t			   buf_len;
+	bool			   inline_compress = false;
+	bool			   committer_needed, pool_usable;
+	bool			   worker_idle, below_ceiling;
 
 	pthread_mutex_lock(&pool->lock);
 
-	if (!pool->started && !pool->failed && !pool->shutdown)
+	committer_needed = !pool->started && !pool->failed && !pool->shutdown;
+	if (committer_needed)
 		async_start(pool);
 
 	/*
-	 * Only reachable when the committer could not be started: teardown drains
-	 * outstanding tickets before setting shutdown, so a ticket that got this
-	 * far still has a pool to go to.
+	 * Read after the attempt, since async_start() sets started or failed.
+	 * Only false when the committer could not start: teardown drains
+	 * outstanding tickets before setting shutdown.
 	 */
-	if (!pool->started || pool->failed || pool->shutdown) {
+	pool_usable = pool->started && !pool->failed && !pool->shutdown;
+	if (!pool_usable) {
 		pthread_mutex_unlock(&pool->lock);
 		_output_async_unref(ostr);
 		return (false);
@@ -565,13 +626,12 @@ _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	slot = &pool->slots[ticket % pool->depth];
 
 	/*
-	 * Wait for the slot this ticket owns, which the ticket 'depth' earlier
-	 * releases when it is written. Only reached when the writer has fallen
-	 * a whole ring behind.
+	 * Wait for the slot this ticket owns, released by the ticket 'depth'
+	 * earlier. Only reached when the writer is a full 'depth' behind.
 	 */
-	if (ticket >= pool->commit_next + pool->depth) {
+	if (async_slot_busy(pool, ticket)) {
 		pool->n_waited++;
-		while (ticket >= pool->commit_next + pool->depth && !pool->shutdown)
+		while (async_slot_busy(pool, ticket) && !pool->shutdown)
 			pthread_cond_wait(&pool->slot_free, &pool->lock);
 	}
 
@@ -580,29 +640,24 @@ _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	if (ticket >= pool->issued)
 		pool->issued = ticket + 1;
 
+	worker_idle = pool->busy < pool->nstarted;
+	below_ceiling = pool->nstarted < pool->nworkers;
+
 	if (is_frag) {
 		/* Only the committer fragments; see async_committer(). */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_frag;
 		pthread_cond_broadcast(&pool->commit_ready);
-	} else if (pool->busy < pool->nstarted ||
-		   (pool->nstarted < pool->nworkers && async_spawn_worker(pool)))
-	{
-		/*
-		 * A worker is free, or the ceiling left room to add one: hand
-		 * the container over and get back to reading.
-		 */
+	} else if (worker_idle || (below_ceiling && async_spawn_worker(pool))) {
+		/* Hand the container over and get back to reading. */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_work;
 		pool->busy++;
 		pthread_cond_signal(&pool->work_ready);
 	} else {
-		/*
-		 * Every worker is busy and the ceiling is reached. Compress it
-		 * here rather than wait, then deposit the result and return.
-		 */
+		/* Everyone busy and at the ceiling: compress here. */
 		slot->state = slot_taken;
 		pool->n_inline++;
 		inline_compress = true;

--- a/nmsg/output_async.c
+++ b/nmsg/output_async.c
@@ -1,0 +1,631 @@
+/*
+ * Copyright (c) 2026 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The compressor pool for a stream output.
+ *
+ * Everything here is private to this unit: the ring, its slot states and the
+ * threads that walk it. output_nmsg.c hands a sealed container over with
+ * _output_async_submit() and gets the bytes written for it, and calls back
+ * into that file for the actual compressing and writing.
+ */
+
+/* Import. */
+
+#include "private.h"
+
+/* Data structures. */
+
+/*
+ * A compressor pool: a ring of slots, up to nworkers compressor threads and
+ * one committer thread.
+ *
+ * A container is given a ticket when it is sealed, under c_lock, so tickets
+ * follow the order the containers were closed in. Slot i serves every ticket
+ * with (ticket % depth) == i, so the producer of ticket T waits only for
+ * ticket T - depth to have been written.
+ *
+ * Compression runs on whichever thread is free. Only the committer writes, and
+ * only in ticket order, so the byte stream is identical to the synchronous
+ * path however many workers are running.
+ *
+ * A producer that finds every worker busy compresses the container itself
+ * rather than waiting. That is exactly what the synchronous path does, so the
+ * pool is never slower than no pool at all.
+ *
+ * Workers are spawned on demand rather than up front, so 'nworkers' is a
+ * ceiling and not an allocation. Once spawned a worker lives until the pool is destroyed.
+ */
+
+/*
+ * Ring size, independent of the worker ceiling. A slot itself is tiny; what it
+ * costs is the container it points at while a ticket is in flight, so the depth
+ * bounds worst-case backlog rather than resident memory. The margin keeps slots
+ * available for producers to deposit into while every worker is busy, and
+ * capping the ceiling at depth - margin stops the pool having more compressors
+ * than places to put their output.
+ */
+#define ASYNC_RING_DEPTH	32
+#define ASYNC_RING_MARGIN	8
+#define ASYNC_MAX_WORKERS	(ASYNC_RING_DEPTH - ASYNC_RING_MARGIN)
+
+typedef enum {
+	slot_empty = 0,	/* Free. */
+	slot_work,	/* Container waiting for a compressor. */
+	slot_taken,	/* A worker or a producer is compressing it. */
+	slot_done,	/* Compressed, waiting its turn to be written. */
+	slot_frag	/* Oversized: the committer must fragment it itself. */
+} async_slot_state;
+
+struct async_slot {
+	async_slot_state	state;
+	nmsg_container_t	co;		/* slot_work, slot_frag */
+	uint8_t			*buf;		/* slot_done */
+	size_t			buf_len;
+	nmsg_res		res;
+};
+
+struct nmsg_ostr_async {
+	pthread_mutex_t		lock;
+	pthread_cond_t		work_ready;	/* A slot became slot_work. */
+	pthread_cond_t		commit_ready;	/* The committer's slot is ready. */
+	pthread_cond_t		slot_free;	/* A slot became slot_empty. */
+	struct async_slot	*slots;
+	unsigned		depth;
+	unsigned		nworkers;	/* Ceiling; workers start on demand. */
+	unsigned		nstarted;	/* Workers that exist and must be joined. */
+	unsigned		busy;		/* Containers assigned to workers. */
+	uint64_t		issued;		/* Highest ticket claimed, plus one. */
+	uint64_t		commit_next;	/* Ticket allowed to write now. */
+	bool			shutdown;
+	bool			started;	/* Committer exists; must be joined. */
+	bool			failed;		/* No committer; stay inline. */
+	bool			spawn_failed;	/* Worker spawn failed; logged once. */
+	pthread_t		*workers;
+	pthread_t		committer;
+	nmsg_res		first_error;	/* Sticky; surfaced by flush. */
+	nmsg_output_t		output;
+	uint64_t		n_inline;	/* Containers a producer compressed. */
+	uint64_t		n_waited;	/* Producers that waited for a slot. */
+};
+
+/*
+ * Take a reference to the stream's pool, or return NULL if there is none or it
+ * is being torn down. Caller holds c_lock.
+ */
+struct nmsg_ostr_async *
+_output_async_ref(struct nmsg_stream_output *ostr)
+{
+	if (ostr->so_pool == NULL || ostr->so_pool_closing)
+		return (NULL);
+
+	ostr->so_inflight++;
+
+	return (ostr->so_pool);
+}
+
+/* Drop a reference taken by _output_async_ref() and wake any waiting teardown. */
+void
+_output_async_unref(struct nmsg_stream_output *ostr)
+{
+	pthread_mutex_lock(&ostr->c_lock);
+	assert(ostr->so_inflight > 0);
+	if (--ostr->so_inflight == 0)
+		pthread_cond_broadcast(&ostr->c_drained);
+	pthread_mutex_unlock(&ostr->c_lock);
+}
+
+nmsg_res
+_output_async_init(nmsg_output_t output, unsigned nworkers) {
+	struct nmsg_stream_output *ostr = output->stream;
+	struct nmsg_ostr_async *pool;
+	nmsg_res res, old_res = nmsg_res_success;
+
+	if (nworkers == 0)
+		return (nmsg_res_success);
+
+	if (nworkers > ASYNC_MAX_WORKERS)
+		nworkers = ASYNC_MAX_WORKERS;
+
+	/*
+	 * An existing pool's ceiling cannot be changed in place, since its
+	 * worker array and ring are already sized, so a different count means
+	 * building a replacement. Do that before tearing the old one down: if
+	 * the allocation fails there is still a working pool to keep.
+	 */
+	if (ostr->so_pool != NULL && ostr->so_pool->nworkers == nworkers)
+		return (nmsg_res_success);
+
+	pool = calloc(1, sizeof(*pool));
+	if (pool == NULL)
+		return (nmsg_res_memfail);
+
+	res = nmsg_res_memfail;
+
+	pool->slots = calloc(ASYNC_RING_DEPTH, sizeof(*pool->slots));
+	if (pool->slots == NULL)
+		goto fail_slots;
+
+	pool->workers = calloc(nworkers, sizeof(*pool->workers));
+	if (pool->workers == NULL)
+		goto fail_workers;
+
+	res = nmsg_res_failure;
+
+	if (pthread_mutex_init(&pool->lock, NULL) != 0)
+		goto fail_mutex;
+	if (pthread_cond_init(&pool->work_ready, NULL) != 0)
+		goto fail_work_ready;
+	if (pthread_cond_init(&pool->commit_ready, NULL) != 0)
+		goto fail_commit_ready;
+	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
+		goto fail_slot_free;
+
+	pool->depth = ASYNC_RING_DEPTH;
+	pool->nworkers = nworkers;
+	pool->output = output;
+
+	if (ostr->so_pool != NULL)
+		old_res = _output_async_destroy(output);
+
+	pthread_mutex_lock(&ostr->c_lock);
+
+	/*
+	 * Tickets count for the life of the stream, not the life of the pool,
+	 * so a pool built after the first write must start where the stream has
+	 * got to. Seeded under c_lock, and the pool is published in the same
+	 * hold, so a ticket either predates the pool and is compressed inline or
+	 * belongs to it and is at or above commit_next -- never below, where the
+	 * committer would wait for it forever.
+	 */
+	pool->commit_next = pool->issued = ostr->so_ticket;
+
+	/*
+	 * Carry any error the previous pool recorded but had not yet reported,
+	 * so replacing a pool does not swallow a failed write.
+	 */
+	pool->first_error = old_res;
+
+	ostr->so_pool = pool;
+	pthread_mutex_unlock(&ostr->c_lock);
+
+	return (nmsg_res_success);
+
+fail_slot_free:
+	pthread_cond_destroy(&pool->commit_ready);
+fail_commit_ready:
+	pthread_cond_destroy(&pool->work_ready);
+fail_work_ready:
+	pthread_mutex_destroy(&pool->lock);
+fail_mutex:
+	free(pool->workers);
+fail_workers:
+	free(pool->slots);
+fail_slots:
+	free(pool);
+
+	/* Whatever pool was already in place is untouched and still running. */
+	return (res);
+}
+
+/*
+ * Stop the pool and reclaim it. Everything still queued is written first.
+ * Must run before the stream's fd, random and locks go away, since the threads
+ * use all of them.
+ */
+nmsg_res
+_output_async_destroy(nmsg_output_t output) {
+	struct nmsg_stream_output *ostr = output->stream;
+	struct nmsg_ostr_async *pool = ostr->so_pool;
+	nmsg_res res;
+	bool started;
+	unsigned i, nstarted;
+
+	if (pool == NULL)
+		return (nmsg_res_success);
+
+	/*
+	 * Stop handing tickets to the pool, then wait for the ones already
+	 * handed out to arrive. Both happen under c_lock, which is what orders
+	 * them against ticket issuance: once this returns, no producer is still
+	 * on its way here holding a ticket the committer will wait for.
+	 */
+	pthread_mutex_lock(&ostr->c_lock);
+	ostr->so_pool_closing = true;
+	while (ostr->so_inflight > 0)
+		pthread_cond_wait(&ostr->c_drained, &ostr->c_lock);
+	pthread_mutex_unlock(&ostr->c_lock);
+
+	pthread_mutex_lock(&pool->lock);
+	pool->shutdown = true;		/* Set under the lock: a thread about */
+	started = pool->started;	/* to wait would miss the wakeup. */
+	nstarted = pool->nstarted;
+	pthread_cond_broadcast(&pool->work_ready);
+	pthread_cond_broadcast(&pool->commit_ready);
+	pthread_cond_broadcast(&pool->slot_free);
+	pthread_mutex_unlock(&pool->lock);
+
+	/*
+	 * Workers and committer are joined on their own counters.
+	 */
+	for (i = 0; i < nstarted; i++)
+		pthread_join(pool->workers[i], NULL);
+	if (started)
+		pthread_join(pool->committer, NULL);
+
+	if (pool->n_inline > 0 || pool->n_waited > 0)
+		_nmsg_dprintf(2, "%s: %u of %u worker(s) started; %" PRIu64
+			      " container(s) compressed by the reader, %" PRIu64
+			      " wait(s) for a free slot\n", __func__, nstarted,
+			      pool->nworkers, pool->n_inline, pool->n_waited);
+
+	/* Read after the joins; the threads write it until they exit. */
+	res = pool->first_error;
+
+	pthread_mutex_lock(&ostr->c_lock);
+	ostr->so_pool = NULL;
+	ostr->so_pool_closing = false;
+	pthread_mutex_unlock(&ostr->c_lock);
+
+	pthread_cond_destroy(&pool->slot_free);
+	pthread_cond_destroy(&pool->commit_ready);
+	pthread_cond_destroy(&pool->work_ready);
+	pthread_mutex_destroy(&pool->lock);
+	free(pool->workers);
+	free(pool->slots);
+	free(pool);
+
+	return (res);
+}
+
+/* Note an error, keeping the first one seen. Caller holds pool->lock. */
+static void
+async_record_error(struct nmsg_ostr_async *pool, nmsg_res res)
+{
+	if (res != nmsg_res_success && pool->first_error == nmsg_res_success)
+		pool->first_error = res;
+}
+
+/*
+ * Compressor thread. Takes any slot that needs compressing, in whatever order
+ * they become ready: compression order does not matter, only write order does,
+ * and the committer enforces that.
+ */
+static void *
+async_worker(void *arg)
+{
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+
+	pthread_mutex_lock(&pool->lock);
+
+	for (;;) {
+		struct async_slot *slot = NULL;
+		nmsg_container_t co;
+		uint8_t *buf;
+		size_t buf_len;
+		nmsg_res res;
+		unsigned i;
+
+		for (i = 0; i < pool->depth; i++) {
+			if (pool->slots[i].state == slot_work) {
+				slot = &pool->slots[i];
+				break;
+			}
+		}
+
+		if (slot == NULL) {
+			/*
+			 * Nothing to compress. Exit only once the producers
+			 * have stopped, so a container queued just before
+			 * shutdown is still compressed and written; that
+			 * happens on every clean SIGTERM.
+			 */
+			if (pool->shutdown)
+				break;
+			pthread_cond_wait(&pool->work_ready, &pool->lock);
+			continue;
+		}
+
+		slot->state = slot_taken;
+		co = slot->co;
+		slot->co = NULL;
+		pthread_mutex_unlock(&pool->lock);
+
+		res = _output_nmsg_container_compress(pool->output, &co, &buf, &buf_len);
+
+		pthread_mutex_lock(&pool->lock);
+		pool->busy--;		/* Counted at deposit; see container_submit(). */
+		slot->buf = buf;
+		slot->buf_len = buf_len;
+		slot->res = res;
+		slot->state = slot_done;
+		pthread_cond_broadcast(&pool->commit_ready);
+	}
+
+	pthread_mutex_unlock(&pool->lock);
+
+	return (NULL);
+}
+
+/*
+ * The only thread that writes. It takes tickets strictly in order, so the file
+ * is byte-identical to what the synchronous path would have produced no matter
+ * how many workers compressed in parallel.
+ *
+ * It is also the only caller of _output_nmsg_frag_write().
+ */
+static void *
+async_committer(void *arg)
+{
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+
+	pthread_mutex_lock(&pool->lock);
+
+	for (;;) {
+		struct async_slot *slot = &pool->slots[pool->commit_next % pool->depth];
+		uint8_t *buf;
+		size_t buf_len;
+		nmsg_container_t co;
+		nmsg_res res = nmsg_res_success;
+
+		switch (slot->state) {
+		case slot_done:
+			buf = slot->buf;
+			buf_len = slot->buf_len;
+			res = slot->res;
+			slot->buf = NULL;
+			pthread_mutex_unlock(&pool->lock);
+
+			/*
+			 * _output_nmsg_send_buffer() frees buf. It is not called when the
+			 * compression failed, but then buf is NULL anyway; see
+			 * _output_nmsg_container_compress().
+			 */
+			if (res == nmsg_res_success)
+				res = _output_nmsg_send_buffer(pool->output, buf, buf_len);
+
+			pthread_mutex_lock(&pool->lock);
+			break;
+
+		case slot_frag:
+			co = slot->co;
+			slot->co = NULL;
+			pthread_mutex_unlock(&pool->lock);
+
+			/* _output_nmsg_frag_write() takes the container by value and destroys it. */
+			res = _output_nmsg_frag_write(pool->output, co);
+
+			pthread_mutex_lock(&pool->lock);
+			break;
+
+		case slot_empty:
+		case slot_work:
+		case slot_taken:
+			/*
+			 * The next ticket is not ready. Exit only when the
+			 * producers have stopped and every ticket they issued
+			 * has been written.
+			 */
+			if (pool->shutdown && pool->commit_next >= pool->issued)
+				goto out;
+			pthread_cond_wait(&pool->commit_ready, &pool->lock);
+			continue;
+		}
+
+		async_record_error(pool, res);
+		slot->state = slot_empty;
+		pool->commit_next++;
+		pthread_cond_broadcast(&pool->slot_free);
+	}
+
+out:
+	pthread_mutex_unlock(&pool->lock);
+
+	return (NULL);
+}
+
+/*
+ * Start the committer. Called under pool->lock on first submit rather than when
+ * the output is configured, because nmsgtool creates its outputs before it
+ * daemonizes, and daemonize() is a bare fork() which no thread survives.
+ * Starting on first write puts the threads in whichever process does the
+ * writing.
+ *
+ * Only the committer starts here. Workers are added by async_spawn_worker() as
+ * load calls for them.
+ */
+static void
+async_start(struct nmsg_ostr_async *pool)
+{
+	int pthread_res;
+
+	pthread_res = pthread_create(&pool->committer, NULL, async_committer, pool);
+	if (pthread_res != 0) {
+		/*
+		 * Nothing can be written without a committer, so give up on the
+		 * pool entirely and compress inline from here on. No worker has
+		 * been created yet and no container has been deposited, so there
+		 * is nothing to unwind.
+		 */
+		pool->failed = true;
+		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
+			      strerror(pthread_res));
+		return;
+	}
+
+	pool->started = true;
+}
+
+/*
+ * Add a compressor thread, up to the ceiling. Called under pool->lock when a
+ * producer finds every existing worker busy, so the pool grows to the load it
+ * actually sees instead of to the configured ceiling.
+ *
+ * Returns false if the thread could not be created, which is not fatal: the
+ * caller compresses that container itself and the pool keeps running with the
+ * workers it has.
+ */
+static bool
+async_spawn_worker(struct nmsg_ostr_async *pool)
+{
+	int pthread_res;
+
+	pthread_res = pthread_create(&pool->workers[pool->nstarted], NULL,
+				     async_worker, pool);
+	if (pthread_res != 0) {
+		/* Logged once; a persistent failure would flood the log. */
+		if (!pool->spawn_failed) {
+			pool->spawn_failed = true;
+			_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n",
+				      __func__, strerror(pthread_res));
+		}
+		return (false);
+	}
+
+	pool->nstarted++;
+
+	return (true);
+}
+
+/*
+ * Wait until every ticket issued so far has been written, and take any error
+ * the pool recorded. Under nmsg_io this cannot starve: check_close_event()
+ * holds io_output->refcount across the write and call_close_fp() waits for it
+ * to drop, so no other thread is inside nmsg_output_write() while a close runs.
+ * A caller driving nmsg_output_flush() directly from several threads has no
+ * such guarantee.
+ */
+nmsg_res
+_output_async_drain(struct nmsg_ostr_async *pool)
+{
+	nmsg_res res;
+
+	if (pool == NULL)
+		return (nmsg_res_success);
+
+	pthread_mutex_lock(&pool->lock);
+	while (!pool->failed && pool->commit_next < pool->issued)
+		pthread_cond_wait(&pool->slot_free, &pool->lock);
+	res = pool->first_error;
+	pool->first_error = nmsg_res_success;
+	pthread_mutex_unlock(&pool->lock);
+
+	return (res);
+}
+
+/*
+ * Hand a sealed container to the pool, consuming it only if the pool takes it.
+ * Returns false if it does not, and the caller writes the container itself.
+ * The pool reference is released either way.
+ *
+ * On success *res_out carries the error from an EARLIER container, since the
+ * one just handed over has not been written yet.
+ */
+bool
+_output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
+		     nmsg_container_t *co, bool is_frag, uint64_t ticket,
+		     nmsg_res *res_out)
+{
+	struct nmsg_stream_output *ostr = output->stream;
+	struct async_slot *slot;
+	nmsg_res res = nmsg_res_success;
+	uint8_t *buf;
+	size_t buf_len;
+	bool inline_compress = false;
+
+	pthread_mutex_lock(&pool->lock);
+
+	if (!pool->started && !pool->failed && !pool->shutdown)
+		async_start(pool);
+
+	/*
+	 * Only reachable when the committer could not be started: teardown drains
+	 * outstanding tickets before setting shutdown, so a ticket that got this
+	 * far still has a pool to go to.
+	 */
+	if (!pool->started || pool->failed || pool->shutdown) {
+		pthread_mutex_unlock(&pool->lock);
+		_output_async_unref(ostr);
+		return (false);
+	}
+
+	slot = &pool->slots[ticket % pool->depth];
+
+	/*
+	 * Wait for the slot this ticket owns, which the ticket 'depth' earlier
+	 * releases when it is written. Only reached when the writer has fallen
+	 * a whole ring behind.
+	 */
+	if (ticket >= pool->commit_next + pool->depth) {
+		pool->n_waited++;
+		while (ticket >= pool->commit_next + pool->depth && !pool->shutdown)
+			pthread_cond_wait(&pool->slot_free, &pool->lock);
+	}
+
+	assert(slot->state == slot_empty);
+
+	if (ticket >= pool->issued)
+		pool->issued = ticket + 1;
+
+	if (is_frag) {
+		/* Only the committer fragments; see async_committer(). */
+		slot->co = *co;
+		*co = NULL;
+		slot->state = slot_frag;
+		pthread_cond_broadcast(&pool->commit_ready);
+	} else if (pool->busy < pool->nstarted ||
+		   (pool->nstarted < pool->nworkers && async_spawn_worker(pool)))
+	{
+		/*
+		 * A worker is free, or the ceiling left room to add one: hand
+		 * the container over and get back to reading.
+		 */
+		slot->co = *co;
+		*co = NULL;
+		slot->state = slot_work;
+		pool->busy++;
+		pthread_cond_signal(&pool->work_ready);
+	} else {
+		/*
+		 * Every worker is busy and the ceiling is reached. Compress it
+		 * here rather than wait, then deposit the result and return.
+		 */
+		slot->state = slot_taken;
+		pool->n_inline++;
+		inline_compress = true;
+	}
+
+	res = pool->first_error;
+	pool->first_error = nmsg_res_success;
+	pthread_mutex_unlock(&pool->lock);
+
+	if (inline_compress) {
+		nmsg_res c_res = _output_nmsg_container_compress(output, co, &buf, &buf_len);
+
+		pthread_mutex_lock(&pool->lock);
+		slot->buf = buf;
+		slot->buf_len = buf_len;
+		slot->res = c_res;
+		slot->state = slot_done;
+		pthread_cond_broadcast(&pool->commit_ready);
+		pthread_mutex_unlock(&pool->lock);
+	}
+
+	*res_out = res;
+	_output_async_unref(ostr);
+
+	return (true);
+}

--- a/nmsg/output_async.c
+++ b/nmsg/output_async.c
@@ -40,7 +40,8 @@
  *
  * A producer that finds every worker busy compresses inline rather than wait,
  * so the pool is never slower than no pool. Workers spawn on demand, making
- * 'nworkers' a ceiling rather than an allocation.
+ * 'nworkers' a ceiling rather than an allocation, and go away again once they
+ * have been idle long enough; see async_worker().
  */
 
 /*
@@ -69,9 +70,27 @@ struct async_slot {
 	nmsg_res	 res;
 };
 
+/*
+ * A compressor. The record outlives the thread: a culled worker leaves its
+ * 'tid' for the next producer that needs one to join and take over. Idle
+ * workers are linked most recently used first and a producer takes the head;
+ * If wakeups are spread evenly instead then nothing is ever idle long enough to cull.
+ */
+struct async_worker {
+	pthread_t		tid;
+	pthread_cond_t		ready; /* Has a slot, or should look again. */
+	struct async_slot      *slot;  /* Work handed over, or NULL. */
+	struct async_worker    *idle_prev;
+	struct async_worker    *idle_next;
+	bool			idle;	  /* On the idle list. */
+	bool			joinable; /* tid is valid and unjoined. */
+	bool			exited;	  /* Thread returned; needs a join. */
+	bool			reaping;  /* A producer is joining it. */
+	struct nmsg_ostr_async *pool;
+};
+
 struct nmsg_ostr_async {
 	pthread_mutex_t lock;
-	pthread_cond_t	work_ready;   /* A slot became slot_work. */
 	pthread_cond_t	commit_ready; /* The committer's slot is ready. */
 	pthread_cond_t	slot_free;    /* A slot became slot_empty. */
 	/*
@@ -79,23 +98,29 @@ struct nmsg_ostr_async {
 	 * depth) == i, so a producer runs at most 'depth' tickets ahead of
 	 * commit_next and waits only for ticket T - depth to be written.
 	 */
-	struct async_slot *slots;
-	unsigned	   depth;
-	unsigned	   nworkers;	/* Ceiling; workers start on demand. */
-	unsigned	   nstarted;	/* Workers that exist and must be joined. */
-	unsigned	   busy;	/* Containers assigned to workers. */
-	uint64_t	   issued;	/* Highest ticket claimed, plus one. */
-	uint64_t	   commit_next; /* Ticket allowed to write now. */
-	bool		   shutdown;
-	bool		   started;	 /* Committer exists; must be joined. */
-	bool		   failed;	 /* No committer; stay inline. */
-	bool		   spawn_failed; /* Worker spawn failed; logged once. */
-	pthread_t	  *workers;
-	pthread_t	   committer;
-	nmsg_res	   first_error; /* Sticky; surfaced by flush. */
-	nmsg_output_t	   output;
-	uint64_t	   n_inline; /* Containers a producer compressed. */
-	uint64_t	   n_waited; /* Producers that waited for a slot. */
+	struct async_slot   *slots;
+	unsigned	     depth;
+	unsigned	     nworkers;	  /* Ceiling; workers start on demand. */
+	unsigned	     nlive;	  /* Workers running now. */
+	unsigned	     npeak;	  /* Most that ran at once. */
+	unsigned	     min_workers; /* Workers culling leaves alone. */
+	unsigned	     cull_secs;	  /* Idle seconds before a cull; 0 is off. */
+	clockid_t	     cull_clock;  /* The clock 'ready' was built with. */
+	struct async_worker *workers;
+	struct async_worker *idle_head; /* Most recently used. */
+	struct async_worker *idle_tail;
+	uint64_t	     issued;	  /* Highest ticket claimed, plus one. */
+	uint64_t	     commit_next; /* Ticket allowed to write now. */
+	bool		     shutdown;
+	bool		     started;	   /* Committer exists; must be joined. */
+	bool		     failed;	   /* No committer; stay inline. */
+	bool		     spawn_failed; /* Worker spawn failed; stop trying. */
+	pthread_t	     committer;
+	nmsg_res	     first_error; /* Sticky; surfaced by flush. */
+	nmsg_output_t	     output;
+	uint64_t	     n_inline; /* Containers a producer compressed. */
+	uint64_t	     n_waited; /* Producers that waited for a slot. */
+	uint64_t	     n_culled; /* Workers that gave up their place. */
 };
 
 /*
@@ -121,6 +146,87 @@ void _output_async_unref(struct nmsg_stream_output *ostr)
 	if (--ostr->so_inflight == 0)
 		pthread_cond_broadcast(&ostr->c_drained);
 	pthread_mutex_unlock(&ostr->c_lock);
+}
+
+/* Put a worker at the head of the idle list. Caller holds pool->lock. */
+static void
+async_idle_push(struct nmsg_ostr_async *pool, struct async_worker *worker)
+{
+	assert(!worker->idle);
+
+	worker->idle_prev = NULL;
+	worker->idle_next = pool->idle_head;
+	if (pool->idle_head != NULL)
+		pool->idle_head->idle_prev = worker;
+	else
+		pool->idle_tail = worker;
+	pool->idle_head = worker;
+	worker->idle = true;
+}
+
+/* Take a worker out of the idle list. Caller holds pool->lock. */
+static void
+async_idle_unlink(struct nmsg_ostr_async *pool, struct async_worker *worker)
+{
+	assert(worker->idle);
+
+	if (worker->idle_prev != NULL)
+		worker->idle_prev->idle_next = worker->idle_next;
+	else
+		pool->idle_head = worker->idle_next;
+
+	if (worker->idle_next != NULL)
+		worker->idle_next->idle_prev = worker->idle_prev;
+	else
+		pool->idle_tail = worker->idle_prev;
+
+	worker->idle_prev = NULL;
+	worker->idle_next = NULL;
+	worker->idle = false;
+}
+
+/*
+ * The compressor to hand the next container to, or NULL if all of them are
+ * busy. Caller holds pool->lock.
+ */
+static struct async_worker *
+async_idle_pop(struct nmsg_ostr_async *pool)
+{
+	struct async_worker *worker = pool->idle_head;
+
+	if (worker != NULL)
+		async_idle_unlink(pool, worker);
+
+	return (worker);
+}
+
+/*
+ * When a worker idle from now has outstayed its welcome. Read from the clock
+ * its condvar was built with: mismatch the two and the deadline lands decades
+ * out, silently ending culling. Caller holds pool->lock.
+ */
+static void
+async_cull_deadline(const struct nmsg_ostr_async *pool, struct timespec *deadline)
+{
+	clock_gettime(pool->cull_clock, deadline);
+	deadline->tv_sec += pool->cull_secs;
+}
+
+/*
+ * The floor a pool of this size can honour. At the ceiling there is nothing
+ * left to cull, so say so rather than quietly do nothing.
+ */
+static unsigned
+async_min_workers_for(unsigned nworkers, unsigned min_workers)
+{
+	if (min_workers > nworkers) {
+		_nmsg_dprintf(2, "%s: floor of %u lowered to the %u compressor(s) "
+				 "this output may run\n",
+			      __func__, min_workers, nworkers);
+		min_workers = nworkers;
+	}
+
+	return (min_workers);
 }
 
 /*
@@ -185,14 +291,50 @@ async_max_workers(void)
 	return ((unsigned)(ncpu - ASYNC_REORDER_MARGIN));
 }
 
+/* Apply a cull policy to a running pool. */
+void _output_async_set_cull(struct nmsg_ostr_async *pool, unsigned min_workers,
+			    unsigned idle_secs)
+{
+	unsigned i;
+
+	pthread_mutex_lock(&pool->lock);
+
+	pool->min_workers = async_min_workers_for(pool->nworkers, min_workers);
+	pool->cull_secs = idle_secs;
+
+	/* Parked workers are waiting on the policy that has just been replaced. */
+	for (i = 0; i < pool->nworkers; i++)
+		pthread_cond_signal(&pool->workers[i].ready);
+
+	pthread_mutex_unlock(&pool->lock);
+}
+
+/* Worker counts, for tests and diagnostics. Any of the outputs may be NULL. */
+void _output_async_counts(struct nmsg_ostr_async *pool, unsigned *live, unsigned *peak,
+			  uint64_t *culled)
+{
+	pthread_mutex_lock(&pool->lock);
+	if (live != NULL)
+		*live = pool->nlive;
+	if (peak != NULL)
+		*peak = pool->npeak;
+	if (culled != NULL)
+		*culled = pool->n_culled;
+	pthread_mutex_unlock(&pool->lock);
+}
+
 nmsg_res
 _output_async_init(nmsg_output_t output, unsigned nworkers)
 {
 	struct nmsg_stream_output *ostr = output->stream;
 	struct nmsg_ostr_async	  *pool;
 	nmsg_res		   res, old_res = nmsg_res_success;
-	unsigned		   depth, max_workers;
+	unsigned		   depth, max_workers, zmin, zcull;
+	unsigned		   i, nconds = 0;
 	bool			   same_ceiling;
+	pthread_condattr_t	   cattr;
+	pthread_condattr_t	  *cattrp = NULL;
+	clockid_t		   cull_clock = CLOCK_REALTIME;
 
 	if (nworkers == 0)
 		return (nmsg_res_success);
@@ -203,6 +345,10 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 
 	depth = async_depth_for(nworkers);
 
+	/* Set before the pool exists, and carried across a replacement. */
+	zmin = ostr->so_zmin;
+	zcull = ostr->so_zcull;
+
 	/*
 	 * A pool's ceiling cannot change in place, so a different count means
 	 * a replacement. Build it before tearing the old one down, so a failed
@@ -210,8 +356,11 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 	 */
 	same_ceiling = ostr->so_pool != NULL &&
 		       ostr->so_pool->nworkers == nworkers;
-	if (same_ceiling)
+	if (same_ceiling) {
+		/* Nothing to rebuild, but the cull policy may have moved on. */
+		_output_async_set_cull(ostr->so_pool, zmin, zcull);
 		return (nmsg_res_success);
+	}
 
 	pool = calloc(1, sizeof(*pool));
 	if (pool == NULL)
@@ -231,15 +380,43 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 
 	if (pthread_mutex_init(&pool->lock, NULL) != 0)
 		goto fail_mutex;
-	if (pthread_cond_init(&pool->work_ready, NULL) != 0)
-		goto fail_work_ready;
 	if (pthread_cond_init(&pool->commit_ready, NULL) != 0)
 		goto fail_commit_ready;
 	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
 		goto fail_slot_free;
 
+	/*
+	 * One attribute for every worker condvar, so any of them can carry a
+	 * cull deadline. Monotonic, or a stepped wall clock retimes culling.
+	 */
+#ifdef HAVE_PTHREAD_CONDATTR_SETCLOCK
+	if (pthread_condattr_init(&cattr) == 0) {
+		if (pthread_condattr_setclock(&cattr, CLOCK_MONOTONIC) == 0) {
+			cattrp = &cattr;
+			cull_clock = CLOCK_MONOTONIC;
+		} else {
+			pthread_condattr_destroy(&cattr);
+		}
+	}
+#endif /* HAVE_PTHREAD_CONDATTR_SETCLOCK */
+
+	for (nconds = 0; nconds < nworkers; nconds++) {
+		if (pthread_cond_init(&pool->workers[nconds].ready, cattrp) != 0)
+			break;
+		pool->workers[nconds].pool = pool;
+	}
+
+	if (cattrp != NULL)
+		pthread_condattr_destroy(cattrp);
+
+	if (nconds < nworkers)
+		goto fail_worker_conds;
+
 	pool->depth = depth;
 	pool->nworkers = nworkers;
+	pool->cull_clock = cull_clock;
+	pool->min_workers = async_min_workers_for(nworkers, zmin);
+	pool->cull_secs = zcull;
 	pool->output = output;
 
 	if (ostr->so_pool != NULL)
@@ -264,11 +441,13 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 
 	return (nmsg_res_success);
 
+fail_worker_conds:
+	for (i = 0; i < nconds; i++)
+		pthread_cond_destroy(&pool->workers[i].ready);
+	pthread_cond_destroy(&pool->slot_free);
 fail_slot_free:
 	pthread_cond_destroy(&pool->commit_ready);
 fail_commit_ready:
-	pthread_cond_destroy(&pool->work_ready);
-fail_work_ready:
 	pthread_mutex_destroy(&pool->lock);
 fail_mutex:
 	free(pool->workers);
@@ -292,7 +471,8 @@ _output_async_destroy(nmsg_output_t output)
 	struct nmsg_ostr_async	  *pool = ostr->so_pool;
 	nmsg_res		   res;
 	bool			   started;
-	unsigned		   i, nstarted;
+	unsigned		   i, npeak;
+	uint64_t		   n_culled;
 
 	if (pool == NULL)
 		return (nmsg_res_success);
@@ -311,20 +491,28 @@ _output_async_destroy(nmsg_output_t output)
 	pthread_mutex_lock(&pool->lock);
 	pool->shutdown = true;	 /* Set under the lock: a thread about */
 	started = pool->started; /* to wait would miss the wakeup. */
-	nstarted = pool->nstarted;
-	pthread_cond_broadcast(&pool->work_ready);
+	npeak = pool->npeak;
+	n_culled = pool->n_culled;
+	for (i = 0; i < pool->nworkers; i++)
+		pthread_cond_signal(&pool->workers[i].ready);
 	pthread_cond_broadcast(&pool->commit_ready);
 	pthread_cond_broadcast(&pool->slot_free);
 	pthread_mutex_unlock(&pool->lock);
 
-	for (i = 0; i < nstarted; i++)
-		pthread_join(pool->workers[i], NULL);
+	/*
+	 * 'joinable' is written only by a spawn, and no producer is left to
+	 * spawn, so it is settled. Culled workers are joined here too.
+	 */
+	for (i = 0; i < pool->nworkers; i++) {
+		if (pool->workers[i].joinable)
+			pthread_join(pool->workers[i].tid, NULL);
+	}
 	if (started)
 		pthread_join(pool->committer, NULL);
 
-	if (pool->n_inline > 0 || pool->n_waited > 0)
-		_nmsg_dprintf(2, "%s: %u of %u worker(s) started, %u slot(s); %" PRIu64 " container(s) compressed by the reader, %" PRIu64 " wait(s) for a free slot\n", __func__, nstarted,
-			      pool->nworkers, pool->depth, pool->n_inline, pool->n_waited);
+	if (pool->n_inline > 0 || pool->n_waited > 0 || n_culled > 0)
+		_nmsg_dprintf(2, "%s: %u of %u worker(s) at once, %u slot(s); %" PRIu64 " container(s) compressed by the reader, %" PRIu64 " wait(s) for a free slot, %" PRIu64 " worker(s) culled\n", __func__, npeak,
+			      pool->nworkers, pool->depth, pool->n_inline, pool->n_waited, n_culled);
 
 	/* Read after the joins; the threads write it until they exit. */
 	res = pool->first_error;
@@ -334,9 +522,10 @@ _output_async_destroy(nmsg_output_t output)
 	ostr->so_pool_closing = false;
 	pthread_mutex_unlock(&ostr->c_lock);
 
+	for (i = 0; i < pool->nworkers; i++)
+		pthread_cond_destroy(&pool->workers[i].ready);
 	pthread_cond_destroy(&pool->slot_free);
 	pthread_cond_destroy(&pool->commit_ready);
-	pthread_cond_destroy(&pool->work_ready);
 	pthread_mutex_destroy(&pool->lock);
 	free(pool->workers);
 	free(pool->slots);
@@ -373,30 +562,28 @@ async_all_written(const struct nmsg_ostr_async *pool)
 }
 
 /*
- * Compressor thread. Takes any slot needing work, in any order: only write
- * order matters, and the committer enforces that.
+ * Compressor thread. Waits to be handed a slot rather than looking for one, so
+ * the producer decides which worker runs and the rest go quiet.
+ *
+ * A worker idle for cull_secs gives up its place, down to min_workers. That
+ * decision and leaving the idle list are one lock hold, so a producer can never
+ * hand work to a thread on its way out.
  */
 static void *
 async_worker(void *arg)
 {
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *)arg;
+	struct async_worker    *self = (struct async_worker *)arg;
+	struct nmsg_ostr_async *pool = self->pool;
+	bool			timed_out = false;
 
 	pthread_mutex_lock(&pool->lock);
 
 	for (;;) {
-		struct async_slot *slot = NULL;
+		struct async_slot *slot = self->slot;
 		nmsg_container_t   co;
 		uint8_t		  *buf;
 		size_t		   buf_len;
 		nmsg_res	   res;
-		unsigned	   i;
-
-		for (i = 0; i < pool->depth; i++) {
-			if (pool->slots[i].state == slot_work) {
-				slot = &pool->slots[i];
-				break;
-			}
-		}
 
 		if (slot == NULL) {
 			/*
@@ -406,10 +593,37 @@ async_worker(void *arg)
 			 */
 			if (pool->shutdown)
 				break;
-			pthread_cond_wait(&pool->work_ready, &pool->lock);
+
+			if (timed_out && pool->nlive > pool->min_workers) {
+				pool->n_culled++;
+				break;
+			}
+
+			timed_out = false;
+
+			if (!self->idle)
+				async_idle_push(pool, self);
+
+			/*
+			 * No deadline with culling off, nor at the floor,
+			 * where it could only cost wakeups. The floor is not
+			 * tied to particular threads: grow again and the
+			 * workers added on top are the ones that time out.
+			 */
+			if (pool->cull_secs == 0 ||
+			    pool->nlive <= pool->min_workers) {
+				pthread_cond_wait(&self->ready, &pool->lock);
+			} else {
+				struct timespec deadline;
+
+				async_cull_deadline(pool, &deadline);
+				timed_out = pthread_cond_timedwait(&self->ready,
+								   &pool->lock, &deadline) == ETIMEDOUT;
+			}
 			continue;
 		}
 
+		self->slot = NULL;
 		slot->state = slot_taken;
 		co = slot->co;
 		slot->co = NULL;
@@ -418,13 +632,18 @@ async_worker(void *arg)
 		res = _output_nmsg_container_compress(pool->output, &co, &buf, &buf_len);
 
 		pthread_mutex_lock(&pool->lock);
-		pool->busy--; /* Counted at deposit; see container_submit(). */
+		timed_out = false;
 		slot->buf = buf;
 		slot->buf_len = buf_len;
 		slot->res = res;
 		slot->state = slot_done;
 		pthread_cond_broadcast(&pool->commit_ready);
 	}
+
+	if (self->idle)
+		async_idle_unlink(pool, self);
+	self->exited = true;
+	pool->nlive--;
 
 	pthread_mutex_unlock(&pool->lock);
 
@@ -532,32 +751,85 @@ async_start(struct nmsg_ostr_async *pool)
 }
 
 /*
- * Add a compressor thread, up to the ceiling. Called under pool->lock when a
- * producer finds every worker busy, so the pool grows to the load it sees.
+ * Claim a record for a new compressor, joining the culled thread that left it,
+ * or NULL when every record is running -- which is what holds the ceiling.
  *
- * Returns false if the thread could not be created: not fatal, the caller
- * compresses that container itself.
+ * The join runs with pool->lock dropped: a returned thread still has the C
+ * library's teardown to be scheduled for, and waiting under the lock would stop
+ * the committer writing. Caller holds pool->lock.
  */
-static bool
-async_spawn_worker(struct nmsg_ostr_async *pool)
+static struct async_worker *
+async_take_worker(struct nmsg_ostr_async *pool)
 {
-	int pthread_res;
+	struct async_worker *worker = NULL;
+	unsigned	     i;
 
-	pthread_res = pthread_create(&pool->workers[pool->nstarted], NULL,
-				     async_worker, pool);
-	if (pthread_res != 0) {
-		/* Logged once; a persistent failure would flood the log. */
-		if (!pool->spawn_failed) {
-			pool->spawn_failed = true;
-			_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n",
-				      __func__, strerror(pthread_res));
-		}
-		return (false);
+	for (i = 0; i < pool->nworkers; i++) {
+		/* Free outright: never used, or already reaped. */
+		if (!pool->workers[i].joinable)
+			return (&pool->workers[i]);
+
+		if (worker == NULL && pool->workers[i].exited &&
+		    !pool->workers[i].reaping)
+			worker = &pool->workers[i];
 	}
 
-	pool->nstarted++;
+	if (worker == NULL)
+		return (NULL);
 
-	return (true);
+	worker->reaping = true;
+	pthread_mutex_unlock(&pool->lock);
+	pthread_join(worker->tid, NULL);
+	pthread_mutex_lock(&pool->lock);
+
+	/* Cleared before the spawn: if it fails, there is nothing to join. */
+	worker->joinable = false;
+	worker->exited = false;
+	worker->reaping = false;
+
+	return (worker);
+}
+
+/*
+ * Add a compressor, up to the ceiling. Called under pool->lock when a producer
+ * finds no idle worker, so the pool grows to the load it sees.
+ *
+ * Returns NULL if one could not be started: not fatal, the caller compresses
+ * that container itself.
+ */
+static struct async_worker *
+async_spawn_worker(struct nmsg_ostr_async *pool)
+{
+	struct async_worker *worker;
+	int		     pthread_res;
+
+	if (pool->spawn_failed)
+		return (NULL);
+
+	worker = async_take_worker(pool);
+	if (worker == NULL)
+		return (NULL);
+
+	assert(!worker->joinable && !worker->idle && worker->slot == NULL);
+
+	pthread_res = pthread_create(&worker->tid, NULL, async_worker, worker);
+	if (pthread_res != 0) {
+		/*
+		 * Latched, not retried: culling holds the pool below its
+		 * ceiling, so retrying means this syscall per container.
+		 */
+		pool->spawn_failed = true;
+		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n",
+			      __func__, strerror(pthread_res));
+		return (NULL);
+	}
+
+	worker->joinable = true;
+	pool->nlive++;
+	if (pool->nlive > pool->npeak)
+		pool->npeak = pool->nlive;
+
+	return (worker);
 }
 
 /*
@@ -598,12 +870,12 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 {
 	struct nmsg_stream_output *ostr = output->stream;
 	struct async_slot	  *slot;
+	struct async_worker	  *worker;
 	nmsg_res		   res = nmsg_res_success;
 	uint8_t			  *buf;
 	size_t			   buf_len;
 	bool			   inline_compress = false;
 	bool			   committer_needed, pool_usable;
-	bool			   worker_idle, below_ceiling;
 
 	pthread_mutex_lock(&pool->lock);
 
@@ -640,22 +912,24 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	if (ticket >= pool->issued)
 		pool->issued = ticket + 1;
 
-	worker_idle = pool->busy < pool->nstarted;
-	below_ceiling = pool->nstarted < pool->nworkers;
-
 	if (is_frag) {
 		/* Only the committer fragments; see async_committer(). */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_frag;
 		pthread_cond_broadcast(&pool->commit_ready);
-	} else if (worker_idle || (below_ceiling && async_spawn_worker(pool))) {
-		/* Hand the container over and get back to reading. */
+	} else if ((worker = async_idle_pop(pool)) != NULL ||
+		   (worker = async_spawn_worker(pool)) != NULL) {
+		/*
+		 * Hand the container over and get back to reading. The slot
+		 * stays ours across the spawn's lock drop: no other ticket
+		 * maps to it, and the committer waits until it is ready.
+		 */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_work;
-		pool->busy++;
-		pthread_cond_signal(&pool->work_ready);
+		worker->slot = slot;
+		pthread_cond_signal(&worker->ready);
 	} else {
 		/* Everyone busy and at the ceiling: compress here. */
 		slot->state = slot_taken;

--- a/nmsg/output_async.c
+++ b/nmsg/output_async.c
@@ -24,9 +24,7 @@
 
 #include "private.h"
 
-#ifdef __linux__
-#include <sched.h>
-#endif /* __linux__ */
+#include "libmy/my_cpu.h"
 
 /* Data structures. */
 
@@ -72,20 +70,17 @@ struct async_slot {
 
 /*
  * A compressor. The record outlives the thread: a culled worker leaves its
- * 'tid' for the next producer that needs one to join and take over. Idle
- * workers are linked most recently used first and a producer takes the head;
- * If wakeups are spread evenly instead then nothing is ever idle long enough to cull.
+ * 'tid' for the committer to join before the record is reused. Producers always
+ * take the lowest free index, so the front of the array carries the load;
+ * spread the work evenly instead and nothing is idle long enough to cull.
  */
 struct async_worker {
 	pthread_t		tid;
-	pthread_cond_t		ready; /* Has a slot, or should look again. */
-	struct async_slot      *slot;  /* Work handed over, or NULL. */
-	struct async_worker    *idle_prev;
-	struct async_worker    *idle_next;
-	bool			idle;	  /* On the idle list. */
+	pthread_cond_t		ready;	  /* Has a slot, or should look again. */
+	struct async_slot      *slot;	  /* Work handed over, or NULL. */
+	bool			idle;	  /* Waiting for work. */
 	bool			joinable; /* tid is valid and unjoined. */
 	bool			exited;	  /* Thread returned; needs a join. */
-	bool			reaping;  /* A producer is joining it. */
 	struct nmsg_ostr_async *pool;
 };
 
@@ -107,8 +102,6 @@ struct nmsg_ostr_async {
 	unsigned	     cull_secs;	  /* Idle seconds before a cull; 0 is off. */
 	clockid_t	     cull_clock;  /* The clock 'ready' was built with. */
 	struct async_worker *workers;
-	struct async_worker *idle_head; /* Most recently used. */
-	struct async_worker *idle_tail;
 	uint64_t	     issued;	  /* Highest ticket claimed, plus one. */
 	uint64_t	     commit_next; /* Ticket allowed to write now. */
 	bool		     shutdown;
@@ -148,68 +141,42 @@ void _output_async_unref(struct nmsg_stream_output *ostr)
 	pthread_mutex_unlock(&ostr->c_lock);
 }
 
-/* Put a worker at the head of the idle list. Caller holds pool->lock. */
-static void
-async_idle_push(struct nmsg_ostr_async *pool, struct async_worker *worker)
-{
-	assert(!worker->idle);
-
-	worker->idle_prev = NULL;
-	worker->idle_next = pool->idle_head;
-	if (pool->idle_head != NULL)
-		pool->idle_head->idle_prev = worker;
-	else
-		pool->idle_tail = worker;
-	pool->idle_head = worker;
-	worker->idle = true;
-}
-
-/* Take a worker out of the idle list. Caller holds pool->lock. */
-static void
-async_idle_unlink(struct nmsg_ostr_async *pool, struct async_worker *worker)
-{
-	assert(worker->idle);
-
-	if (worker->idle_prev != NULL)
-		worker->idle_prev->idle_next = worker->idle_next;
-	else
-		pool->idle_head = worker->idle_next;
-
-	if (worker->idle_next != NULL)
-		worker->idle_next->idle_prev = worker->idle_prev;
-	else
-		pool->idle_tail = worker->idle_prev;
-
-	worker->idle_prev = NULL;
-	worker->idle_next = NULL;
-	worker->idle = false;
-}
-
 /*
  * The compressor to hand the next container to, or NULL if all of them are
- * busy. Caller holds pool->lock.
+ * busy. Lowest free index every time, so the front of the array takes the load
+ * and the back stays idle long enough to be worth culling.
+ *
+ * Taken in the same lock hold that hands it a slot, so a producer can never
+ * pick one that is on its way out. Caller holds pool->lock.
  */
 static struct async_worker *
-async_idle_pop(struct nmsg_ostr_async *pool)
+async_idle_take(struct nmsg_ostr_async *pool)
 {
-	struct async_worker *worker = pool->idle_head;
+	unsigned i;
 
-	if (worker != NULL)
-		async_idle_unlink(pool, worker);
+	for (i = 0; i < pool->nworkers; i++) {
+		if (pool->workers[i].idle) {
+			pool->workers[i].idle = false;
+			return (&pool->workers[i]);
+		}
+	}
 
-	return (worker);
+	return (NULL);
 }
 
 /*
  * When a worker idle from now has outstayed its welcome. Read from the clock
- * its condvar was built with: mismatch the two and the deadline lands decades
- * out, silently ending culling. Caller holds pool->lock.
+ * its condvar was built with.
  */
-static void
+static bool
 async_cull_deadline(const struct nmsg_ostr_async *pool, struct timespec *deadline)
 {
-	clock_gettime(pool->cull_clock, deadline);
+	if (clock_gettime(pool->cull_clock, deadline) != 0)
+		return (false);
+
 	deadline->tv_sec += pool->cull_secs;
+
+	return (true);
 }
 
 /*
@@ -237,9 +204,10 @@ async_min_workers_for(unsigned nworkers, unsigned min_workers)
  * and what it would be covering for is a slow write -- which is single-threaded
  * on the committer, and no amount of depth helps.
  *
- * Sized here rather than fixed because the worker count spans an order of
- * magnitude across the boxes this runs on, and a buffer sized for the largest
- * is megabytes that a two-worker output never touches.
+ * Sized here rather than fixed because a slot pins a compressed container until
+ * every earlier ticket is written: at the 1 MiB containers a file output uses,
+ * a buffer sized for the largest box is tens of megabytes that a two-worker
+ * output never needs.
  */
 static unsigned
 async_depth_for(unsigned nworkers)
@@ -247,29 +215,6 @@ async_depth_for(unsigned nworkers)
 	unsigned depth = nworkers + ASYNC_REORDER_MARGIN;
 
 	return (depth < ASYNC_DEPTH_MIN ? ASYNC_DEPTH_MIN : depth);
-}
-
-/*
- * Cores this process may run on. nmsgtool computes the same thing for its own
- * sizing, but sees only the public header and cannot reach this one.
- */
-static long
-async_ncpu(void)
-{
-	long ncpu = -1;
-#ifdef __linux__
-	cpu_set_t set;
-
-	if (sched_getaffinity(0, sizeof(set), &set) == 0)
-		ncpu = CPU_COUNT(&set);
-#endif /* __linux__ */
-
-	if (ncpu < 1)
-		ncpu = sysconf(_SC_NPROCESSORS_ONLN);
-	if (ncpu < 1)
-		ncpu = 1;
-
-	return (ncpu);
 }
 
 /*
@@ -283,12 +228,7 @@ async_ncpu(void)
 static unsigned
 async_max_workers(void)
 {
-	long ncpu = async_ncpu();
-
-	if (ncpu < ASYNC_DEPTH_MIN)
-		ncpu = ASYNC_DEPTH_MIN;
-
-	return ((unsigned)(ncpu - ASYNC_REORDER_MARGIN));
+	return ((unsigned)my_ncpu());
 }
 
 /* Apply a cull policy to a running pool. */
@@ -310,8 +250,8 @@ void _output_async_set_cull(struct nmsg_ostr_async *pool, unsigned min_workers,
 }
 
 /* Worker counts, for tests and diagnostics. Any of the outputs may be NULL. */
-void _output_async_counts(struct nmsg_ostr_async *pool, unsigned *live, unsigned *peak,
-			  uint64_t *culled)
+void _output_async_counts(struct nmsg_ostr_async *pool, unsigned *live,
+			  unsigned *peak, uint64_t *culled)
 {
 	pthread_mutex_lock(&pool->lock);
 	if (live != NULL)
@@ -327,7 +267,7 @@ nmsg_res
 _output_async_init(nmsg_output_t output, unsigned nworkers)
 {
 	struct nmsg_stream_output *ostr = output->stream;
-	struct nmsg_ostr_async	  *pool;
+	struct nmsg_ostr_async	  *pool, *old;
 	nmsg_res		   res, old_res = nmsg_res_success;
 	unsigned		   depth, max_workers, zmin, zcull;
 	unsigned		   i, nconds = 0;
@@ -345,22 +285,32 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 
 	depth = async_depth_for(nworkers);
 
-	/* Set before the pool exists, and carried across a replacement. */
+	/*
+	 * The policy is set before the pool exists and carried across a
+	 * replacement. Read with the pool under one c_lock hold, and the pool
+	 * referenced, so a teardown cannot free it underneath.
+	 */
+	pthread_mutex_lock(&ostr->c_lock);
 	zmin = ostr->so_zmin;
 	zcull = ostr->so_zcull;
+	old = _output_async_ref(ostr);
+	same_ceiling = old != NULL && old->nworkers == nworkers;
+	pthread_mutex_unlock(&ostr->c_lock);
 
 	/*
 	 * A pool's ceiling cannot change in place, so a different count means
 	 * a replacement. Build it before tearing the old one down, so a failed
 	 * allocation leaves the working pool in place.
 	 */
-	same_ceiling = ostr->so_pool != NULL &&
-		       ostr->so_pool->nworkers == nworkers;
 	if (same_ceiling) {
 		/* Nothing to rebuild, but the cull policy may have moved on. */
-		_output_async_set_cull(ostr->so_pool, zmin, zcull);
+		_output_async_set_cull(old, zmin, zcull);
+		_output_async_unref(ostr);
 		return (nmsg_res_success);
 	}
+
+	if (old != NULL)
+		_output_async_unref(ostr);
 
 	pool = calloc(1, sizeof(*pool));
 	if (pool == NULL)
@@ -419,8 +369,8 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 	pool->cull_secs = zcull;
 	pool->output = output;
 
-	if (ostr->so_pool != NULL)
-		old_res = _output_async_destroy(output);
+	/* A no-op under c_lock if there is nothing to replace. */
+	old_res = _output_async_destroy(output);
 
 	pthread_mutex_lock(&ostr->c_lock);
 
@@ -428,8 +378,13 @@ _output_async_init(nmsg_output_t output, unsigned nworkers)
 	 * Tickets span the stream, not the pool, so a pool built mid-stream
 	 * must start where the stream got to. Seeded and published in one
 	 * c_lock hold, so a ticket either predates the pool or is at or above
-	 * commit_next -- never below, where the committer would wait for it
+	 * commit_next, never below, where the committer would wait for it
 	 * forever.
+	 *
+	 * That settles the pool's own liveness, not the byte order: a container
+	 * from a ticket just before this may still be waiting to go out inline,
+	 * and nothing holds this pool back for it. See
+	 * nmsg_output_set_zlib_workers().
 	 */
 	pool->commit_next = pool->issued = ostr->so_ticket;
 
@@ -468,21 +423,33 @@ nmsg_res
 _output_async_destroy(nmsg_output_t output)
 {
 	struct nmsg_stream_output *ostr = output->stream;
-	struct nmsg_ostr_async	  *pool = ostr->so_pool;
+	struct nmsg_ostr_async	  *pool;
 	nmsg_res		   res;
 	bool			   started;
 	unsigned		   i, npeak;
-	uint64_t		   n_culled;
+	uint64_t		   n_culled, n_inline, n_waited;
 
-	if (pool == NULL)
+	pthread_mutex_lock(&ostr->c_lock);
+
+	/*
+	 * One teardown at a time. A second waits the first out rather than
+	 * returning, so a close cannot reach the fd while another thread's
+	 * committer is still draining onto it.
+	 */
+	while (ostr->so_pool_closing)
+		pthread_cond_wait(&ostr->c_drained, &ostr->c_lock);
+
+	pool = ostr->so_pool;
+	if (pool == NULL) {
+		pthread_mutex_unlock(&ostr->c_lock);
 		return (nmsg_res_success);
+	}
 
 	/*
 	 * Stop issuing tickets to the pool, then wait for the outstanding ones
 	 * to arrive. Both under c_lock, which orders them against issuance:
 	 * once this returns, no producer is still en route with a ticket.
 	 */
-	pthread_mutex_lock(&ostr->c_lock);
 	ostr->so_pool_closing = true;
 	while (ostr->so_inflight > 0)
 		pthread_cond_wait(&ostr->c_drained, &ostr->c_lock);
@@ -493,6 +460,8 @@ _output_async_destroy(nmsg_output_t output)
 	started = pool->started; /* to wait would miss the wakeup. */
 	npeak = pool->npeak;
 	n_culled = pool->n_culled;
+	n_inline = pool->n_inline;
+	n_waited = pool->n_waited;
 	for (i = 0; i < pool->nworkers; i++)
 		pthread_cond_signal(&pool->workers[i].ready);
 	pthread_cond_broadcast(&pool->commit_ready);
@@ -500,19 +469,25 @@ _output_async_destroy(nmsg_output_t output)
 	pthread_mutex_unlock(&pool->lock);
 
 	/*
-	 * 'joinable' is written only by a spawn, and no producer is left to
-	 * spawn, so it is settled. Culled workers are joined here too.
+	 * The committer first: it is the only other thread that joins workers,
+	 * so joining it settles 'joinable' before the loop reads it. No
+	 * producer is left to spawn, and the committer already waits for every
+	 * worker to deposit before it exits.
 	 */
+	if (started)
+		pthread_join(pool->committer, NULL);
 	for (i = 0; i < pool->nworkers; i++) {
 		if (pool->workers[i].joinable)
 			pthread_join(pool->workers[i].tid, NULL);
 	}
-	if (started)
-		pthread_join(pool->committer, NULL);
 
-	if (pool->n_inline > 0 || pool->n_waited > 0 || n_culled > 0)
-		_nmsg_dprintf(2, "%s: %u of %u worker(s) at once, %u slot(s); %" PRIu64 " container(s) compressed by the reader, %" PRIu64 " wait(s) for a free slot, %" PRIu64 " worker(s) culled\n", __func__, npeak,
-			      pool->nworkers, pool->depth, pool->n_inline, pool->n_waited, n_culled);
+	if (n_inline > 0 || n_waited > 0 || n_culled > 0)
+		_nmsg_dprintf(2, "%s: %u of %u worker(s) at once, %u slot(s); "
+				 "%" PRIu64 " container(s) compressed by the reader, "
+				 "%" PRIu64 " wait(s) for a free slot, "
+				 "%" PRIu64 " worker(s) culled\n",
+			      __func__, npeak, pool->nworkers, pool->depth,
+			      n_inline, n_waited, n_culled);
 
 	/* Read after the joins; the threads write it until they exit. */
 	res = pool->first_error;
@@ -520,6 +495,7 @@ _output_async_destroy(nmsg_output_t output)
 	pthread_mutex_lock(&ostr->c_lock);
 	ostr->so_pool = NULL;
 	ostr->so_pool_closing = false;
+	pthread_cond_broadcast(&ostr->c_drained); /* Any teardown behind us. */
 	pthread_mutex_unlock(&ostr->c_lock);
 
 	for (i = 0; i < pool->nworkers; i++)
@@ -528,6 +504,17 @@ _output_async_destroy(nmsg_output_t output)
 	pthread_cond_destroy(&pool->commit_ready);
 	pthread_mutex_destroy(&pool->lock);
 	free(pool->workers);
+
+	/*
+	 * Every slot is empty by now: producers are gone, the threads are
+	 * joined, and the committer writes every ticket that was issued. Swept
+	 * anyway, so the invariant is checked rather than assumed.
+	 */
+	for (i = 0; i < pool->depth; i++) {
+		assert(pool->slots[i].state == slot_empty);
+		nmsg_container_destroy(&pool->slots[i].co);
+		free(pool->slots[i].buf);
+	}
 	free(pool->slots);
 	free(pool);
 
@@ -566,8 +553,8 @@ async_all_written(const struct nmsg_ostr_async *pool)
  * the producer decides which worker runs and the rest go quiet.
  *
  * A worker idle for cull_secs gives up its place, down to min_workers. That
- * decision and leaving the idle list are one lock hold, so a producer can never
- * hand work to a thread on its way out.
+ * decision and clearing its idle flag are one lock hold, so a producer can
+ * never hand work to a thread on its way out.
  */
 static void *
 async_worker(void *arg)
@@ -586,6 +573,8 @@ async_worker(void *arg)
 		nmsg_res	   res;
 
 		if (slot == NULL) {
+			struct timespec deadline;
+
 			/*
 			 * Exit only once producers have stopped, so a
 			 * container queued just before shutdown is still
@@ -601,8 +590,7 @@ async_worker(void *arg)
 
 			timed_out = false;
 
-			if (!self->idle)
-				async_idle_push(pool, self);
+			self->idle = true;
 
 			/*
 			 * No deadline with culling off, nor at the floor,
@@ -611,14 +599,16 @@ async_worker(void *arg)
 			 * workers added on top are the ones that time out.
 			 */
 			if (pool->cull_secs == 0 ||
-			    pool->nlive <= pool->min_workers) {
+			    pool->nlive <= pool->min_workers ||
+			    !async_cull_deadline(pool, &deadline)) {
 				pthread_cond_wait(&self->ready, &pool->lock);
 			} else {
-				struct timespec deadline;
+				int wait_res;
 
-				async_cull_deadline(pool, &deadline);
-				timed_out = pthread_cond_timedwait(&self->ready,
-								   &pool->lock, &deadline) == ETIMEDOUT;
+				wait_res = pthread_cond_timedwait(&self->ready,
+								  &pool->lock,
+								  &deadline);
+				timed_out = wait_res == ETIMEDOUT;
 			}
 			continue;
 		}
@@ -640,8 +630,7 @@ async_worker(void *arg)
 		pthread_cond_broadcast(&pool->commit_ready);
 	}
 
-	if (self->idle)
-		async_idle_unlink(pool, self);
+	self->idle = false;
 	self->exited = true;
 	pool->nlive--;
 
@@ -651,9 +640,40 @@ async_worker(void *arg)
 }
 
 /*
- * The only thread that writes, and the only caller of
- * _output_nmsg_frag_write(). Takes tickets strictly in order, so the file
- * matches what the synchronous path would have produced.
+ * Join the workers culling has retired, freeing their records to be spawned
+ * into again. Runs on the committer because the join is unbounded -- the thread
+ * has returned but still has the C library's teardown to be scheduled for --
+ * and the committer is the one thread that may block for it.
+ *
+ * Being the only reaper is what lets a producer skip a record on 'joinable'
+ * alone, so nothing can claim one while the lock is dropped here.
+ * Caller holds pool->lock.
+ */
+static void
+async_reap_exited(struct nmsg_ostr_async *pool)
+{
+	unsigned i;
+
+	for (i = 0; i < pool->nworkers; i++) {
+		struct async_worker *worker = &pool->workers[i];
+
+		if (!worker->exited)
+			continue;
+
+		pthread_mutex_unlock(&pool->lock);
+		pthread_join(worker->tid, NULL);
+		pthread_mutex_lock(&pool->lock);
+
+		/* Cleared last: until then the record is not free. */
+		worker->exited = false;
+		worker->joinable = false;
+	}
+}
+
+/*
+ * Takes tickets strictly in order, so the file matches what the synchronous
+ * path would have produced. The only writer while the pool is up: a producer
+ * writes inline only when there is no pool to take its ticket.
  */
 static void *
 async_committer(void *arg)
@@ -715,6 +735,8 @@ async_committer(void *arg)
 		slot->state = slot_empty;
 		pool->commit_next++;
 		pthread_cond_broadcast(&pool->slot_free);
+
+		async_reap_exited(pool);
 	}
 
 out:
@@ -751,66 +773,35 @@ async_start(struct nmsg_ostr_async *pool)
 }
 
 /*
- * Claim a record for a new compressor, joining the culled thread that left it,
- * or NULL when every record is running -- which is what holds the ceiling.
- *
- * The join runs with pool->lock dropped: a returned thread still has the C
- * library's teardown to be scheduled for, and waiting under the lock would stop
- * the committer writing. Caller holds pool->lock.
- */
-static struct async_worker *
-async_take_worker(struct nmsg_ostr_async *pool)
-{
-	struct async_worker *worker = NULL;
-	unsigned	     i;
-
-	for (i = 0; i < pool->nworkers; i++) {
-		/* Free outright: never used, or already reaped. */
-		if (!pool->workers[i].joinable)
-			return (&pool->workers[i]);
-
-		if (worker == NULL && pool->workers[i].exited &&
-		    !pool->workers[i].reaping)
-			worker = &pool->workers[i];
-	}
-
-	if (worker == NULL)
-		return (NULL);
-
-	worker->reaping = true;
-	pthread_mutex_unlock(&pool->lock);
-	pthread_join(worker->tid, NULL);
-	pthread_mutex_lock(&pool->lock);
-
-	/* Cleared before the spawn: if it fails, there is nothing to join. */
-	worker->joinable = false;
-	worker->exited = false;
-	worker->reaping = false;
-
-	return (worker);
-}
-
-/*
  * Add a compressor, up to the ceiling. Called under pool->lock when a producer
  * finds no idle worker, so the pool grows to the load it sees.
  *
- * Returns NULL if one could not be started: not fatal, the caller compresses
- * that container itself.
+ * Takes only a free record: one a culled worker left stays off limits until the
+ * committer has joined it, so this never blocks the reader. Returns NULL if
+ * there is none or the spawn failed which is not fatal, the caller compresses that
+ * container itself.
  */
 static struct async_worker *
 async_spawn_worker(struct nmsg_ostr_async *pool)
 {
-	struct async_worker *worker;
+	struct async_worker *worker = NULL;
+	unsigned	     i;
 	int		     pthread_res;
 
 	if (pool->spawn_failed)
 		return (NULL);
 
-	worker = async_take_worker(pool);
+	for (i = 0; i < pool->nworkers; i++) {
+		if (!pool->workers[i].joinable) {
+			worker = &pool->workers[i];
+			break;
+		}
+	}
+
 	if (worker == NULL)
 		return (NULL);
 
-	assert(!worker->joinable && !worker->idle && worker->slot == NULL);
+	assert(!worker->idle && worker->slot == NULL);
 
 	pthread_res = pthread_create(&worker->tid, NULL, async_worker, worker);
 	if (pthread_res != 0) {
@@ -833,14 +824,11 @@ async_spawn_worker(struct nmsg_ostr_async *pool)
 }
 
 /*
- * Wait until every ticket issued so far has been written, and take any error
- * the pool recorded. Under nmsg_io this cannot starve: check_close_event()
- * holds io_output->refcount across the write, so no writer is inside
- * nmsg_output_write() while a close runs. Callers driving nmsg_output_flush()
- * from several threads have no such guarantee.
+ * Wait until every ticket below 'upto' has been written, and take any error the
+ * pool recorded.
  */
 nmsg_res
-_output_async_drain(struct nmsg_ostr_async *pool)
+_output_async_drain(struct nmsg_ostr_async *pool, uint64_t upto)
 {
 	nmsg_res res;
 
@@ -848,7 +836,7 @@ _output_async_drain(struct nmsg_ostr_async *pool)
 		return (nmsg_res_success);
 
 	pthread_mutex_lock(&pool->lock);
-	while (!pool->failed && !async_all_written(pool))
+	while (!pool->failed && pool->commit_next < upto)
 		pthread_cond_wait(&pool->slot_free, &pool->lock);
 	res = pool->first_error;
 	pool->first_error = nmsg_res_success;
@@ -870,26 +858,24 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 {
 	struct nmsg_stream_output *ostr = output->stream;
 	struct async_slot	  *slot;
-	struct async_worker	  *worker;
+	struct async_worker	  *worker = NULL;
 	nmsg_res		   res = nmsg_res_success;
 	uint8_t			  *buf;
 	size_t			   buf_len;
 	bool			   inline_compress = false;
-	bool			   committer_needed, pool_usable;
 
 	pthread_mutex_lock(&pool->lock);
 
-	committer_needed = !pool->started && !pool->failed && !pool->shutdown;
-	if (committer_needed)
+	/*
+	 * No teardown can be running: it waits out the tickets already issued
+	 * before it sets shutdown, and this producer is holding one. That is
+	 * also what lets the slot wait below trust its slot is free.
+	 */
+	if (!pool->started && !pool->failed)
 		async_start(pool);
 
-	/*
-	 * Read after the attempt, since async_start() sets started or failed.
-	 * Only false when the committer could not start: teardown drains
-	 * outstanding tickets before setting shutdown.
-	 */
-	pool_usable = pool->started && !pool->failed && !pool->shutdown;
-	if (!pool_usable) {
+	/* Read after the attempt: async_start() sets started or failed. */
+	if (!pool->started) {
 		pthread_mutex_unlock(&pool->lock);
 		_output_async_unref(ostr);
 		return (false);
@@ -903,7 +889,7 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	 */
 	if (async_slot_busy(pool, ticket)) {
 		pool->n_waited++;
-		while (async_slot_busy(pool, ticket) && !pool->shutdown)
+		while (async_slot_busy(pool, ticket))
 			pthread_cond_wait(&pool->slot_free, &pool->lock);
 	}
 
@@ -912,19 +898,21 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 	if (ticket >= pool->issued)
 		pool->issued = ticket + 1;
 
+	/* An idle compressor, or a new one if the pool may still grow. */
+	if (!is_frag) {
+		worker = async_idle_take(pool);
+		if (worker == NULL)
+			worker = async_spawn_worker(pool);
+	}
+
 	if (is_frag) {
 		/* Only the committer fragments; see async_committer(). */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_frag;
 		pthread_cond_broadcast(&pool->commit_ready);
-	} else if ((worker = async_idle_pop(pool)) != NULL ||
-		   (worker = async_spawn_worker(pool)) != NULL) {
-		/*
-		 * Hand the container over and get back to reading. The slot
-		 * stays ours across the spawn's lock drop: no other ticket
-		 * maps to it, and the committer waits until it is ready.
-		 */
+	} else if (worker != NULL) {
+		/* Hand the container over and get back to reading. */
 		slot->co = *co;
 		*co = NULL;
 		slot->state = slot_work;
@@ -937,8 +925,11 @@ bool _output_async_submit(struct nmsg_ostr_async *pool, nmsg_output_t output,
 		inline_compress = true;
 	}
 
+	/*
+	 * Reported but not consumed: a write that never reached disk must still
+	 * be there for the flush or close to find. Cleared by the drain.
+	 */
 	res = pool->first_error;
-	pool->first_error = nmsg_res_success;
 	pthread_mutex_unlock(&pool->lock);
 
 	if (inline_compress) {

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -33,7 +33,7 @@ _output_nmsg_flush(nmsg_output_t output) {
 	nmsg_res res = nmsg_res_success;
 	nmsg_res drain_res;
 	nmsg_container_t old_c = NULL;
-	uint64_t ticket = 0;
+	uint64_t ticket = 0, upto;
 
 	pthread_mutex_lock(&ostr->c_lock);
 
@@ -55,6 +55,9 @@ _output_nmsg_flush(nmsg_output_t output) {
 			nmsg_container_set_sequence(ostr->c, ostr->do_sequence);
 	}
 
+	/* Everything sealed so far, including the container just taken. */
+	upto = ostr->so_ticket;
+
 	pthread_mutex_unlock(&ostr->c_lock);
 
 	/*
@@ -70,7 +73,7 @@ _output_nmsg_flush(nmsg_output_t output) {
 	}
 
 	/* A flush means written, so wait out anything the pool still holds. */
-	drain_res = _output_async_drain(pool);
+	drain_res = _output_async_drain(pool, upto);
 	if (res == nmsg_res_success)
 		res = drain_res;
 
@@ -86,7 +89,7 @@ _output_nmsg_write(nmsg_output_t output, nmsg_message_t msg) {
 	struct nmsg_stream_output *ostr = output->stream;
 	struct nmsg_ostr_async *pool;
 	nmsg_container_t old_c, new_c;
-	nmsg_res res;
+	nmsg_res res, sub_res, pending = nmsg_res_success;
 	uint64_t ticket;
 	bool must_flush, is_buffered;
 
@@ -161,13 +164,20 @@ retry:
 	pthread_mutex_unlock(&ostr->c_lock);	/* Release locked container to other threads. */
 
 	if (!must_flush)			/* Nothing more to do here. */
-		return (res);
+		return (pending != nmsg_res_success ? pending : res);
 
 	/* Reaching here WILL flush the prior container. */
 	if (res == nmsg_res_container_full) {		/* Doesn't include current message. */
-		res = container_submit(output, &old_c, false, ticket, pool);	/* Write data from prior container. */
-		if (res != nmsg_res_success)
-			return (res);
+		/* Write data from prior container. */
+		sub_res = container_submit(output, &old_c, false, ticket, pool);
+
+		/*
+		 * Kept rather than returned: with a pool the result belongs to
+		 * some earlier container, and returning here would drop this
+		 * message.
+		 */
+		if (pending == nmsg_res_success)
+			pending = sub_res;
 
 		/* Proceed to write current message to new container. */
 		goto retry;
@@ -177,7 +187,7 @@ retry:
 		res = container_submit(output, &old_c, true, ticket, pool);
 	}
 
-	return (res);
+	return (pending != nmsg_res_success ? pending : res);
 }
 
 /* Private functions. */

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -21,7 +21,7 @@
 
 /* Forward. */
 static nmsg_res container_write(nmsg_output_t, nmsg_container_t*);
-static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool);
+static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool, uint64_t);
 static nmsg_res frag_write(nmsg_output_t, nmsg_container_t);
 static nmsg_res send_buffer(nmsg_output_t, uint8_t *buf, size_t len);
 static nmsg_res async_drain(struct nmsg_ostr_async *);
@@ -29,96 +29,176 @@ static nmsg_res async_drain(struct nmsg_ostr_async *);
 /* Data structures. */
 
 /*
- * One compressor thread and one handoff slot. The producer fills 'pending' and
- * moves on; the worker takes it, compresses and writes it outside the lock.
- * A producer finding the slot still occupied blocks, so a compressor that
- * cannot keep up applies backpressure rather than growing a backlog.
+ * A compressor pool: a ring of slots, nworkers compressor threads and one
+ * committer thread.
+ *
+ * A container is given a ticket when it is sealed, under c_lock, so tickets
+ * follow the order the containers were closed in. Slot i serves every ticket
+ * with (ticket % depth) == i, so the producer of ticket T waits only for
+ * ticket T - depth to have been written.
+ *
+ * Compression runs on whichever thread is free. Only the committer writes, and
+ * only in ticket order, so the byte stream is identical to the synchronous
+ * path however many workers are running.
+ *
+ * A producer that finds every worker busy compresses the container itself
+ * rather than waiting. That is exactly what the synchronous path does, so the
+ * pool is never slower than no pool at all.
  */
+typedef enum {
+	slot_empty = 0,	/* Free. */
+	slot_work,	/* Container waiting for a compressor. */
+	slot_taken,	/* A worker or a producer is compressing it. */
+	slot_done,	/* Compressed, waiting its turn to be written. */
+	slot_frag	/* Oversized: the committer must fragment it itself. */
+} async_slot_state;
+
+struct async_slot {
+	async_slot_state	state;
+	nmsg_container_t	co;		/* slot_work, slot_frag */
+	uint8_t			*buf;		/* slot_done */
+	size_t			buf_len;
+	nmsg_res		res;
+};
+
 struct nmsg_ostr_async {
 	pthread_mutex_t		lock;
-	pthread_cond_t		work_ready;	/* pending != NULL || shutdown */
-	pthread_cond_t		slot_free;	/* pending == NULL && !busy */
-	nmsg_container_t	pending;
-	bool			pending_frag;	/* Overfull: needs frag_write(). */
-	bool			busy;		/* Worker holds a container. */
+	pthread_cond_t		work_ready;	/* A slot became slot_work. */
+	pthread_cond_t		commit_ready;	/* The committer's slot is ready. */
+	pthread_cond_t		slot_free;	/* A slot became slot_empty. */
+	struct async_slot	*slots;
+	unsigned		depth;
+	unsigned		nworkers;
+	unsigned		busy;		/* Workers currently compressing. */
+	uint64_t		issued;		/* Highest ticket claimed, plus one. */
+	uint64_t		commit_next;	/* Ticket allowed to write now. */
 	bool			shutdown;
-	bool			started;	/* Worker exists; must be joined. */
-	bool			failed;		/* pthread_create() failed; do not retry. */
-	pthread_t		worker;
+	bool			started;
+	bool			failed;		/* Thread creation failed; stay inline. */
+	pthread_t		*workers;
+	pthread_t		committer;
 	nmsg_res		first_error;	/* Sticky; surfaced by flush. */
 	nmsg_output_t		output;
-	uint64_t		n_blocked;	/* Producer waits on a full slot. */
+	uint64_t		n_inline;	/* Containers a producer compressed. */
+	uint64_t		n_waited;	/* Producers that waited for a slot. */
 };
 
 /* Internal functions. */
 
 nmsg_res
-_output_nmsg_async_init(nmsg_output_t output) {
+_output_nmsg_async_init(nmsg_output_t output, unsigned nworkers) {
 	struct nmsg_ostr_async *pool;
+	unsigned depth;
+
+	if (nworkers == 0)
+		return (nmsg_res_success);
 
 	if (output->stream->so_pool != NULL)
 		return (nmsg_res_success);
+
+	/*
+	 * One slot per worker to compress in, plus a fixed margin for
+	 * producers to deposit into and for finished buffers waiting their
+	 * turn to be written. The margin does not need to scale with the
+	 * worker count: a producer that cannot get a slot compresses the
+	 * container itself rather than waiting, so a tight ring costs a little
+	 * of the parallelism and never blocks a reader.
+	 *
+	 * A slot holds a container's payloads in memory, which is not the
+	 * 1 MiB serialized size -- a channel of 30-byte payloads puts ~37k of
+	 * them in a container, over 5 MB. That is what bounds the ring, and
+	 * why the automatic worker count is capped.
+	 */
+	depth = nworkers + 8;
 
 	pool = calloc(1, sizeof(*pool));
 	if (pool == NULL)
 		return (nmsg_res_memfail);
 
+	pool->slots = calloc(depth, sizeof(*pool->slots));
+	if (pool->slots == NULL)
+		goto fail_slots;
+
+	pool->workers = calloc(nworkers, sizeof(*pool->workers));
+	if (pool->workers == NULL)
+		goto fail_workers;
+
 	if (pthread_mutex_init(&pool->lock, NULL) != 0)
 		goto fail_mutex;
 	if (pthread_cond_init(&pool->work_ready, NULL) != 0)
 		goto fail_work_ready;
+	if (pthread_cond_init(&pool->commit_ready, NULL) != 0)
+		goto fail_commit_ready;
 	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
 		goto fail_slot_free;
 
+	pool->depth = depth;
+	pool->nworkers = nworkers;
 	pool->output = output;
 	output->stream->so_pool = pool;
 
 	return (nmsg_res_success);
 
 fail_slot_free:
+	pthread_cond_destroy(&pool->commit_ready);
+fail_commit_ready:
 	pthread_cond_destroy(&pool->work_ready);
 fail_work_ready:
 	pthread_mutex_destroy(&pool->lock);
 fail_mutex:
+	free(pool->workers);
+fail_workers:
+	free(pool->slots);
+fail_slots:
 	free(pool);
 
 	return (nmsg_res_failure);
 }
 
 /*
- * Stop the compressor and reclaim it. Any pending container is written first.
- * Must run before the stream's fd, random and locks go away, since the worker
- * uses all of them.
+ * Stop the pool and reclaim it. Everything still queued is written first.
+ * Must run before the stream's fd, random and locks go away, since the threads
+ * use all of them.
  */
 nmsg_res
 _output_nmsg_async_destroy(nmsg_output_t output) {
 	struct nmsg_ostr_async *pool = output->stream->so_pool;
 	nmsg_res res;
 	bool started;
+	unsigned i;
 
 	if (pool == NULL)
 		return (nmsg_res_success);
 
 	pthread_mutex_lock(&pool->lock);
-	pool->shutdown = true;		/* Set under the lock: a worker about */
+	pool->shutdown = true;		/* Set under the lock: a thread about */
 	started = pool->started;	/* to wait would miss the wakeup. */
 	pthread_cond_broadcast(&pool->work_ready);
+	pthread_cond_broadcast(&pool->commit_ready);
 	pthread_cond_broadcast(&pool->slot_free);
 	pthread_mutex_unlock(&pool->lock);
 
-	if (started)
-		pthread_join(pool->worker, NULL);
+	if (started) {
+		for (i = 0; i < pool->nworkers; i++)
+			pthread_join(pool->workers[i], NULL);
+		pthread_join(pool->committer, NULL);
+	}
 
-	if (pool->n_blocked > 0)
-		_nmsg_dprintf(2, "%s: producer waited on the compressor %" PRIu64
-			      " times\n", __func__, pool->n_blocked);
+	if (pool->n_inline > 0 || pool->n_waited > 0)
+		_nmsg_dprintf(2, "%s: %u worker(s); %" PRIu64 " container(s) "
+			      "compressed by the reader, %" PRIu64 " wait(s) for "
+			      "a free slot\n", __func__, pool->nworkers,
+			      pool->n_inline, pool->n_waited);
 
-	/* Read after the join; the worker writes it up to the moment it exits. */
+	/* Read after the joins; the threads write it until they exit. */
 	res = pool->first_error;
 
 	pthread_cond_destroy(&pool->slot_free);
+	pthread_cond_destroy(&pool->commit_ready);
 	pthread_cond_destroy(&pool->work_ready);
 	pthread_mutex_destroy(&pool->lock);
+	free(pool->workers);
+	free(pool->slots);
 	free(pool);
 	output->stream->so_pool = NULL;
 
@@ -127,32 +207,45 @@ _output_nmsg_async_destroy(nmsg_output_t output) {
 
 nmsg_res
 _output_nmsg_flush(nmsg_output_t output) {
+	struct nmsg_stream_output *ostr = output->stream;
 	nmsg_res res = nmsg_res_success;
 	nmsg_res drain_res;
+	nmsg_container_t old_c = NULL;
+	uint64_t ticket = 0;
 
-	pthread_mutex_lock(&output->stream->c_lock);
+	pthread_mutex_lock(&ostr->c_lock);
 
-	if (nmsg_container_get_num_payloads(output->stream->c) > 0) {
+	if (nmsg_container_get_num_payloads(ostr->c) > 0) {
+		old_c = ostr->c;
+		ticket = ostr->so_ticket++;
 
-		/* Process container; container is destroyed. */
-		res = container_submit(output, &output->stream->c, false /* is_frag */);
-
-		output->stream->c = nmsg_container_init(output->stream->bufsz);
-		if (output->stream->c == NULL)
+		ostr->c = nmsg_container_init(ostr->bufsz);
+		if (ostr->c == NULL)
 			res = nmsg_res_memfail;
 		else
-			nmsg_container_set_sequence(output->stream->c, output->stream->do_sequence);
-
+			nmsg_container_set_sequence(ostr->c, ostr->do_sequence);
 	}
 
-	pthread_mutex_unlock(&output->stream->c_lock);
+	pthread_mutex_unlock(&ostr->c_lock);
+
+	/*
+	 * Submitted outside c_lock. Flush runs on every file rotation, and a
+	 * submit can wait for a free slot; doing that under c_lock would hold
+	 * off every reader thread for the length of a compression.
+	 */
+	if (old_c != NULL) {
+		nmsg_res sub_res;
+
+		sub_res = container_submit(output, &old_c, false, ticket);
+		if (res == nmsg_res_success)
+			res = sub_res;
+	}
 
 	/*
 	 * A flush means the data has been written, so wait out anything the
-	 * compressor is still holding. Done outside c_lock so producers are not
-	 * held off for the length of a compression.
+	 * pool is still holding.
 	 */
-	drain_res = async_drain(output->stream->so_pool);
+	drain_res = async_drain(ostr->so_pool);
 	if (res == nmsg_res_success)
 		res = drain_res;
 
@@ -165,6 +258,7 @@ _output_nmsg_write(nmsg_output_t output, nmsg_message_t msg) {
 	struct nmsg_stream_output *ostr = output->stream;
 	nmsg_container_t old_c, new_c;
 	nmsg_res res;
+	uint64_t ticket = 0;
 	bool must_flush, is_buffered;
 
 	assert(msg->np != NULL);
@@ -221,6 +315,15 @@ retry:
 
 		old_c = ostr->c;	/* Process old, proceed with new. */
 		ostr->c = new_c;
+
+		/*
+		 * Ticket taken here, under c_lock, because this is where the
+		 * container's contents become final. Taking it in
+		 * container_submit() would order the containers by which
+		 * thread won the race after the unlock, which is not the
+		 * order they were filled in.
+		 */
+		ticket = ostr->so_ticket++;
 	}
 
 	pthread_mutex_unlock(&ostr->c_lock);	/* Release locked container to other threads. */
@@ -230,16 +333,16 @@ retry:
 
 	/* Reaching here WILL flush the prior container. */
 	if (res == nmsg_res_container_full) {		/* Doesn't include current message. */
-		res = container_submit(output, &old_c, false /* is_frag */);	/* Write data from prior container. */
+		res = container_submit(output, &old_c, false, ticket);	/* Write data from prior container. */
 		if (res != nmsg_res_success)
 			return (res);
 
 		/* Proceed to write current message to new container. */
 		goto retry;
 	} else if (res == nmsg_res_success && is_buffered == false) {	/* Includes current message. */
-		res = container_submit(output, &old_c, false /* is_frag */);
+		res = container_submit(output, &old_c, false, ticket);
 	} else if (res == nmsg_res_container_overfull) {		/* Includes current message. */
-		res = container_submit(output, &old_c, true /* is_frag */);
+		res = container_submit(output, &old_c, true, ticket);
 	}
 
 	return (res);
@@ -247,100 +350,40 @@ retry:
 
 /* Private functions. */
 
-static void *
-async_worker(void *arg)
-{
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
-
-	pthread_mutex_lock(&pool->lock);
-
-	/*
-	 * Keep going while there is work, or until told to stop. Testing
-	 * 'pending' first is what stops shutdown from discarding a container:
-	 * a slot filled just before shutdown is still written. That happens on
-	 * every clean SIGTERM, and dropping it would lose the tail of the
-	 * final file.
-	 */
-	while (pool->pending != NULL || !pool->shutdown) {
-		nmsg_container_t co;
-		bool is_frag;
-		nmsg_res res;
-
-		if (pool->pending == NULL) {
-			pthread_cond_wait(&pool->work_ready, &pool->lock);
-			continue;
-		}
-
-		co = pool->pending;
-		is_frag = pool->pending_frag;
-		pool->pending = NULL;
-		pool->busy = true;
-
-		pthread_cond_broadcast(&pool->slot_free);
-		pthread_mutex_unlock(&pool->lock);
-
-		if (is_frag)
-			res = frag_write(pool->output, co);
-		else
-			res = container_write(pool->output, &co);
-
-		pthread_mutex_lock(&pool->lock);
-		pool->busy = false;
-		if (res != nmsg_res_success && pool->first_error == nmsg_res_success)
-			pool->first_error = res;
-
-		/* A drainer waits on !busy, not just on an empty slot. */
-		pthread_cond_broadcast(&pool->slot_free);
-	}
-	pthread_mutex_unlock(&pool->lock);
-
-	return (NULL);
-}
-
 /*
- * Start the worker. Called under pool->lock on first submit rather than when
- * the output is configured, because nmsgtool creates its outputs before it
- * daemonizes, and daemonize() is a bare fork() which no thread survives.
- * Starting on first write puts the worker in whichever process does the
- * writing.
- */
-static void
-async_start(struct nmsg_ostr_async *pool)
-{
-	int pthread_res;
-
-	pthread_res = pthread_create(&pool->worker, NULL, async_worker, pool);
-	if (pthread_res != 0) {
-		pool->failed = true;
-		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
-			      strerror(pthread_res));
-		return;
-	}
-	pool->started = true;
-}
-
-/*
- * Wait until nothing is queued or in flight, and take any error the worker
- * recorded. Under nmsg_io this cannot starve: check_close_event() holds
- * io_output->refcount across the write and call_close_fp() waits for it to
- * drop, so no other thread is inside nmsg_output_write() while a close runs.
- * A caller driving nmsg_output_flush() directly from several threads has no
- * such guarantee.
+ * Compress one container into a standalone buffer. The container is destroyed
+ * either way, as container_write() does.
  */
 static nmsg_res
-async_drain(struct nmsg_ostr_async *pool)
+container_compress(nmsg_output_t output, nmsg_container_t *co,
+		   uint8_t **buf, size_t *buf_len)
 {
+	struct nmsg_stream_output *ostr = output->stream;
 	nmsg_res res;
+	uint32_t seq;
+	uint8_t *shrunk;
 
-	if (pool == NULL)
-		return (nmsg_res_success);
+	/* Multiple threads can enter here at once. */
+	seq = atomic_fetch_add_explicit(&ostr->so_sequence_num, 1, memory_order_relaxed);
 
-	pthread_mutex_lock(&pool->lock);
-	while (pool->pending != NULL || pool->busy)
-		pthread_cond_wait(&pool->slot_free, &pool->lock);
-	res = pool->first_error;
-	pool->first_error = nmsg_res_success;
-	pthread_mutex_unlock(&pool->lock);
+	res = nmsg_container_serialize(*co, buf, buf_len, true, /* do_header */
+				       ostr->do_zlib, seq, ostr->sequence_id);
+	nmsg_container_destroy(co);
+
+	if (res != nmsg_res_success) {
+		*buf = NULL;
+		*buf_len = 0;
+		return (res);
+	}
+
+	/*
+	 * nmsg_container_serialize() returns the base of an allocation sized
+	 * for the worst case, twice the unpacked estimate. A slot holds that
+	 * until every earlier ticket has been written, so hand the rest back.
+	 */
+	shrunk = realloc(*buf, *buf_len);
+	if (shrunk != NULL)
+		*buf = shrunk;
 
 	return (res);
 }
@@ -354,83 +397,313 @@ container_write(nmsg_output_t output, nmsg_container_t *co)
 {
 	nmsg_res res;
 	size_t buf_len;
-	uint32_t seq;
 	uint8_t *buf;
 
-	/* Multiple threads can enter here at once. */
-	seq = atomic_fetch_add_explicit(&output->stream->so_sequence_num, 1, memory_order_relaxed);
-
-	res = nmsg_container_serialize(*co, &buf, &buf_len, true, /* do_header */
-					output->stream->do_zlib, seq, output->stream->sequence_id);
-
+	res = container_compress(output, co, &buf, &buf_len);
 	if (res != nmsg_res_success)
-		goto out;
+		return (res);
 
-	res = send_buffer(output, buf, buf_len);
-out:
-	nmsg_container_destroy(co);
+	return (send_buffer(output, buf, buf_len));
+}
+
+/* Note an error, keeping the first one seen. Caller holds pool->lock. */
+static void
+async_record_error(struct nmsg_ostr_async *pool, nmsg_res res)
+{
+	if (res != nmsg_res_success && pool->first_error == nmsg_res_success)
+		pool->first_error = res;
+}
+
+/*
+ * Compressor thread. Takes any slot that needs compressing, in whatever order
+ * they become ready: compression order does not matter, only write order does,
+ * and the committer enforces that.
+ */
+static void *
+async_worker(void *arg)
+{
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+
+	pthread_mutex_lock(&pool->lock);
+
+	for (;;) {
+		struct async_slot *slot = NULL;
+		nmsg_container_t co;
+		uint8_t *buf;
+		size_t buf_len;
+		nmsg_res res;
+		unsigned i;
+
+		for (i = 0; i < pool->depth; i++) {
+			if (pool->slots[i].state == slot_work) {
+				slot = &pool->slots[i];
+				break;
+			}
+		}
+
+		if (slot == NULL) {
+			/*
+			 * Nothing to compress. Exit only once the producers
+			 * have stopped, so a container queued just before
+			 * shutdown is still compressed and written; that
+			 * happens on every clean SIGTERM.
+			 */
+			if (pool->shutdown)
+				break;
+			pthread_cond_wait(&pool->work_ready, &pool->lock);
+			continue;
+		}
+
+		slot->state = slot_taken;
+		co = slot->co;
+		slot->co = NULL;
+		pool->busy++;
+		pthread_mutex_unlock(&pool->lock);
+
+		res = container_compress(pool->output, &co, &buf, &buf_len);
+
+		pthread_mutex_lock(&pool->lock);
+		pool->busy--;
+		slot->buf = buf;
+		slot->buf_len = buf_len;
+		slot->res = res;
+		slot->state = slot_done;
+		pthread_cond_broadcast(&pool->commit_ready);
+	}
+
+	pthread_mutex_unlock(&pool->lock);
+
+	return (NULL);
+}
+
+/*
+ * The only thread that writes. It takes tickets strictly in order, so the file
+ * is byte-identical to what the synchronous path would have produced no matter
+ * how many workers compressed in parallel.
+ *
+ * It is also the only caller of frag_write().
+ */
+static void *
+async_committer(void *arg)
+{
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+
+	pthread_mutex_lock(&pool->lock);
+
+	for (;;) {
+		struct async_slot *slot = &pool->slots[pool->commit_next % pool->depth];
+		async_slot_state state = slot->state;
+		nmsg_res res;
+
+		if (state == slot_done) {
+			uint8_t *buf = slot->buf;
+			size_t buf_len = slot->buf_len;
+
+			res = slot->res;
+			slot->buf = NULL;
+			pthread_mutex_unlock(&pool->lock);
+
+			/* send_buffer() owns buf from here, error or not. */
+			if (res == nmsg_res_success)
+				res = send_buffer(pool->output, buf, buf_len);
+
+			pthread_mutex_lock(&pool->lock);
+		} else if (state == slot_frag) {
+			nmsg_container_t co = slot->co;
+
+			slot->co = NULL;
+			pthread_mutex_unlock(&pool->lock);
+
+			/* frag_write() takes the container by value and destroys it. */
+			res = frag_write(pool->output, co);
+
+			pthread_mutex_lock(&pool->lock);
+		} else {
+			/*
+			 * The next ticket is not ready. Exit only when the
+			 * producers have stopped and every ticket they issued
+			 * has been written.
+			 */
+			if (pool->shutdown && pool->commit_next >= pool->issued)
+				break;
+			pthread_cond_wait(&pool->commit_ready, &pool->lock);
+			continue;
+		}
+
+		async_record_error(pool, res);
+		slot->state = slot_empty;
+		pool->commit_next++;
+		pthread_cond_broadcast(&pool->slot_free);
+	}
+
+	pthread_mutex_unlock(&pool->lock);
+
+	return (NULL);
+}
+
+/*
+ * Start the threads. Called under pool->lock on first submit rather than when
+ * the output is configured, because nmsgtool creates its outputs before it
+ * daemonizes, and daemonize() is a bare fork() which no thread survives.
+ * Starting on first write puts the threads in whichever process does the
+ * writing.
+ */
+static void
+async_start(struct nmsg_ostr_async *pool)
+{
+	unsigned i;
+	int pthread_res;
+
+	for (i = 0; i < pool->nworkers; i++) {
+		pthread_res = pthread_create(&pool->workers[i], NULL, async_worker, pool);
+		if (pthread_res != 0)
+			goto fail;
+	}
+
+	pthread_res = pthread_create(&pool->committer, NULL, async_committer, pool);
+	if (pthread_res != 0)
+		goto fail;
+
+	pool->started = true;
+	return;
+
+fail:
+	/*
+	 * Stop whatever did start and fall back to compressing inline. Joining
+	 * needs the lock released, and the caller still holds a container, so
+	 * this stays simple: the threads created so far see shutdown and exit,
+	 * and destroy joins them.
+	 */
+	pool->nworkers = i;
+	pool->failed = true;
+	pool->shutdown = true;
+	pool->started = (i > 0);
+	pthread_cond_broadcast(&pool->work_ready);
+	pthread_cond_broadcast(&pool->commit_ready);
+	_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
+		      strerror(pthread_res));
+}
+
+/*
+ * Wait until every ticket issued so far has been written, and take any error
+ * the pool recorded. Under nmsg_io this cannot starve: check_close_event()
+ * holds io_output->refcount across the write and call_close_fp() waits for it
+ * to drop, so no other thread is inside nmsg_output_write() while a close runs.
+ * A caller driving nmsg_output_flush() directly from several threads has no
+ * such guarantee.
+ */
+static nmsg_res
+async_drain(struct nmsg_ostr_async *pool)
+{
+	nmsg_res res;
+
+	if (pool == NULL)
+		return (nmsg_res_success);
+
+	pthread_mutex_lock(&pool->lock);
+	while (pool->started && !pool->failed && pool->commit_next < pool->issued)
+		pthread_cond_wait(&pool->slot_free, &pool->lock);
+	res = pool->first_error;
+	pool->first_error = nmsg_res_success;
+	pthread_mutex_unlock(&pool->lock);
 
 	return (res);
 }
 
 /*
- * Hand a finished container to the compressor thread, or process it inline if
- * there is no compressor. The container is consumed either way.
+ * Hand a finished container to the pool, or process it inline if there is no
+ * pool. The container is consumed either way.
  *
- * The async path reports success for the container it just took, since that
+ * The pool reports success for the container it just took, since that
  * container has not been written yet. An error from an EARLIER container is
- * returned here instead, which is what keeps a full disk fatal: write_file()
- * returns nmsg_res_errno, io_thr_input() stops the loop on it (nmsg/io.c), 
- * and that is the only way nmsgtool notices ENOSPC. Delayed by one
- * container rather than by a whole rotation.
+ * returned here.
  */
 static nmsg_res
-container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag)
+container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag,
+		 uint64_t ticket)
 {
 	struct nmsg_ostr_async *pool = output->stream->so_pool;
+	struct async_slot *slot;
 	nmsg_res res = nmsg_res_success;
-	bool handed_off = false;
+	uint8_t *buf;
+	size_t buf_len;
+	bool inline_compress = false;
 
-	if (pool != NULL) {
-		bool blocked = false;
+	if (pool == NULL)
+		goto inline_path;
+
+	pthread_mutex_lock(&pool->lock);
+
+	if (!pool->started && !pool->failed && !pool->shutdown)
+		async_start(pool);
+
+	if (!pool->started || pool->failed || pool->shutdown) {
+		pthread_mutex_unlock(&pool->lock);
+		goto inline_path;
+	}
+
+	slot = &pool->slots[ticket % pool->depth];
+
+	/*
+	 * Wait for the slot this ticket owns, which the ticket 'depth' earlier
+	 * releases when it is written. Only reached when the writer has fallen
+	 * a whole ring behind.
+	 */
+	if (slot->state != slot_empty) {
+		pool->n_waited++;
+		while (slot->state != slot_empty && !pool->shutdown)
+			pthread_cond_wait(&pool->slot_free, &pool->lock);
+
+		if (pool->shutdown) {
+			pthread_mutex_unlock(&pool->lock);
+			goto inline_path;
+		}
+	}
+
+	if (ticket >= pool->issued)
+		pool->issued = ticket + 1;
+
+	if (is_frag) {
+		/* Only the committer fragments; see async_committer(). */
+		slot->co = *co;
+		*co = NULL;
+		slot->state = slot_frag;
+		pthread_cond_broadcast(&pool->commit_ready);
+	} else if (pool->busy < pool->nworkers) {
+		/* A worker is free: hand it over and get back to reading. */
+		slot->co = *co;
+		*co = NULL;
+		slot->state = slot_work;
+		pthread_cond_signal(&pool->work_ready);
+	} else {
+		/*
+		 * Every worker is busy. Compress it here rather than wait then deposit
+		 * the result and return.
+		 */
+		slot->state = slot_taken;
+		pool->n_inline++;
+		inline_compress = true;
+	}
+
+	res = pool->first_error;
+	pool->first_error = nmsg_res_success;
+	pthread_mutex_unlock(&pool->lock);
+
+	if (inline_compress) {
+		nmsg_res c_res = container_compress(output, co, &buf, &buf_len);
 
 		pthread_mutex_lock(&pool->lock);
-
-		if (!pool->started && !pool->failed && !pool->shutdown)
-			async_start(pool);
-
-		if (pool->started) {
-			while (pool->pending != NULL && !pool->shutdown) {
-				if (!blocked) {
-					pool->n_blocked++;
-					blocked = true;
-				}
-				pthread_cond_wait(&pool->slot_free, &pool->lock);
-			}
-
-			/*
-			 * Re-tested after the wait: shutdown can arrive while
-			 * blocked here.
-			 */
-			if (!pool->shutdown) {
-				pool->pending = *co;
-				pool->pending_frag = is_frag;
-				*co = NULL;
-				handed_off = true;
-
-				res = pool->first_error;
-				pool->first_error = nmsg_res_success;
-
-				pthread_cond_signal(&pool->work_ready);
-			}
-		}
-
+		slot->buf = buf;
+		slot->buf_len = buf_len;
+		slot->res = c_res;
+		slot->state = slot_done;
+		pthread_cond_broadcast(&pool->commit_ready);
 		pthread_mutex_unlock(&pool->lock);
 	}
 
-	if (handed_off)
-		return (res);
+	return (res);
 
+inline_path:
 	if (is_frag) {
 		nmsg_container_t tmp = *co;
 

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -164,7 +164,7 @@ retry:
 	pthread_mutex_unlock(&ostr->c_lock);	/* Release locked container to other threads. */
 
 	if (!must_flush)			/* Nothing more to do here. */
-		return (pending != nmsg_res_success ? pending : res);
+		goto out;
 
 	/* Reaching here WILL flush the prior container. */
 	if (res == nmsg_res_container_full) {		/* Doesn't include current message. */
@@ -187,6 +187,8 @@ retry:
 		res = container_submit(output, &old_c, true, ticket, pool);
 	}
 
+out:
+	/* An earlier container's error outranks this one's disposition. */
 	return (pending != nmsg_res_success ? pending : res);
 }
 

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -21,21 +21,121 @@
 
 /* Forward. */
 static nmsg_res container_write(nmsg_output_t, nmsg_container_t*);
+static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool);
 static nmsg_res frag_write(nmsg_output_t, nmsg_container_t);
 static nmsg_res send_buffer(nmsg_output_t, uint8_t *buf, size_t len);
+static nmsg_res async_drain(struct nmsg_ostr_async *);
+
+/* Data structures. */
+
+/*
+ * One compressor thread and one handoff slot. The producer fills 'pending' and
+ * moves on; the worker takes it, compresses and writes it outside the lock.
+ * A producer finding the slot still occupied blocks, so a compressor that
+ * cannot keep up applies backpressure rather than growing a backlog.
+ */
+struct nmsg_ostr_async {
+	pthread_mutex_t		lock;
+	pthread_cond_t		work_ready;	/* pending != NULL || shutdown */
+	pthread_cond_t		slot_free;	/* pending == NULL && !busy */
+	nmsg_container_t	pending;
+	bool			pending_frag;	/* Overfull: needs frag_write(). */
+	bool			busy;		/* Worker holds a container. */
+	bool			shutdown;
+	bool			started;	/* Worker exists; must be joined. */
+	bool			failed;		/* pthread_create() failed; do not retry. */
+	pthread_t		worker;
+	nmsg_res		first_error;	/* Sticky; surfaced by flush. */
+	nmsg_output_t		output;
+	uint64_t		n_blocked;	/* Producer waits on a full slot. */
+};
 
 /* Internal functions. */
 
 nmsg_res
+_output_nmsg_async_init(nmsg_output_t output) {
+	struct nmsg_ostr_async *pool;
+
+	if (output->stream->so_pool != NULL)
+		return (nmsg_res_success);
+
+	pool = calloc(1, sizeof(*pool));
+	if (pool == NULL)
+		return (nmsg_res_memfail);
+
+	if (pthread_mutex_init(&pool->lock, NULL) != 0)
+		goto fail_mutex;
+	if (pthread_cond_init(&pool->work_ready, NULL) != 0)
+		goto fail_work_ready;
+	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
+		goto fail_slot_free;
+
+	pool->output = output;
+	output->stream->so_pool = pool;
+
+	return (nmsg_res_success);
+
+fail_slot_free:
+	pthread_cond_destroy(&pool->work_ready);
+fail_work_ready:
+	pthread_mutex_destroy(&pool->lock);
+fail_mutex:
+	free(pool);
+
+	return (nmsg_res_failure);
+}
+
+/*
+ * Stop the compressor and reclaim it. Any pending container is written first.
+ * Must run before the stream's fd, random and locks go away, since the worker
+ * uses all of them.
+ */
+nmsg_res
+_output_nmsg_async_destroy(nmsg_output_t output) {
+	struct nmsg_ostr_async *pool = output->stream->so_pool;
+	nmsg_res res;
+	bool started;
+
+	if (pool == NULL)
+		return (nmsg_res_success);
+
+	pthread_mutex_lock(&pool->lock);
+	pool->shutdown = true;		/* Set under the lock: a worker about */
+	started = pool->started;	/* to wait would miss the wakeup. */
+	pthread_cond_broadcast(&pool->work_ready);
+	pthread_cond_broadcast(&pool->slot_free);
+	pthread_mutex_unlock(&pool->lock);
+
+	if (started)
+		pthread_join(pool->worker, NULL);
+
+	if (pool->n_blocked > 0)
+		_nmsg_dprintf(2, "%s: producer waited on the compressor %" PRIu64
+			      " times\n", __func__, pool->n_blocked);
+
+	/* Read after the join; the worker writes it up to the moment it exits. */
+	res = pool->first_error;
+
+	pthread_cond_destroy(&pool->slot_free);
+	pthread_cond_destroy(&pool->work_ready);
+	pthread_mutex_destroy(&pool->lock);
+	free(pool);
+	output->stream->so_pool = NULL;
+
+	return (res);
+}
+
+nmsg_res
 _output_nmsg_flush(nmsg_output_t output) {
 	nmsg_res res = nmsg_res_success;
+	nmsg_res drain_res;
 
 	pthread_mutex_lock(&output->stream->c_lock);
 
 	if (nmsg_container_get_num_payloads(output->stream->c) > 0) {
 
 		/* Process container; container is destroyed. */
-		res = container_write(output, &output->stream->c);
+		res = container_submit(output, &output->stream->c, false /* is_frag */);
 
 		output->stream->c = nmsg_container_init(output->stream->bufsz);
 		if (output->stream->c == NULL)
@@ -46,6 +146,15 @@ _output_nmsg_flush(nmsg_output_t output) {
 	}
 
 	pthread_mutex_unlock(&output->stream->c_lock);
+
+	/*
+	 * A flush means the data has been written, so wait out anything the
+	 * compressor is still holding. Done outside c_lock so producers are not
+	 * held off for the length of a compression.
+	 */
+	drain_res = async_drain(output->stream->so_pool);
+	if (res == nmsg_res_success)
+		res = drain_res;
 
 	return (res);
 }
@@ -121,22 +230,120 @@ retry:
 
 	/* Reaching here WILL flush the prior container. */
 	if (res == nmsg_res_container_full) {		/* Doesn't include current message. */
-		res = container_write(output, &old_c);	/* Write data from prior container. */
+		res = container_submit(output, &old_c, false /* is_frag */);	/* Write data from prior container. */
 		if (res != nmsg_res_success)
 			return (res);
 
 		/* Proceed to write current message to new container. */
 		goto retry;
 	} else if (res == nmsg_res_success && is_buffered == false) {	/* Includes current message. */
-		res = container_write(output, &old_c);
+		res = container_submit(output, &old_c, false /* is_frag */);
 	} else if (res == nmsg_res_container_overfull) {		/* Includes current message. */
-		res = frag_write(output, old_c);
+		res = container_submit(output, &old_c, true /* is_frag */);
 	}
 
 	return (res);
 }
 
 /* Private functions. */
+
+static void *
+async_worker(void *arg)
+{
+	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
+
+	pthread_mutex_lock(&pool->lock);
+
+	/*
+	 * Keep going while there is work, or until told to stop. Testing
+	 * 'pending' first is what stops shutdown from discarding a container:
+	 * a slot filled just before shutdown is still written. That happens on
+	 * every clean SIGTERM, and dropping it would lose the tail of the
+	 * final file.
+	 */
+	while (pool->pending != NULL || !pool->shutdown) {
+		nmsg_container_t co;
+		bool is_frag;
+		nmsg_res res;
+
+		if (pool->pending == NULL) {
+			pthread_cond_wait(&pool->work_ready, &pool->lock);
+			continue;
+		}
+
+		co = pool->pending;
+		is_frag = pool->pending_frag;
+		pool->pending = NULL;
+		pool->busy = true;
+
+		pthread_cond_broadcast(&pool->slot_free);
+		pthread_mutex_unlock(&pool->lock);
+
+		if (is_frag)
+			res = frag_write(pool->output, co);
+		else
+			res = container_write(pool->output, &co);
+
+		pthread_mutex_lock(&pool->lock);
+		pool->busy = false;
+		if (res != nmsg_res_success && pool->first_error == nmsg_res_success)
+			pool->first_error = res;
+
+		/* A drainer waits on !busy, not just on an empty slot. */
+		pthread_cond_broadcast(&pool->slot_free);
+	}
+	pthread_mutex_unlock(&pool->lock);
+
+	return (NULL);
+}
+
+/*
+ * Start the worker. Called under pool->lock on first submit rather than when
+ * the output is configured, because nmsgtool creates its outputs before it
+ * daemonizes, and daemonize() is a bare fork() which no thread survives.
+ * Starting on first write puts the worker in whichever process does the
+ * writing.
+ */
+static void
+async_start(struct nmsg_ostr_async *pool)
+{
+	int pthread_res;
+
+	pthread_res = pthread_create(&pool->worker, NULL, async_worker, pool);
+	if (pthread_res != 0) {
+		pool->failed = true;
+		_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
+			      strerror(pthread_res));
+		return;
+	}
+	pool->started = true;
+}
+
+/*
+ * Wait until nothing is queued or in flight, and take any error the worker
+ * recorded. Under nmsg_io this cannot starve: check_close_event() holds
+ * io_output->refcount across the write and call_close_fp() waits for it to
+ * drop, so no other thread is inside nmsg_output_write() while a close runs.
+ * A caller driving nmsg_output_flush() directly from several threads has no
+ * such guarantee.
+ */
+static nmsg_res
+async_drain(struct nmsg_ostr_async *pool)
+{
+	nmsg_res res;
+
+	if (pool == NULL)
+		return (nmsg_res_success);
+
+	pthread_mutex_lock(&pool->lock);
+	while (pool->pending != NULL || pool->busy)
+		pthread_cond_wait(&pool->slot_free, &pool->lock);
+	res = pool->first_error;
+	pool->first_error = nmsg_res_success;
+	pthread_mutex_unlock(&pool->lock);
+
+	return (res);
+}
 
 /*
  * Send/write the contents of a container.
@@ -164,6 +371,78 @@ out:
 	nmsg_container_destroy(co);
 
 	return (res);
+}
+
+/*
+ * Hand a finished container to the compressor thread, or process it inline if
+ * there is no compressor. The container is consumed either way.
+ *
+ * The async path reports success for the container it just took, since that
+ * container has not been written yet. An error from an EARLIER container is
+ * returned here instead, which is what keeps a full disk fatal: write_file()
+ * returns nmsg_res_errno, io_thr_input() stops the loop on it (nmsg/io.c), 
+ * and that is the only way nmsgtool notices ENOSPC. Delayed by one
+ * container rather than by a whole rotation.
+ */
+static nmsg_res
+container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag)
+{
+	struct nmsg_ostr_async *pool = output->stream->so_pool;
+	nmsg_res res = nmsg_res_success;
+	bool handed_off = false;
+
+	if (pool != NULL) {
+		bool blocked = false;
+
+		pthread_mutex_lock(&pool->lock);
+
+		if (!pool->started && !pool->failed && !pool->shutdown)
+			async_start(pool);
+
+		if (pool->started) {
+			while (pool->pending != NULL && !pool->shutdown) {
+				if (!blocked) {
+					pool->n_blocked++;
+					blocked = true;
+				}
+				pthread_cond_wait(&pool->slot_free, &pool->lock);
+			}
+
+			/*
+			 * Re-tested after the wait: shutdown can arrive while
+			 * blocked here.
+			 */
+			if (!pool->shutdown) {
+				pool->pending = *co;
+				pool->pending_frag = is_frag;
+				*co = NULL;
+				handed_off = true;
+
+				res = pool->first_error;
+				pool->first_error = nmsg_res_success;
+
+				pthread_cond_signal(&pool->work_ready);
+			}
+		}
+
+		pthread_mutex_unlock(&pool->lock);
+	}
+
+	if (handed_off)
+		return (res);
+
+	if (is_frag) {
+		nmsg_container_t tmp = *co;
+
+		/*
+		 * frag_write() takes the container by value and destroys it
+		 * internally, unlike container_write().
+		 */
+		*co = NULL;
+		return (frag_write(output, tmp));
+	}
+
+	return (container_write(output, co));
 }
 
 static nmsg_res

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -21,193 +21,20 @@
 
 /* Forward. */
 static nmsg_res container_write(nmsg_output_t, nmsg_container_t*);
-static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool, uint64_t);
-static nmsg_res frag_write(nmsg_output_t, nmsg_container_t);
-static nmsg_res send_buffer(nmsg_output_t, uint8_t *buf, size_t len);
-static nmsg_res async_drain(struct nmsg_ostr_async *);
+static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool, uint64_t,
+				 struct nmsg_ostr_async *);
 
 /* Data structures. */
 
-/*
- * A compressor pool: a ring of slots, nworkers compressor threads and one
- * committer thread.
- *
- * A container is given a ticket when it is sealed, under c_lock, so tickets
- * follow the order the containers were closed in. Slot i serves every ticket
- * with (ticket % depth) == i, so the producer of ticket T waits only for
- * ticket T - depth to have been written.
- *
- * Compression runs on whichever thread is free. Only the committer writes, and
- * only in ticket order, so the byte stream is identical to the synchronous
- * path however many workers are running.
- *
- * A producer that finds every worker busy compresses the container itself
- * rather than waiting. That is exactly what the synchronous path does, so the
- * pool is never slower than no pool at all.
- */
-typedef enum {
-	slot_empty = 0,	/* Free. */
-	slot_work,	/* Container waiting for a compressor. */
-	slot_taken,	/* A worker or a producer is compressing it. */
-	slot_done,	/* Compressed, waiting its turn to be written. */
-	slot_frag	/* Oversized: the committer must fragment it itself. */
-} async_slot_state;
-
-struct async_slot {
-	async_slot_state	state;
-	nmsg_container_t	co;		/* slot_work, slot_frag */
-	uint8_t			*buf;		/* slot_done */
-	size_t			buf_len;
-	nmsg_res		res;
-};
-
-struct nmsg_ostr_async {
-	pthread_mutex_t		lock;
-	pthread_cond_t		work_ready;	/* A slot became slot_work. */
-	pthread_cond_t		commit_ready;	/* The committer's slot is ready. */
-	pthread_cond_t		slot_free;	/* A slot became slot_empty. */
-	struct async_slot	*slots;
-	unsigned		depth;
-	unsigned		nworkers;
-	unsigned		busy;		/* Workers currently compressing. */
-	uint64_t		issued;		/* Highest ticket claimed, plus one. */
-	uint64_t		commit_next;	/* Ticket allowed to write now. */
-	bool			shutdown;
-	bool			started;
-	bool			failed;		/* Thread creation failed; stay inline. */
-	pthread_t		*workers;
-	pthread_t		committer;
-	nmsg_res		first_error;	/* Sticky; surfaced by flush. */
-	nmsg_output_t		output;
-	uint64_t		n_inline;	/* Containers a producer compressed. */
-	uint64_t		n_waited;	/* Producers that waited for a slot. */
-};
 
 /* Internal functions. */
 
-nmsg_res
-_output_nmsg_async_init(nmsg_output_t output, unsigned nworkers) {
-	struct nmsg_ostr_async *pool;
-	unsigned depth;
 
-	if (nworkers == 0)
-		return (nmsg_res_success);
-
-	if (output->stream->so_pool != NULL)
-		return (nmsg_res_success);
-
-	/*
-	 * One slot per worker to compress in, plus a fixed margin for
-	 * producers to deposit into and for finished buffers waiting their
-	 * turn to be written. The margin does not need to scale with the
-	 * worker count: a producer that cannot get a slot compresses the
-	 * container itself rather than waiting, so a tight ring costs a little
-	 * of the parallelism and never blocks a reader.
-	 *
-	 * A slot holds a container's payloads in memory, which is not the
-	 * 1 MiB serialized size -- a channel of 30-byte payloads puts ~37k of
-	 * them in a container, over 5 MB. That is what bounds the ring, and
-	 * why the automatic worker count is capped.
-	 */
-	depth = nworkers + 8;
-
-	pool = calloc(1, sizeof(*pool));
-	if (pool == NULL)
-		return (nmsg_res_memfail);
-
-	pool->slots = calloc(depth, sizeof(*pool->slots));
-	if (pool->slots == NULL)
-		goto fail_slots;
-
-	pool->workers = calloc(nworkers, sizeof(*pool->workers));
-	if (pool->workers == NULL)
-		goto fail_workers;
-
-	if (pthread_mutex_init(&pool->lock, NULL) != 0)
-		goto fail_mutex;
-	if (pthread_cond_init(&pool->work_ready, NULL) != 0)
-		goto fail_work_ready;
-	if (pthread_cond_init(&pool->commit_ready, NULL) != 0)
-		goto fail_commit_ready;
-	if (pthread_cond_init(&pool->slot_free, NULL) != 0)
-		goto fail_slot_free;
-
-	pool->depth = depth;
-	pool->nworkers = nworkers;
-	pool->output = output;
-	output->stream->so_pool = pool;
-
-	return (nmsg_res_success);
-
-fail_slot_free:
-	pthread_cond_destroy(&pool->commit_ready);
-fail_commit_ready:
-	pthread_cond_destroy(&pool->work_ready);
-fail_work_ready:
-	pthread_mutex_destroy(&pool->lock);
-fail_mutex:
-	free(pool->workers);
-fail_workers:
-	free(pool->slots);
-fail_slots:
-	free(pool);
-
-	return (nmsg_res_failure);
-}
-
-/*
- * Stop the pool and reclaim it. Everything still queued is written first.
- * Must run before the stream's fd, random and locks go away, since the threads
- * use all of them.
- */
-nmsg_res
-_output_nmsg_async_destroy(nmsg_output_t output) {
-	struct nmsg_ostr_async *pool = output->stream->so_pool;
-	nmsg_res res;
-	bool started;
-	unsigned i;
-
-	if (pool == NULL)
-		return (nmsg_res_success);
-
-	pthread_mutex_lock(&pool->lock);
-	pool->shutdown = true;		/* Set under the lock: a thread about */
-	started = pool->started;	/* to wait would miss the wakeup. */
-	pthread_cond_broadcast(&pool->work_ready);
-	pthread_cond_broadcast(&pool->commit_ready);
-	pthread_cond_broadcast(&pool->slot_free);
-	pthread_mutex_unlock(&pool->lock);
-
-	if (started) {
-		for (i = 0; i < pool->nworkers; i++)
-			pthread_join(pool->workers[i], NULL);
-		pthread_join(pool->committer, NULL);
-	}
-
-	if (pool->n_inline > 0 || pool->n_waited > 0)
-		_nmsg_dprintf(2, "%s: %u worker(s); %" PRIu64 " container(s) "
-			      "compressed by the reader, %" PRIu64 " wait(s) for "
-			      "a free slot\n", __func__, pool->nworkers,
-			      pool->n_inline, pool->n_waited);
-
-	/* Read after the joins; the threads write it until they exit. */
-	res = pool->first_error;
-
-	pthread_cond_destroy(&pool->slot_free);
-	pthread_cond_destroy(&pool->commit_ready);
-	pthread_cond_destroy(&pool->work_ready);
-	pthread_mutex_destroy(&pool->lock);
-	free(pool->workers);
-	free(pool->slots);
-	free(pool);
-	output->stream->so_pool = NULL;
-
-	return (res);
-}
 
 nmsg_res
 _output_nmsg_flush(nmsg_output_t output) {
 	struct nmsg_stream_output *ostr = output->stream;
+	struct nmsg_ostr_async *pool, *submit_pool = NULL;
 	nmsg_res res = nmsg_res_success;
 	nmsg_res drain_res;
 	nmsg_container_t old_c = NULL;
@@ -215,9 +42,16 @@ _output_nmsg_flush(nmsg_output_t output) {
 
 	pthread_mutex_lock(&ostr->c_lock);
 
+	/*
+	 * The pool is picked up here rather than read again later, so a teardown
+	 * running alongside this flush cannot free it underneath.
+	 */
+	pool = _output_async_ref(ostr);
+
 	if (nmsg_container_get_num_payloads(ostr->c) > 0) {
 		old_c = ostr->c;
 		ticket = ostr->so_ticket++;
+		submit_pool = _output_async_ref(ostr);
 
 		ostr->c = nmsg_container_init(ostr->bufsz);
 		if (ostr->c == NULL)
@@ -236,7 +70,7 @@ _output_nmsg_flush(nmsg_output_t output) {
 	if (old_c != NULL) {
 		nmsg_res sub_res;
 
-		sub_res = container_submit(output, &old_c, false, ticket);
+		sub_res = container_submit(output, &old_c, false, ticket, submit_pool);
 		if (res == nmsg_res_success)
 			res = sub_res;
 	}
@@ -245,9 +79,12 @@ _output_nmsg_flush(nmsg_output_t output) {
 	 * A flush means the data has been written, so wait out anything the
 	 * pool is still holding.
 	 */
-	drain_res = async_drain(ostr->so_pool);
+	drain_res = _output_async_drain(pool);
 	if (res == nmsg_res_success)
 		res = drain_res;
+
+	if (pool != NULL)
+		_output_async_unref(ostr);
 
 	return (res);
 }
@@ -256,9 +93,10 @@ nmsg_res
 _output_nmsg_write(nmsg_output_t output, nmsg_message_t msg) {
 	Nmsg__NmsgPayload *np;
 	struct nmsg_stream_output *ostr = output->stream;
+	struct nmsg_ostr_async *pool;
 	nmsg_container_t old_c, new_c;
 	nmsg_res res;
-	uint64_t ticket = 0;
+	uint64_t ticket;
 	bool must_flush, is_buffered;
 
 	assert(msg->np != NULL);
@@ -281,6 +119,8 @@ _output_nmsg_write(nmsg_output_t output, nmsg_message_t msg) {
 retry:
 	must_flush = false;
 	old_c = new_c = NULL;
+	pool = NULL;
+	ticket = 0;
 
 	pthread_mutex_lock(&ostr->c_lock);	/* Lock for add to container. */
 
@@ -321,9 +161,12 @@ retry:
 		 * container's contents become final. Taking it in
 		 * container_submit() would order the containers by which
 		 * thread won the race after the unlock, which is not the
-		 * order they were filled in.
+		 * order they were filled in. The pool is claimed in the same
+		 * hold, so the ticket and the pool that will serve it are
+		 * chosen together.
 		 */
 		ticket = ostr->so_ticket++;
+		pool = _output_async_ref(ostr);
 	}
 
 	pthread_mutex_unlock(&ostr->c_lock);	/* Release locked container to other threads. */
@@ -333,16 +176,16 @@ retry:
 
 	/* Reaching here WILL flush the prior container. */
 	if (res == nmsg_res_container_full) {		/* Doesn't include current message. */
-		res = container_submit(output, &old_c, false, ticket);	/* Write data from prior container. */
+		res = container_submit(output, &old_c, false, ticket, pool);	/* Write data from prior container. */
 		if (res != nmsg_res_success)
 			return (res);
 
 		/* Proceed to write current message to new container. */
 		goto retry;
 	} else if (res == nmsg_res_success && is_buffered == false) {	/* Includes current message. */
-		res = container_submit(output, &old_c, false, ticket);
+		res = container_submit(output, &old_c, false, ticket, pool);
 	} else if (res == nmsg_res_container_overfull) {		/* Includes current message. */
-		res = container_submit(output, &old_c, true, ticket);
+		res = container_submit(output, &old_c, true, ticket, pool);
 	}
 
 	return (res);
@@ -354,8 +197,8 @@ retry:
  * Compress one container into a standalone buffer. The container is destroyed
  * either way, as container_write() does.
  */
-static nmsg_res
-container_compress(nmsg_output_t output, nmsg_container_t *co,
+nmsg_res
+_output_nmsg_container_compress(nmsg_output_t output, nmsg_container_t *co,
 		   uint8_t **buf, size_t *buf_len)
 {
 	struct nmsg_stream_output *ostr = output->stream;
@@ -363,7 +206,10 @@ container_compress(nmsg_output_t output, nmsg_container_t *co,
 	uint32_t seq;
 	uint8_t *shrunk;
 
-	/* Multiple threads can enter here at once. */
+	/*
+	 * Multiple threads can enter here at once, so the numbers are handed out
+	 * in compression order rather than write order.
+	 */
 	seq = atomic_fetch_add_explicit(&ostr->so_sequence_num, 1, memory_order_relaxed);
 
 	res = nmsg_container_serialize(*co, buf, buf_len, true, /* do_header */
@@ -399,323 +245,55 @@ container_write(nmsg_output_t output, nmsg_container_t *co)
 	size_t buf_len;
 	uint8_t *buf;
 
-	res = container_compress(output, co, &buf, &buf_len);
+	res = _output_nmsg_container_compress(output, co, &buf, &buf_len);
 	if (res != nmsg_res_success)
 		return (res);
 
-	return (send_buffer(output, buf, buf_len));
+	return (_output_nmsg_send_buffer(output, buf, buf_len));
 }
 
-/* Note an error, keeping the first one seen. Caller holds pool->lock. */
-static void
-async_record_error(struct nmsg_ostr_async *pool, nmsg_res res)
-{
-	if (res != nmsg_res_success && pool->first_error == nmsg_res_success)
-		pool->first_error = res;
-}
 
-/*
- * Compressor thread. Takes any slot that needs compressing, in whatever order
- * they become ready: compression order does not matter, only write order does,
- * and the committer enforces that.
- */
-static void *
-async_worker(void *arg)
-{
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
 
-	pthread_mutex_lock(&pool->lock);
 
-	for (;;) {
-		struct async_slot *slot = NULL;
-		nmsg_container_t co;
-		uint8_t *buf;
-		size_t buf_len;
-		nmsg_res res;
-		unsigned i;
 
-		for (i = 0; i < pool->depth; i++) {
-			if (pool->slots[i].state == slot_work) {
-				slot = &pool->slots[i];
-				break;
-			}
-		}
 
-		if (slot == NULL) {
-			/*
-			 * Nothing to compress. Exit only once the producers
-			 * have stopped, so a container queued just before
-			 * shutdown is still compressed and written; that
-			 * happens on every clean SIGTERM.
-			 */
-			if (pool->shutdown)
-				break;
-			pthread_cond_wait(&pool->work_ready, &pool->lock);
-			continue;
-		}
 
-		slot->state = slot_taken;
-		co = slot->co;
-		slot->co = NULL;
-		pool->busy++;
-		pthread_mutex_unlock(&pool->lock);
-
-		res = container_compress(pool->output, &co, &buf, &buf_len);
-
-		pthread_mutex_lock(&pool->lock);
-		pool->busy--;
-		slot->buf = buf;
-		slot->buf_len = buf_len;
-		slot->res = res;
-		slot->state = slot_done;
-		pthread_cond_broadcast(&pool->commit_ready);
-	}
-
-	pthread_mutex_unlock(&pool->lock);
-
-	return (NULL);
-}
-
-/*
- * The only thread that writes. It takes tickets strictly in order, so the file
- * is byte-identical to what the synchronous path would have produced no matter
- * how many workers compressed in parallel.
- *
- * It is also the only caller of frag_write().
- */
-static void *
-async_committer(void *arg)
-{
-	struct nmsg_ostr_async *pool = (struct nmsg_ostr_async *) arg;
-
-	pthread_mutex_lock(&pool->lock);
-
-	for (;;) {
-		struct async_slot *slot = &pool->slots[pool->commit_next % pool->depth];
-		async_slot_state state = slot->state;
-		nmsg_res res;
-
-		if (state == slot_done) {
-			uint8_t *buf = slot->buf;
-			size_t buf_len = slot->buf_len;
-
-			res = slot->res;
-			slot->buf = NULL;
-			pthread_mutex_unlock(&pool->lock);
-
-			/* send_buffer() owns buf from here, error or not. */
-			if (res == nmsg_res_success)
-				res = send_buffer(pool->output, buf, buf_len);
-
-			pthread_mutex_lock(&pool->lock);
-		} else if (state == slot_frag) {
-			nmsg_container_t co = slot->co;
-
-			slot->co = NULL;
-			pthread_mutex_unlock(&pool->lock);
-
-			/* frag_write() takes the container by value and destroys it. */
-			res = frag_write(pool->output, co);
-
-			pthread_mutex_lock(&pool->lock);
-		} else {
-			/*
-			 * The next ticket is not ready. Exit only when the
-			 * producers have stopped and every ticket they issued
-			 * has been written.
-			 */
-			if (pool->shutdown && pool->commit_next >= pool->issued)
-				break;
-			pthread_cond_wait(&pool->commit_ready, &pool->lock);
-			continue;
-		}
-
-		async_record_error(pool, res);
-		slot->state = slot_empty;
-		pool->commit_next++;
-		pthread_cond_broadcast(&pool->slot_free);
-	}
-
-	pthread_mutex_unlock(&pool->lock);
-
-	return (NULL);
-}
-
-/*
- * Start the threads. Called under pool->lock on first submit rather than when
- * the output is configured, because nmsgtool creates its outputs before it
- * daemonizes, and daemonize() is a bare fork() which no thread survives.
- * Starting on first write puts the threads in whichever process does the
- * writing.
- */
-static void
-async_start(struct nmsg_ostr_async *pool)
-{
-	unsigned i;
-	int pthread_res;
-
-	for (i = 0; i < pool->nworkers; i++) {
-		pthread_res = pthread_create(&pool->workers[i], NULL, async_worker, pool);
-		if (pthread_res != 0)
-			goto fail;
-	}
-
-	pthread_res = pthread_create(&pool->committer, NULL, async_committer, pool);
-	if (pthread_res != 0)
-		goto fail;
-
-	pool->started = true;
-	return;
-
-fail:
-	/*
-	 * Stop whatever did start and fall back to compressing inline. Joining
-	 * needs the lock released, and the caller still holds a container, so
-	 * this stays simple: the threads created so far see shutdown and exit,
-	 * and destroy joins them.
-	 */
-	pool->nworkers = i;
-	pool->failed = true;
-	pool->shutdown = true;
-	pool->started = (i > 0);
-	pthread_cond_broadcast(&pool->work_ready);
-	pthread_cond_broadcast(&pool->commit_ready);
-	_nmsg_dprintf(1, "%s: pthread_create() failed: %s\n", __func__,
-		      strerror(pthread_res));
-}
-
-/*
- * Wait until every ticket issued so far has been written, and take any error
- * the pool recorded. Under nmsg_io this cannot starve: check_close_event()
- * holds io_output->refcount across the write and call_close_fp() waits for it
- * to drop, so no other thread is inside nmsg_output_write() while a close runs.
- * A caller driving nmsg_output_flush() directly from several threads has no
- * such guarantee.
- */
+/* Compress and write on the calling thread. The container is consumed. */
 static nmsg_res
-async_drain(struct nmsg_ostr_async *pool)
+container_submit_inline(nmsg_output_t output, nmsg_container_t *co, bool is_frag)
 {
-	nmsg_res res;
-
-	if (pool == NULL)
-		return (nmsg_res_success);
-
-	pthread_mutex_lock(&pool->lock);
-	while (pool->started && !pool->failed && pool->commit_next < pool->issued)
-		pthread_cond_wait(&pool->slot_free, &pool->lock);
-	res = pool->first_error;
-	pool->first_error = nmsg_res_success;
-	pthread_mutex_unlock(&pool->lock);
-
-	return (res);
-}
-
-/*
- * Hand a finished container to the pool, or process it inline if there is no
- * pool. The container is consumed either way.
- *
- * The pool reports success for the container it just took, since that
- * container has not been written yet. An error from an EARLIER container is
- * returned here.
- */
-static nmsg_res
-container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag,
-		 uint64_t ticket)
-{
-	struct nmsg_ostr_async *pool = output->stream->so_pool;
-	struct async_slot *slot;
-	nmsg_res res = nmsg_res_success;
-	uint8_t *buf;
-	size_t buf_len;
-	bool inline_compress = false;
-
-	if (pool == NULL)
-		goto inline_path;
-
-	pthread_mutex_lock(&pool->lock);
-
-	if (!pool->started && !pool->failed && !pool->shutdown)
-		async_start(pool);
-
-	if (!pool->started || pool->failed || pool->shutdown) {
-		pthread_mutex_unlock(&pool->lock);
-		goto inline_path;
-	}
-
-	slot = &pool->slots[ticket % pool->depth];
-
-	/*
-	 * Wait for the slot this ticket owns, which the ticket 'depth' earlier
-	 * releases when it is written. Only reached when the writer has fallen
-	 * a whole ring behind.
-	 */
-	if (slot->state != slot_empty) {
-		pool->n_waited++;
-		while (slot->state != slot_empty && !pool->shutdown)
-			pthread_cond_wait(&pool->slot_free, &pool->lock);
-
-		if (pool->shutdown) {
-			pthread_mutex_unlock(&pool->lock);
-			goto inline_path;
-		}
-	}
-
-	if (ticket >= pool->issued)
-		pool->issued = ticket + 1;
-
-	if (is_frag) {
-		/* Only the committer fragments; see async_committer(). */
-		slot->co = *co;
-		*co = NULL;
-		slot->state = slot_frag;
-		pthread_cond_broadcast(&pool->commit_ready);
-	} else if (pool->busy < pool->nworkers) {
-		/* A worker is free: hand it over and get back to reading. */
-		slot->co = *co;
-		*co = NULL;
-		slot->state = slot_work;
-		pthread_cond_signal(&pool->work_ready);
-	} else {
-		/*
-		 * Every worker is busy. Compress it here rather than wait then deposit
-		 * the result and return.
-		 */
-		slot->state = slot_taken;
-		pool->n_inline++;
-		inline_compress = true;
-	}
-
-	res = pool->first_error;
-	pool->first_error = nmsg_res_success;
-	pthread_mutex_unlock(&pool->lock);
-
-	if (inline_compress) {
-		nmsg_res c_res = container_compress(output, co, &buf, &buf_len);
-
-		pthread_mutex_lock(&pool->lock);
-		slot->buf = buf;
-		slot->buf_len = buf_len;
-		slot->res = c_res;
-		slot->state = slot_done;
-		pthread_cond_broadcast(&pool->commit_ready);
-		pthread_mutex_unlock(&pool->lock);
-	}
-
-	return (res);
-
-inline_path:
 	if (is_frag) {
 		nmsg_container_t tmp = *co;
 
 		/*
-		 * frag_write() takes the container by value and destroys it
+		 * _output_nmsg_frag_write() takes the container by value and destroys it
 		 * internally, unlike container_write().
 		 */
 		*co = NULL;
-		return (frag_write(output, tmp));
+		return (_output_nmsg_frag_write(output, tmp));
 	}
 
 	return (container_write(output, co));
+}
+
+/*
+ * Hand a finished container to the pool, or process it inline if there is no
+ * pool or the pool declines it. The container is consumed either way.
+ *
+ * 'pool' is the reference taken under c_lock when the ticket was issued, so it
+ * is NULL exactly when the ticket was never promised to a pool.
+ */
+static nmsg_res
+container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag,
+		 uint64_t ticket, struct nmsg_ostr_async *pool)
+{
+	nmsg_res res;
+
+	if (pool != NULL &&
+	    _output_async_submit(pool, output, co, is_frag, ticket, &res))
+		return (res);
+
+	return (container_submit_inline(output, co, is_frag));
 }
 
 static nmsg_res
@@ -808,8 +386,8 @@ write_file(int fd, uint8_t *buf, size_t len)
  *
  * Returns status of send.
  */
-static nmsg_res
-send_buffer(nmsg_output_t output, uint8_t *buf, size_t len)
+nmsg_res
+_output_nmsg_send_buffer(nmsg_output_t output, uint8_t *buf, size_t len)
 {
 	struct nmsg_stream_output *ostr = output->stream;
 	nmsg_res res;
@@ -907,8 +485,8 @@ header_serialize(uint8_t *buf, uint8_t flags, uint32_t len)
 	store_net32(buf, len);
 }
 
-static nmsg_res
-frag_write(nmsg_output_t output, nmsg_container_t co)
+nmsg_res
+_output_nmsg_frag_write(nmsg_output_t output, nmsg_container_t co)
 {
 	Nmsg__NmsgFragment nf;
 	struct nmsg_stream_output *ostr = output->stream;
@@ -944,7 +522,7 @@ frag_write(nmsg_output_t output, nmsg_container_t co)
 
 	if (ostr->do_zlib && len <= max_fragsz) {
 		/* write out the unfragmented NMSG container */
-		res = send_buffer(output, packed, len);
+		res = _output_nmsg_send_buffer(output, packed, len);
 		goto frag_out;
 	}
 
@@ -978,7 +556,7 @@ frag_write(nmsg_output_t output, nmsg_container_t co)
 		fraglen += NMSG_HDRLSZ_V2;
 
 		/* send the serialized fragment */
-		res = send_buffer(output, frag_packed, fraglen);
+		res = _output_nmsg_send_buffer(output, frag_packed, fraglen);
 	}
 	free(packed);
 

--- a/nmsg/output_nmsg.c
+++ b/nmsg/output_nmsg.c
@@ -24,12 +24,7 @@ static nmsg_res container_write(nmsg_output_t, nmsg_container_t*);
 static nmsg_res container_submit(nmsg_output_t, nmsg_container_t *, bool, uint64_t,
 				 struct nmsg_ostr_async *);
 
-/* Data structures. */
-
-
 /* Internal functions. */
-
-
 
 nmsg_res
 _output_nmsg_flush(nmsg_output_t output) {
@@ -63,9 +58,8 @@ _output_nmsg_flush(nmsg_output_t output) {
 	pthread_mutex_unlock(&ostr->c_lock);
 
 	/*
-	 * Submitted outside c_lock. Flush runs on every file rotation, and a
-	 * submit can wait for a free slot; doing that under c_lock would hold
-	 * off every reader thread for the length of a compression.
+	 * Submitted outside c_lock: a submit can wait for a free slot, and
+	 * holding c_lock across that would stall every reader thread.
 	 */
 	if (old_c != NULL) {
 		nmsg_res sub_res;
@@ -75,10 +69,7 @@ _output_nmsg_flush(nmsg_output_t output) {
 			res = sub_res;
 	}
 
-	/*
-	 * A flush means the data has been written, so wait out anything the
-	 * pool is still holding.
-	 */
+	/* A flush means written, so wait out anything the pool still holds. */
 	drain_res = _output_async_drain(pool);
 	if (res == nmsg_res_success)
 		res = drain_res;
@@ -139,11 +130,11 @@ retry:
 	 * container for the other threads to use.
 	 */
 	is_buffered = ostr->buffered;	/* Save this value. */
-	if ((res == nmsg_res_container_full) ||
-	    (res == nmsg_res_success && is_buffered == false) ||
-	    (res == nmsg_res_container_overfull)) {
-		must_flush = true;	/* Will flush container below. */
+	must_flush = (res == nmsg_res_container_full) ||
+		     (res == nmsg_res_success && is_buffered == false) ||
+		     (res == nmsg_res_container_overfull);
 
+	if (must_flush) {
 		/* Create replacement container. */
 		new_c = nmsg_container_init(ostr->bufsz);
 		if (new_c == NULL) {
@@ -157,12 +148,10 @@ retry:
 		ostr->c = new_c;
 
 		/*
-		 * Ticket taken here, under c_lock, because this is where the
-		 * container's contents become final. Taking it in
-		 * container_submit() would order the containers by which
-		 * thread won the race after the unlock, which is not the
-		 * order they were filled in. The pool is claimed in the same
-		 * hold, so the ticket and the pool that will serve it are
+		 * Ticket taken under c_lock, where the container's contents
+		 * become final. Taking it after the unlock would order
+		 * containers by which thread won the race, not by fill order.
+		 * The pool is claimed in the same hold, so ticket and pool are
 		 * chosen together.
 		 */
 		ticket = ostr->so_ticket++;
@@ -199,7 +188,7 @@ retry:
  */
 nmsg_res
 _output_nmsg_container_compress(nmsg_output_t output, nmsg_container_t *co,
-		   uint8_t **buf, size_t *buf_len)
+				uint8_t **buf, size_t *buf_len)
 {
 	struct nmsg_stream_output *ostr = output->stream;
 	nmsg_res res;
@@ -207,8 +196,10 @@ _output_nmsg_container_compress(nmsg_output_t output, nmsg_container_t *co,
 	uint8_t *shrunk;
 
 	/*
-	 * Multiple threads can enter here at once, so the numbers are handed out
-	 * in compression order rather than write order.
+	 * Multiple threads can enter here at once, so numbers go out in
+	 * compression order, not write order. Safe only because pools are
+	 * file-only and file outputs leave do_sequence false; a pool on a
+	 * sequenced output would scramble them.
 	 */
 	seq = atomic_fetch_add_explicit(&ostr->so_sequence_num, 1, memory_order_relaxed);
 
@@ -223,9 +214,9 @@ _output_nmsg_container_compress(nmsg_output_t output, nmsg_container_t *co,
 	}
 
 	/*
-	 * nmsg_container_serialize() returns the base of an allocation sized
-	 * for the worst case, twice the unpacked estimate. A slot holds that
-	 * until every earlier ticket has been written, so hand the rest back.
+	 * serialize() allocates for the worst case, twice the unpacked
+	 * estimate. A slot pins that until every earlier ticket is written, so
+	 * hand it back.
 	 */
 	shrunk = realloc(*buf, *buf_len);
 	if (shrunk != NULL)
@@ -252,12 +243,6 @@ container_write(nmsg_output_t output, nmsg_container_t *co)
 	return (_output_nmsg_send_buffer(output, buf, buf_len));
 }
 
-
-
-
-
-
-
 /* Compress and write on the calling thread. The container is consumed. */
 static nmsg_res
 container_submit_inline(nmsg_output_t output, nmsg_container_t *co, bool is_frag)
@@ -265,10 +250,7 @@ container_submit_inline(nmsg_output_t output, nmsg_container_t *co, bool is_frag
 	if (is_frag) {
 		nmsg_container_t tmp = *co;
 
-		/*
-		 * _output_nmsg_frag_write() takes the container by value and destroys it
-		 * internally, unlike container_write().
-		 */
+		/* Takes the container by value and destroys it. */
 		*co = NULL;
 		return (_output_nmsg_frag_write(output, tmp));
 	}
@@ -278,19 +260,20 @@ container_submit_inline(nmsg_output_t output, nmsg_container_t *co, bool is_frag
 
 /*
  * Hand a finished container to the pool, or process it inline if there is no
- * pool or the pool declines it. The container is consumed either way.
- *
- * 'pool' is the reference taken under c_lock when the ticket was issued, so it
- * is NULL exactly when the ticket was never promised to a pool.
+ * pool or it declines. The container is consumed either way. 'pool' is the
+ * reference taken when the ticket was issued, so it is NULL exactly when the
+ * ticket was never promised to a pool.
  */
 static nmsg_res
 container_submit(nmsg_output_t output, nmsg_container_t *co, bool is_frag,
 		 uint64_t ticket, struct nmsg_ostr_async *pool)
 {
 	nmsg_res res;
+	bool taken_by_pool;
 
-	if (pool != NULL &&
-	    _output_async_submit(pool, output, co, is_frag, ticket, &res))
+	taken_by_pool = pool != NULL &&
+			_output_async_submit(pool, output, co, is_frag, ticket, &res);
+	if (taken_by_pool)
 		return (res);
 
 	return (container_submit_inline(output, co, is_frag));

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -337,6 +337,9 @@ struct nmsg_stream_output {
 	atomic_uint_fast32_t	so_sequence_num;
 	uint64_t		sequence_id;
 	uint64_t		so_ticket;		/* Next container ticket; c_lock. */
+	unsigned		so_inflight;		/* Tickets owed to the pool; c_lock. */
+	bool			so_pool_closing;	/* Pool teardown started; c_lock. */
+	pthread_cond_t		c_drained;		/* so_inflight == 0; c_lock. */
 	struct nmsg_ostr_async	*so_pool;		/* Async compressor, or NULL. */
 };
 
@@ -593,8 +596,19 @@ nmsg_output_t		_output_open_kafka(void *s, size_t bufsz);
 /* from output_nmsg.c */
 nmsg_res		_output_nmsg_flush(nmsg_output_t);
 nmsg_res		_output_nmsg_write(nmsg_output_t, nmsg_message_t);
-nmsg_res		_output_nmsg_async_init(nmsg_output_t, unsigned);
-nmsg_res		_output_nmsg_async_destroy(nmsg_output_t);
+nmsg_res		_output_nmsg_container_compress(nmsg_output_t, nmsg_container_t *,
+						uint8_t **, size_t *);
+nmsg_res		_output_nmsg_send_buffer(nmsg_output_t, uint8_t *, size_t);
+nmsg_res		_output_nmsg_frag_write(nmsg_output_t, nmsg_container_t);
+
+/* from output_async.c */
+nmsg_res		_output_async_init(nmsg_output_t, unsigned);
+nmsg_res		_output_async_destroy(nmsg_output_t);
+nmsg_res		_output_async_drain(struct nmsg_ostr_async *);
+struct nmsg_ostr_async *_output_async_ref(struct nmsg_stream_output *);
+void			_output_async_unref(struct nmsg_stream_output *);
+bool			_output_async_submit(struct nmsg_ostr_async *, nmsg_output_t,
+					     nmsg_container_t *, bool, uint64_t, nmsg_res *);
 #ifdef HAVE_LIBRDKAFKA
 nmsg_res		_output_kafka_payload_write(nmsg_output_t, nmsg_message_t);
 nmsg_res		_output_kafka_payload_flush(nmsg_output_t);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -336,6 +336,7 @@ struct nmsg_stream_output {
 	bool			do_sequence;
 	atomic_uint_fast32_t	so_sequence_num;
 	uint64_t		sequence_id;
+	uint64_t		so_ticket;		/* Next container ticket; c_lock. */
 	struct nmsg_ostr_async	*so_pool;		/* Async compressor, or NULL. */
 };
 
@@ -592,7 +593,7 @@ nmsg_output_t		_output_open_kafka(void *s, size_t bufsz);
 /* from output_nmsg.c */
 nmsg_res		_output_nmsg_flush(nmsg_output_t);
 nmsg_res		_output_nmsg_write(nmsg_output_t, nmsg_message_t);
-nmsg_res		_output_nmsg_async_init(nmsg_output_t);
+nmsg_res		_output_nmsg_async_init(nmsg_output_t, unsigned);
 nmsg_res		_output_nmsg_async_destroy(nmsg_output_t);
 #ifdef HAVE_LIBRDKAFKA
 nmsg_res		_output_kafka_payload_write(nmsg_output_t, nmsg_message_t);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -344,13 +344,14 @@ struct nmsg_stream_output {
 	bool			do_sequence;
 	atomic_uint_fast32_t	so_sequence_num;
 	uint64_t		sequence_id;
-	uint64_t		so_ticket;		/* Next container ticket; c_lock. */
-	unsigned		so_inflight;		/* Tickets owed to the pool; c_lock. */
-	bool			so_pool_closing;	/* Pool teardown started; c_lock. */
-	pthread_cond_t		c_drained;		/* so_inflight == 0; c_lock. */
-	struct nmsg_ostr_async	*so_pool;		/* Async compressor, or NULL. */
-	unsigned		so_zmin;		/* Compressors culling leaves; c_lock. */
-	unsigned		so_zcull;		/* Idle seconds before a cull; c_lock. */
+	/* The five below are guarded by c_lock. */
+	uint64_t		so_ticket;	/* Next container ticket. */
+	unsigned		so_inflight;	/* Tickets owed to the pool. */
+	bool			so_pool_closing;/* Teardown started. */
+	unsigned		so_zmin;	/* Compressors culling leaves. */
+	unsigned		so_zcull;	/* Idle seconds before a cull. */
+	pthread_cond_t		c_drained;	/* so_inflight == 0. */
+	struct nmsg_ostr_async	*so_pool;	/* Async compressor, or NULL. */
 };
 
 /* nmsg_callback_output: used by nmsg_output */
@@ -617,7 +618,7 @@ nmsg_res		_output_async_destroy(nmsg_output_t);
 void			_output_async_set_cull(struct nmsg_ostr_async *, unsigned, unsigned);
 void			_output_async_counts(struct nmsg_ostr_async *, unsigned *,
 					     unsigned *, uint64_t *);
-nmsg_res		_output_async_drain(struct nmsg_ostr_async *);
+nmsg_res		_output_async_drain(struct nmsg_ostr_async *, uint64_t);
 struct nmsg_ostr_async *_output_async_ref(struct nmsg_stream_output *);
 void			_output_async_unref(struct nmsg_stream_output *);
 bool			_output_async_submit(struct nmsg_ostr_async *, nmsg_output_t,

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -312,6 +312,14 @@ struct nmsg_stream_input {
  */
 struct nmsg_ostr_async;
 
+/*
+ * Compressor threads left alone when the pool shrinks, and the idle time that
+ * costs a thread its place. Defaults rather than constants: nmsg_output_set_zlib_cull()
+ * overrides both, and output_open_stream_base() seeds every stream with them.
+ */
+#define NMSG_ZCULL_MIN_WORKERS_DEFAULT	1
+#define NMSG_ZCULL_SECS_DEFAULT		300
+
 /* nmsg_stream_output: used by nmsg_output */
 struct nmsg_stream_output {
 	pthread_mutex_t		c_lock;			/* Container lock. */
@@ -341,6 +349,8 @@ struct nmsg_stream_output {
 	bool			so_pool_closing;	/* Pool teardown started; c_lock. */
 	pthread_cond_t		c_drained;		/* so_inflight == 0; c_lock. */
 	struct nmsg_ostr_async	*so_pool;		/* Async compressor, or NULL. */
+	unsigned		so_zmin;		/* Compressors culling leaves; c_lock. */
+	unsigned		so_zcull;		/* Idle seconds before a cull; c_lock. */
 };
 
 /* nmsg_callback_output: used by nmsg_output */
@@ -604,6 +614,9 @@ nmsg_res		_output_nmsg_frag_write(nmsg_output_t, nmsg_container_t);
 /* from output_async.c */
 nmsg_res		_output_async_init(nmsg_output_t, unsigned);
 nmsg_res		_output_async_destroy(nmsg_output_t);
+void			_output_async_set_cull(struct nmsg_ostr_async *, unsigned, unsigned);
+void			_output_async_counts(struct nmsg_ostr_async *, unsigned *,
+					     unsigned *, uint64_t *);
 nmsg_res		_output_async_drain(struct nmsg_ostr_async *);
 struct nmsg_ostr_async *_output_async_ref(struct nmsg_stream_output *);
 void			_output_async_unref(struct nmsg_stream_output *);

--- a/nmsg/private.h
+++ b/nmsg/private.h
@@ -307,6 +307,11 @@ struct nmsg_stream_input {
 	nmsg_input_stream_read_fp  stream_read_fp;
 };
 
+/*
+ * Asynchronous compressor for a stream output.
+ */
+struct nmsg_ostr_async;
+
 /* nmsg_stream_output: used by nmsg_output */
 struct nmsg_stream_output {
 	pthread_mutex_t		c_lock;			/* Container lock. */
@@ -331,6 +336,7 @@ struct nmsg_stream_output {
 	bool			do_sequence;
 	atomic_uint_fast32_t	so_sequence_num;
 	uint64_t		sequence_id;
+	struct nmsg_ostr_async	*so_pool;		/* Async compressor, or NULL. */
 };
 
 /* nmsg_callback_output: used by nmsg_output */
@@ -586,6 +592,8 @@ nmsg_output_t		_output_open_kafka(void *s, size_t bufsz);
 /* from output_nmsg.c */
 nmsg_res		_output_nmsg_flush(nmsg_output_t);
 nmsg_res		_output_nmsg_write(nmsg_output_t, nmsg_message_t);
+nmsg_res		_output_nmsg_async_init(nmsg_output_t);
+nmsg_res		_output_nmsg_async_destroy(nmsg_output_t);
 #ifdef HAVE_LIBRDKAFKA
 nmsg_res		_output_kafka_payload_write(nmsg_output_t, nmsg_message_t);
 nmsg_res		_output_kafka_payload_flush(nmsg_output_t);

--- a/src/io.c
+++ b/src/io.c
@@ -598,6 +598,7 @@ add_file_output(nmsgtool_ctx *c, const char *fname) {
 		fprintf(stderr, "%s: nmsg file output: %s\n", argv_program,
 			fname);
 	c->n_outputs += 1;
+	c->n_file_outputs += 1;
 }
 
 void

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -326,6 +326,12 @@ static argv_t args[] = {
 		NULL,
 		"compress nmsg output" },
 
+	{ '\0', "zasync",
+		ARGV_BOOL,
+		&ctx.zasync,
+		NULL,
+		"compress file output on a separate thread" },
+
 	{ ARGV_LAST, 0, 0, 0, 0, 0 }
 };
 
@@ -436,6 +442,7 @@ setup_nmsg_output(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_output_set_buffered(output, !(c->unbuffered));
 	nmsg_output_set_endline(output, c->endline_str);
 	nmsg_output_set_zlibout(output, c->zlibout);
+	nmsg_output_set_zlib_async(output, c->zasync);
 	nmsg_output_set_source(output, c->set_source);
 	nmsg_output_set_operator(output, c->set_operator);
 	nmsg_output_set_group(output, c->set_group);

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -34,8 +34,8 @@
 /* Globals. */
 
 /*
- * Defaults set here rather than after argv_process(): 0 is a meaningful value
- * for both cull options, so neither can use it as an "unset" marker.
+ * Cull defaults. 0 is meaningful for both, so the options are read as strings
+ * and these stand until process_args() sees one given.
  */
 static nmsgtool_ctx ctx = {
 	.zmin = NMSGTOOL_ZMIN_DEFAULT,
@@ -340,14 +340,14 @@ static argv_t args[] = {
 		"compress file output on n threads (-1 auto)" },
 
 	{ '\0', "zcull",
-		ARGV_INT,
-		&ctx.zcull,
+		ARGV_CHAR_P,
+		&ctx.zcull_str,
 		"secs",
 		"drop a compressor idle after n secs (0 never)" },
 
 	{ '\0', "zmin",
-		ARGV_INT,
-		&ctx.zmin,
+		ARGV_CHAR_P,
+		&ctx.zmin_str,
 		"n",
 		"never drop below n compressors" },
 
@@ -490,7 +490,7 @@ zworkers_count(const nmsgtool_ctx *c) {
 	if (!c->mirror)
 		n /= c->n_file_outputs;
 
-	/* Room for one even where the readers outnumber the cores. */
+	/* What the readers leave. An upper bound, but see the floor below. */
 	spare = (int) ncpu - c->n_inputs;
 	if (spare < 1)
 		spare = 1;
@@ -498,8 +498,10 @@ zworkers_count(const nmsgtool_ctx *c) {
 		n = spare;
 
 	/*
-	 * Applied last, and per output: a single input can carry several cores'
-	 * worth on its own, which is what this floor is measured against.
+	 * Applied last, and per output, so it overrides the bound above: a
+	 * single input can carry several cores' worth on its own, which is
+	 * what this floor is measured against. Oversubscribing costs nothing
+	 * on an output that never saturates, since workers start on demand.
 	 */
 	if (n < NMSGTOOL_ZWORKERS_MIN)
 		n = NMSGTOOL_ZWORKERS_MIN;
@@ -512,17 +514,11 @@ zworkers_count(const nmsgtool_ctx *c) {
 }
 
 /*
- * Resolve --zasync and apply it to the outputs that already exist. Deferred to
- * the end of process_args() because the input count is not final until then: a
- * channel alias (-C) expands to its sockets after the outputs are created.
- */
-/*
  * Cull policy first: setting the ceiling builds the pool, which reads it. The
  * pool is an optimisation, so a failure to start one is reported, not fatal.
  */
 static void
-apply_zlib_workers(nmsgtool_ctx *c, nmsg_output_t output)
-{
+apply_zlib_workers(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_res res;
 
 	nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
@@ -533,6 +529,11 @@ apply_zlib_workers(nmsgtool_ctx *c, nmsg_output_t output)
 			nmsg_res_lookup(res));
 }
 
+/*
+ * Resolve --zasync and apply it to the outputs that already exist. Deferred to
+ * the end of process_args() because the input count is not final until then: a
+ * channel alias (-C) expands to its sockets after the outputs are created.
+ */
 void
 setup_nmsg_output_workers(nmsgtool_ctx *c) {
 	size_t i;
@@ -549,9 +550,12 @@ setup_nmsg_output_workers(nmsgtool_ctx *c) {
 	}
 
 	if (c->zworkers_resolved == 0) {
-		/* Nothing to apply a cull policy to; say so rather than not. */
-		if (c->zcull != NMSGTOOL_ZCULL_DEFAULT ||
-		    c->zmin != NMSGTOOL_ZMIN_DEFAULT)
+		/* Nothing to compress on; say so rather than not. */
+		if (c->zasync != 0)
+			fprintf(stderr, "%s: --zasync needs an nmsg file "
+				"output; ignored\n", argv_program);
+		else if (c->zcull != NMSGTOOL_ZCULL_DEFAULT ||
+			 c->zmin != NMSGTOOL_ZMIN_DEFAULT)
 			fprintf(stderr, "%s: --zcull and --zmin need --zasync "
 				"and an nmsg file output; ignored\n", argv_program);
 		return;

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -463,27 +463,13 @@ nmsgtool_ncpu(void) {
 }
 
 /*
- * How many compressor threads an output should get.
+ * How many compressor threads an output should get. A negative --zasync means
+ * auto: demand is about two workers per input, since a reader can saturate
+ * roughly one core compressing, and supply is the cores the readers leave.
  *
- * A negative --zasync means auto. Two things bound the answer:
- *
- *   Demand scales with the inputs. Each reader thread can saturate roughly one
- *   core compressing, and covering that takes about two workers per input.
- *
- *   Supply is the cores the readers leave. Workers beyond that only contend.
- *
- * The floor matters because one input can carry several cores' worth on its
- * own, so a count that merely followed the input count would under-serve
- * exactly the case the pool exists for.
- *
- * The budget is then split across the file outputs, since each gets its own
- * pool and they share these same cores. Each output keeps at least one worker:
- * one is still enough to take compression off the reader, which is the point.
- *
- * Getting it wrong is cheap in both directions. Too small a pool degrades to
- * the behaviour of no pool rather than stalling, because a reader that finds
- * every worker busy compresses the container itself. Too large only raises a
- * ceiling that is never reached, since workers are started on demand.
+ * The budget is split across the file outputs, which each get their own pool
+ * and share these cores. One worker is still enough to take compression off
+ * the reader, so no output drops below that.
  */
 static unsigned
 zworkers_count(nmsgtool_ctx *c) {
@@ -515,8 +501,7 @@ zworkers_count(nmsgtool_ctx *c) {
 /*
  * Resolve --zasync and apply it to the outputs that already exist. Deferred to
  * the end of process_args() because the input count is not final until then: a
- * channel alias (-C) expands to its sockets after the outputs have been
- * created, which is exactly the case the pool is sized for.
+ * channel alias (-C) expands to its sockets after the outputs are created.
  */
 void
 setup_nmsg_output_workers(nmsgtool_ctx *c) {

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -327,10 +327,10 @@ static argv_t args[] = {
 		"compress nmsg output" },
 
 	{ '\0', "zasync",
-		ARGV_BOOL,
+		ARGV_INT,
 		&ctx.zasync,
-		NULL,
-		"compress file output on a separate thread" },
+		"n",
+		"compress file output on n threads (-1 chooses)" },
 
 	{ ARGV_LAST, 0, 0, 0, 0, 0 }
 };
@@ -365,6 +365,7 @@ int main(int argc, char **argv) {
 #endif /* HAVE_LIBZMQ */
 
 	ctx.statsmods_loaded = statsmod_vec_init(1);
+	ctx.initial_outputs = output_vec_init(1);
 
 	/* initialize the nmsg_io engine */
 	ctx.io = nmsg_io_init();
@@ -437,15 +438,89 @@ usage(const char *msg) {
 	exit(msg == NULL ? EXIT_SUCCESS : EXIT_FAILURE);
 }
 
+/*
+ * How many compressor threads an output should get.
+ *
+ * A negative --zasync means auto. Two things bound the answer:
+ *
+ *   Demand scales with the input sockets. Each reader thread can saturate
+ *   roughly one core compressing, and covering that takes about two workers
+ *   per socket.
+ *
+ *   Supply is the cores the readers leave. Workers beyond that only contend.
+ *
+ * The floor matters because one socket can carry several cores' worth on its
+ * own, so a count that merely followed the socket count would under-serve
+ * exactly the case the pool exists for.
+ *
+ * Getting it wrong is cheap in one direction: a reader that finds every worker
+ * busy compresses the container itself, so too small a pool degrades to the
+ * behaviour of no pool rather than stalling. Too large only wastes idle
+ * threads and ring slots, and a slot holds a container's payloads in memory.
+ */
+static unsigned
+zworkers_count(nmsgtool_ctx *c) {
+	long ncpu;
+	int n, spare;
+
+	if (c->zasync == 0)
+		return (0);
+	if (c->zasync > 0)
+		return ((unsigned) c->zasync);
+
+	ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+	if (ncpu < 1)
+		ncpu = 1;
+
+	n = 2 * c->n_inputs;
+
+	spare = (int) ncpu - c->n_inputs;
+	if (n > spare)
+		n = spare;
+	if (n < NMSGTOOL_ZWORKERS_MIN)
+		n = NMSGTOOL_ZWORKERS_MIN;
+
+	return ((unsigned) n);
+}
+
+/*
+ * Resolve -W and apply it to the outputs that already exist. Deferred to the
+ * end of process_args() because the input count is not final until then: a
+ * channel alias (-C) expands to its sockets after the outputs have been
+ * created, which is exactly the case the pool is sized for.
+ */
+void
+setup_nmsg_output_workers(nmsgtool_ctx *c) {
+	size_t i;
+
+	c->zworkers_resolved = zworkers_count(c);
+
+	if (c->initial_outputs != NULL) {
+		for (i = 0; i < output_vec_size(c->initial_outputs); i++)
+			nmsg_output_set_zlib_workers(
+				output_vec_data(c->initial_outputs)[i],
+				c->zworkers_resolved);
+		output_vec_destroy(&c->initial_outputs);
+	}
+
+	if (c->zworkers_resolved > 0 && c->debug >= 2)
+		fprintf(stderr, "%s: compressing on %u thread(s)\n",
+			argv_program, c->zworkers_resolved);
+}
+
 void
 setup_nmsg_output(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_output_set_buffered(output, !(c->unbuffered));
 	nmsg_output_set_endline(output, c->endline_str);
 	nmsg_output_set_zlibout(output, c->zlibout);
-	nmsg_output_set_zlib_async(output, c->zasync);
+	nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
 	nmsg_output_set_source(output, c->set_source);
 	nmsg_output_set_operator(output, c->set_operator);
 	nmsg_output_set_group(output, c->set_group);
+
+	/* Outputs made before -W is resolved; see setup_nmsg_output_workers(). */
+	if (c->initial_outputs != NULL)
+		output_vec_add(c->initial_outputs, output);
 }
 
 void

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -20,9 +20,6 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
-#ifdef __linux__
-#include <sched.h>
-#endif /* __linux__ */
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -340,7 +337,7 @@ static argv_t args[] = {
 		ARGV_INT,
 		&ctx.zasync,
 		"n",
-		"compress file output on n threads" },
+		"compress file output on n threads (-1 auto)" },
 
 	{ '\0', "zcull",
 		ARGV_INT,
@@ -387,7 +384,13 @@ int main(int argc, char **argv) {
 #endif /* HAVE_LIBZMQ */
 
 	ctx.statsmods_loaded = statsmod_vec_init(1);
+
+	/* Without it, outputs made before --zasync resolves get no pool. */
 	ctx.initial_outputs = output_vec_init(1);
+	if (ctx.initial_outputs == NULL) {
+		fprintf(stderr, "%s: out of memory\n", argv_program);
+		exit(EXIT_FAILURE);
+	}
 
 	/* initialize the nmsg_io engine */
 	ctx.io = nmsg_io_init();
@@ -461,37 +464,12 @@ usage(const char *msg) {
 }
 
 /*
- * Cores this process may actually run on.
- */
-long
-nmsgtool_ncpu(void) {
-	long ncpu = -1;
-#ifdef __linux__
-	cpu_set_t set;
-
-	if (sched_getaffinity(0, sizeof(set), &set) == 0)
-		ncpu = CPU_COUNT(&set);
-#endif /* __linux__ */
-
-	if (ncpu < 1)
-		ncpu = sysconf(_SC_NPROCESSORS_ONLN);
-	if (ncpu < 1)
-		ncpu = 1;
-
-	return (ncpu);
-}
-
-/*
  * How many compressor threads an output should get. A negative --zasync means
  * auto: demand is about two workers per input, since a reader can saturate
- * roughly one core compressing, and supply is the cores the readers leave.
- *
- * The budget is split across the file outputs, which each get their own pool
- * and share these cores. One worker is still enough to take compression off
- * the reader, so no output drops below that.
+ * roughly one core compressing, bounded by the cores the readers leave.
  */
 static unsigned
-zworkers_count(nmsgtool_ctx *c) {
+zworkers_count(const nmsgtool_ctx *c) {
 	long ncpu;
 	int n, spare;
 
@@ -500,19 +478,35 @@ zworkers_count(nmsgtool_ctx *c) {
 	if (c->zasync > 0)
 		return ((unsigned) c->zasync);
 
-	ncpu = nmsgtool_ncpu();
+	ncpu = my_ncpu();
 
 	n = 2 * c->n_inputs;
 
+	/*
+	 * Split across the file outputs, which each get their own pool and
+	 * share these cores. Not under --mirror, where every output is handed
+	 * the whole stream and so needs the whole budget.
+	 */
+	if (!c->mirror)
+		n /= c->n_file_outputs;
+
+	/* Room for one even where the readers outnumber the cores. */
 	spare = (int) ncpu - c->n_inputs;
+	if (spare < 1)
+		spare = 1;
 	if (n > spare)
 		n = spare;
+
+	/*
+	 * Applied last, and per output: a single input can carry several cores'
+	 * worth on its own, which is what this floor is measured against.
+	 */
 	if (n < NMSGTOOL_ZWORKERS_MIN)
 		n = NMSGTOOL_ZWORKERS_MIN;
 
-	n /= c->n_file_outputs;
-	if (n < 1)
-		n = 1;
+	/* Never past what an explicit --zasync would be allowed. */
+	if (n > (int) ncpu)
+		n = (int) ncpu;
 
 	return ((unsigned) n);
 }
@@ -522,6 +516,23 @@ zworkers_count(nmsgtool_ctx *c) {
  * the end of process_args() because the input count is not final until then: a
  * channel alias (-C) expands to its sockets after the outputs are created.
  */
+/*
+ * Cull policy first: setting the ceiling builds the pool, which reads it. The
+ * pool is an optimisation, so a failure to start one is reported, not fatal.
+ */
+static void
+apply_zlib_workers(nmsgtool_ctx *c, nmsg_output_t output)
+{
+	nmsg_res res;
+
+	nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
+
+	res = nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
+	if (res != nmsg_res_success)
+		fprintf(stderr, "%s: no compressor pool: %s\n", argv_program,
+			nmsg_res_lookup(res));
+}
+
 void
 setup_nmsg_output_workers(nmsgtool_ctx *c) {
 	size_t i;
@@ -532,16 +543,33 @@ setup_nmsg_output_workers(nmsgtool_ctx *c) {
 		for (i = 0; i < output_vec_size(c->initial_outputs); i++) {
 			nmsg_output_t output = output_vec_data(c->initial_outputs)[i];
 
-			nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
-			nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
+			apply_zlib_workers(c, output);
 		}
 		output_vec_destroy(&c->initial_outputs);
 	}
 
-	if (c->zworkers_resolved > 0 && c->debug >= 2)
-		fprintf(stderr, "%s: compressing on up to %u thread(s) per output, "
-			"keeping %d idle for %d second(s)\n", argv_program,
-			c->zworkers_resolved, c->zmin, c->zcull);
+	if (c->zworkers_resolved == 0) {
+		/* Nothing to apply a cull policy to; say so rather than not. */
+		if (c->zcull != NMSGTOOL_ZCULL_DEFAULT ||
+		    c->zmin != NMSGTOOL_ZMIN_DEFAULT)
+			fprintf(stderr, "%s: --zcull and --zmin need --zasync "
+				"and an nmsg file output; ignored\n", argv_program);
+		return;
+	}
+
+	if (c->debug >= 2) {
+		char cull[64];
+
+		if (c->zcull > 0)
+			snprintf(cull, sizeof(cull),
+				 "culling to %d after %d idle second(s)",
+				 c->zmin, c->zcull);
+		else
+			snprintf(cull, sizeof(cull), "never culling");
+
+		fprintf(stderr, "%s: compressing on up to %u thread(s) per "
+			"output, %s\n", argv_program, c->zworkers_resolved, cull);
+	}
 }
 
 void
@@ -549,9 +577,7 @@ setup_nmsg_output(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_output_set_buffered(output, !(c->unbuffered));
 	nmsg_output_set_endline(output, c->endline_str);
 	nmsg_output_set_zlibout(output, c->zlibout);
-	/* Before the ceiling: setting that builds the pool, which reads this. */
-	nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
-	nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
+	apply_zlib_workers(c, output);
 	nmsg_output_set_source(output, c->set_source);
 	nmsg_output_set_operator(output, c->set_operator);
 	nmsg_output_set_group(output, c->set_group);

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -20,6 +20,9 @@
 #include <assert.h>
 #include <errno.h>
 #include <inttypes.h>
+#ifdef __linux__
+#include <sched.h>
+#endif /* __linux__ */
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -330,7 +333,7 @@ static argv_t args[] = {
 		ARGV_INT,
 		&ctx.zasync,
 		"n",
-		"compress file output on n threads (-1 chooses)" },
+		"compress file output on n threads" },
 
 	{ ARGV_LAST, 0, 0, 0, 0, 0 }
 };
@@ -439,38 +442,60 @@ usage(const char *msg) {
 }
 
 /*
+ * Cores this process may actually run on.
+ */
+long
+nmsgtool_ncpu(void) {
+	long ncpu = -1;
+#ifdef __linux__
+	cpu_set_t set;
+
+	if (sched_getaffinity(0, sizeof(set), &set) == 0)
+		ncpu = CPU_COUNT(&set);
+#endif /* __linux__ */
+
+	if (ncpu < 1)
+		ncpu = sysconf(_SC_NPROCESSORS_ONLN);
+	if (ncpu < 1)
+		ncpu = 1;
+
+	return (ncpu);
+}
+
+/*
  * How many compressor threads an output should get.
  *
  * A negative --zasync means auto. Two things bound the answer:
  *
- *   Demand scales with the input sockets. Each reader thread can saturate
- *   roughly one core compressing, and covering that takes about two workers
- *   per socket.
+ *   Demand scales with the inputs. Each reader thread can saturate roughly one
+ *   core compressing, and covering that takes about two workers per input.
  *
  *   Supply is the cores the readers leave. Workers beyond that only contend.
  *
- * The floor matters because one socket can carry several cores' worth on its
- * own, so a count that merely followed the socket count would under-serve
+ * The floor matters because one input can carry several cores' worth on its
+ * own, so a count that merely followed the input count would under-serve
  * exactly the case the pool exists for.
  *
- * Getting it wrong is cheap in one direction: a reader that finds every worker
- * busy compresses the container itself, so too small a pool degrades to the
- * behaviour of no pool rather than stalling. Too large only wastes idle
- * threads and ring slots, and a slot holds a container's payloads in memory.
+ * The budget is then split across the file outputs, since each gets its own
+ * pool and they share these same cores. Each output keeps at least one worker:
+ * one is still enough to take compression off the reader, which is the point.
+ *
+ * Getting it wrong is cheap in both directions. Too small a pool degrades to
+ * the behaviour of no pool rather than stalling, because a reader that finds
+ * every worker busy compresses the container itself. Too large only raises a
+ * ceiling that is never reached, since workers are started on demand.
  */
 static unsigned
 zworkers_count(nmsgtool_ctx *c) {
 	long ncpu;
 	int n, spare;
 
-	if (c->zasync == 0)
+	if (c->zasync == 0 || c->n_file_outputs == 0)
 		return (0);
 	if (c->zasync > 0)
 		return ((unsigned) c->zasync);
 
-	ncpu = sysconf(_SC_NPROCESSORS_ONLN);
-	if (ncpu < 1)
-		ncpu = 1;
+	ncpu = nmsgtool_ncpu();
 
 	n = 2 * c->n_inputs;
 
@@ -480,12 +505,16 @@ zworkers_count(nmsgtool_ctx *c) {
 	if (n < NMSGTOOL_ZWORKERS_MIN)
 		n = NMSGTOOL_ZWORKERS_MIN;
 
+	n /= c->n_file_outputs;
+	if (n < 1)
+		n = 1;
+
 	return ((unsigned) n);
 }
 
 /*
- * Resolve -W and apply it to the outputs that already exist. Deferred to the
- * end of process_args() because the input count is not final until then: a
+ * Resolve --zasync and apply it to the outputs that already exist. Deferred to
+ * the end of process_args() because the input count is not final until then: a
  * channel alias (-C) expands to its sockets after the outputs have been
  * created, which is exactly the case the pool is sized for.
  */
@@ -504,7 +533,7 @@ setup_nmsg_output_workers(nmsgtool_ctx *c) {
 	}
 
 	if (c->zworkers_resolved > 0 && c->debug >= 2)
-		fprintf(stderr, "%s: compressing on %u thread(s)\n",
+		fprintf(stderr, "%s: compressing on up to %u thread(s) per output\n",
 			argv_program, c->zworkers_resolved);
 }
 
@@ -518,7 +547,7 @@ setup_nmsg_output(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_output_set_operator(output, c->set_operator);
 	nmsg_output_set_group(output, c->set_group);
 
-	/* Outputs made before -W is resolved; see setup_nmsg_output_workers(). */
+	/* Outputs made before --zasync is resolved; see setup_nmsg_output_workers(). */
 	if (c->initial_outputs != NULL)
 		output_vec_add(c->initial_outputs, output);
 }

--- a/src/nmsgtool.c
+++ b/src/nmsgtool.c
@@ -36,7 +36,14 @@
 
 /* Globals. */
 
-static nmsgtool_ctx ctx;
+/*
+ * Defaults set here rather than after argv_process(): 0 is a meaningful value
+ * for both cull options, so neither can use it as an "unset" marker.
+ */
+static nmsgtool_ctx ctx = {
+	.zmin = NMSGTOOL_ZMIN_DEFAULT,
+	.zcull = NMSGTOOL_ZCULL_DEFAULT,
+};
 
 static argv_t args[] = {
 	{ 'b',	"bpf",
@@ -335,6 +342,18 @@ static argv_t args[] = {
 		"n",
 		"compress file output on n threads" },
 
+	{ '\0', "zcull",
+		ARGV_INT,
+		&ctx.zcull,
+		"secs",
+		"drop a compressor idle after n secs (0 never)" },
+
+	{ '\0', "zmin",
+		ARGV_INT,
+		&ctx.zmin,
+		"n",
+		"never drop below n compressors" },
+
 	{ ARGV_LAST, 0, 0, 0, 0, 0 }
 };
 
@@ -510,16 +529,19 @@ setup_nmsg_output_workers(nmsgtool_ctx *c) {
 	c->zworkers_resolved = zworkers_count(c);
 
 	if (c->initial_outputs != NULL) {
-		for (i = 0; i < output_vec_size(c->initial_outputs); i++)
-			nmsg_output_set_zlib_workers(
-				output_vec_data(c->initial_outputs)[i],
-				c->zworkers_resolved);
+		for (i = 0; i < output_vec_size(c->initial_outputs); i++) {
+			nmsg_output_t output = output_vec_data(c->initial_outputs)[i];
+
+			nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
+			nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
+		}
 		output_vec_destroy(&c->initial_outputs);
 	}
 
 	if (c->zworkers_resolved > 0 && c->debug >= 2)
-		fprintf(stderr, "%s: compressing on up to %u thread(s) per output\n",
-			argv_program, c->zworkers_resolved);
+		fprintf(stderr, "%s: compressing on up to %u thread(s) per output, "
+			"keeping %d idle for %d second(s)\n", argv_program,
+			c->zworkers_resolved, c->zmin, c->zcull);
 }
 
 void
@@ -527,6 +549,8 @@ setup_nmsg_output(nmsgtool_ctx *c, nmsg_output_t output) {
 	nmsg_output_set_buffered(output, !(c->unbuffered));
 	nmsg_output_set_endline(output, c->endline_str);
 	nmsg_output_set_zlibout(output, c->zlibout);
+	/* Before the ceiling: setting that builds the pool, which reads this. */
+	nmsg_output_set_zlib_cull(output, c->zmin, c->zcull);
 	nmsg_output_set_zlib_workers(output, c->zworkers_resolved);
 	nmsg_output_set_source(output, c->set_source);
 	nmsg_output_set_operator(output, c->set_operator);

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -66,6 +66,13 @@ VECTOR_GENERATE(output_vec, nmsg_output_t)
  */
 #define NMSGTOOL_ZWORKERS_MAX(ncpu)	(ncpu)
 
+/*
+ * Cull policy defaults. NMSGTOOL_ZMIN_DEFAULT is a floor on the live thread
+ * count, unrelated to NMSGTOOL_ZWORKERS_MIN above, which floors the ceiling.
+ */
+#define NMSGTOOL_ZMIN_DEFAULT	1
+#define NMSGTOOL_ZCULL_DEFAULT	300
+
 typedef struct {
 	/* parameters */
 	argv_array_t	filters, statsmods;
@@ -74,6 +81,8 @@ typedef struct {
 	argv_array_t	w_nmsg, w_pres, w_sock, w_kafka, w_zsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
 	int		zasync;			/* Compressor threads; -1 chooses. */
+	int		zmin;			/* Compressors culling leaves. */
+	int		zcull;			/* Idle seconds before a cull. */
 	char		*endline, *kicker, *mname, *vname, *bpfstr, *filter_policy, *kafka_key_field;
 	int		debug, signal;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -56,7 +56,7 @@ typedef struct {
 	argv_array_t	r_nmsg, r_kafka, r_sock, r_zsock, r_channel, r_zchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_kafka, w_zsock, w_json;
-	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
+	bool		help, mirror, unbuffered, zlibout, zasync, daemon, version, interval_randomized;
 	char		*endline, *kicker, *mname, *vname, *bpfstr, *filter_policy, *kafka_key_field;
 	int		debug, signal;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -62,8 +62,8 @@ VECTOR_GENERATE(output_vec, nmsg_output_t)
 /*
  * Ceiling for an explicit --zasync. Compression is CPU-bound, so a thread per
  * core is as far as it can help; workers start on demand, so this only bounds
- * how far a saturated output may grow. libnmsg applies the same rule a margin
- * tighter, since it sizes the reorder buffer that serves them.
+ * how far a saturated output may grow. libnmsg enforces the same ceiling, and
+ * sizes its reorder buffer a margin above it.
  */
 #define NMSGTOOL_ZWORKERS_MAX(ncpu)	(ncpu)
 
@@ -81,6 +81,7 @@ typedef struct {
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_kafka, w_zsock, w_json;
 	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
+	char		*zmin_str, *zcull_str;
 	int		zasync;			/* Compressor threads; -1 chooses. */
 	int		zmin;			/* Compressors culling leaves. */
 	int		zcull;			/* Idle seconds before a cull. */

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -49,6 +49,15 @@ union nmsgtool_sockaddr {
 typedef union nmsgtool_sockaddr nmsgtool_sockaddr;
 
 VECTOR_GENERATE(statsmod_vec, nmsg_statsmod_t)
+VECTOR_GENERATE(output_vec, nmsg_output_t)
+
+/*
+ * Floor for an automatically chosen compressor pool. A single input socket can
+ * carry well over one core's worth of compression on its own -- at 120 MB/s it
+ * needed four workers, where two still lost 13 % -- so the count cannot simply
+ * follow the socket count downwards.
+ */
+#define NMSGTOOL_ZWORKERS_MIN	4
 
 typedef struct {
 	/* parameters */
@@ -56,7 +65,8 @@ typedef struct {
 	argv_array_t	r_nmsg, r_kafka, r_sock, r_zsock, r_channel, r_zchannel, r_json;
 	argv_array_t	r_pcapfile, r_pcapif;
 	argv_array_t	w_nmsg, w_pres, w_sock, w_kafka, w_zsock, w_json;
-	bool		help, mirror, unbuffered, zlibout, zasync, daemon, version, interval_randomized;
+	bool		help, mirror, unbuffered, zlibout, daemon, version, interval_randomized;
+	int		zasync;			/* Compressor threads; -1 chooses. */
 	char		*endline, *kicker, *mname, *vname, *bpfstr, *filter_policy, *kafka_key_field;
 	int		debug, signal;
 	unsigned	mtu, count, interval, rate, freq, byte_rate;
@@ -68,6 +78,8 @@ typedef struct {
 	/* state */
 	char		*endline_str;
 	int		n_inputs, n_outputs;
+	unsigned	zworkers_resolved;	/* 0 until process_args() finishes. */
+	output_vec	*initial_outputs;	/* Non-NULL only during process_args(). */
 	nmsg_io_t	io;
 #ifdef HAVE_LIBZMQ
 	void		*zmq_ctx;
@@ -140,6 +152,7 @@ void pidfile_write(FILE *);
 void process_args(nmsgtool_ctx *);
 void setup_nmsg_input(nmsgtool_ctx *, nmsg_input_t);
 void setup_nmsg_output(nmsgtool_ctx *, nmsg_output_t);
+void setup_nmsg_output_workers(nmsgtool_ctx *);
 void usage(const char *);
 
 #endif /* NMSGTOOL_H */

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -52,19 +52,19 @@ VECTOR_GENERATE(statsmod_vec, nmsg_statsmod_t)
 VECTOR_GENERATE(output_vec, nmsg_output_t)
 
 /*
- * Floor for an automatically chosen compressor pool. A single input socket can
- * carry well over one core's worth of compression on its own -- at 120 MB/s it
- * needed four workers, where two still lost 13 % -- so the count cannot simply
- * follow the socket count downwards.
+ * Floor for an automatically chosen pool. One input socket can carry well over
+ * a core's worth of compression: at 120 MB/s it needed four workers, and two
+ * still lost 13 %.
  */
 #define NMSGTOOL_ZWORKERS_MIN	4
 
 /*
- * Ceiling for an explicit --zasync. Workers start on demand, so this only
- * bounds how far a saturated output may grow; libnmsg applies its own limit
- * on top, since it cannot assume its caller validated anything.
+ * Ceiling for an explicit --zasync. Compression is CPU-bound, so a thread per
+ * core is as far as it can help; workers start on demand, so this only bounds
+ * how far a saturated output may grow. libnmsg applies the same rule a margin
+ * tighter, since it sizes the reorder buffer that serves them.
  */
-#define NMSGTOOL_ZWORKERS_MAX(ncpu)	(2 * (ncpu))
+#define NMSGTOOL_ZWORKERS_MAX(ncpu)	(ncpu)
 
 typedef struct {
 	/* parameters */

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -59,6 +59,13 @@ VECTOR_GENERATE(output_vec, nmsg_output_t)
  */
 #define NMSGTOOL_ZWORKERS_MIN	4
 
+/*
+ * Ceiling for an explicit --zasync. Workers start on demand, so this only
+ * bounds how far a saturated output may grow; libnmsg applies its own limit
+ * on top, since it cannot assume its caller validated anything.
+ */
+#define NMSGTOOL_ZWORKERS_MAX(ncpu)	(2 * (ncpu))
+
 typedef struct {
 	/* parameters */
 	argv_array_t	filters, statsmods;
@@ -78,6 +85,7 @@ typedef struct {
 	/* state */
 	char		*endline_str;
 	int		n_inputs, n_outputs;
+	int		n_file_outputs;		/* Outputs a compressor pool can serve. */
 	unsigned	zworkers_resolved;	/* 0 until process_args() finishes. */
 	output_vec	*initial_outputs;	/* Non-NULL only during process_args(). */
 	nmsg_io_t	io;
@@ -148,6 +156,7 @@ void add_zsock_input(nmsgtool_ctx *, const char *);
 void add_zsock_output(nmsgtool_ctx *, const char *);
 void add_filter_module(nmsgtool_ctx *, const char *);
 void add_stats_module(nmsgtool_ctx *, const char *);
+long nmsgtool_ncpu(void);
 void pidfile_write(FILE *);
 void process_args(nmsgtool_ctx *);
 void setup_nmsg_input(nmsgtool_ctx *, nmsg_input_t);

--- a/src/nmsgtool.h
+++ b/src/nmsgtool.h
@@ -39,6 +39,7 @@
 #endif /* HAVE_LIBRDKAFKA */
 
 #include "libmy/argv.h"
+#include "libmy/my_cpu.h"
 #include "libmy/vector.h"
 
 union nmsgtool_sockaddr {
@@ -165,7 +166,6 @@ void add_zsock_input(nmsgtool_ctx *, const char *);
 void add_zsock_output(nmsgtool_ctx *, const char *);
 void add_filter_module(nmsgtool_ctx *, const char *);
 void add_stats_module(nmsgtool_ctx *, const char *);
-long nmsgtool_ncpu(void);
 void pidfile_write(FILE *);
 void process_args(nmsgtool_ctx *);
 void setup_nmsg_input(nmsgtool_ctx *, nmsg_input_t);

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -17,6 +17,7 @@
 
 #include <sys/types.h>
 #include <errno.h>
+#include <limits.h>
 #include <grp.h>
 #include <pwd.h>
 #include <stdio.h>
@@ -61,6 +62,22 @@ droproot(nmsgtool_ctx *c, FILE *fp_pidfile) {
 	if (c->debug >= 2)
 		fprintf(stderr, "%s: switched to user %s\n",
 			argv_program, c->username);
+}
+
+/* An integer in [min, max], or exit with 'what'. Rejects what atoi() would not. */
+static int
+read_int_range(const char *str, int min, int max, const char *what)
+{
+	char *t;
+	long val;
+
+	errno = 0;
+	val = strtol(str, &t, 0);
+	if (*str == '\0' || *t != '\0' || errno == ERANGE ||
+	    val < min || val > max)
+		usage(what);
+
+	return (int) val;
 }
 
 /* Convert string to non-zero unsigned 32 bit val, returning zero on failure. */
@@ -133,11 +150,13 @@ process_args(nmsgtool_ctx *c) {
 	if (c->zasync != 0 && c->unbuffered)
 		usage("--zasync cannot be used with --unbuffered");
 
-	if (c->zcull < 0)
-		usage("--zcull must be 0 (never cull) or a number of seconds");
+	if (c->zcull_str != NULL)
+		c->zcull = read_int_range(c->zcull_str, 0, INT_MAX,
+			"--zcull must be 0 (never cull) or a number of seconds");
 
-	if (c->zmin < 0)
-		usage("--zmin must be 0 or a number of compressor threads");
+	if (c->zmin_str != NULL)
+		c->zmin = read_int_range(c->zmin_str, 0, INT_MAX,
+			"--zmin must be 0 or a number of compressor threads");
 
 	/*
 	 * Only checked against an explicit ceiling. Under --zasync -1 the

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -125,6 +125,10 @@ process_args(nmsgtool_ctx *c) {
 	if (c->mtu == 0)
 		c->mtu = NMSG_WBUFSZ_JUMBO;
 
+	if (c->zasync < -1 || c->zasync > NMSGTOOL_ZWORKERS_MAX(nmsgtool_ncpu()))
+		usage("--zasync must be -1 (choose), 0 (off), "
+		      "or a thread count no greater than twice the available cores");
+
 	if (c->vname == NULL && c->mname != NULL)
 		c->vname = "base";
 

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -129,6 +129,18 @@ process_args(nmsgtool_ctx *c) {
 		usage("--zasync must be -1 (choose), 0 (off), "
 		      "or a thread count no greater than the available cores");
 
+	if (c->zcull < 0)
+		usage("--zcull must be 0 (never cull) or a number of seconds");
+
+	/*
+	 * Only checked for sanity here: the ceiling --zmin is a floor under is
+	 * not settled until setup_nmsg_output_workers(), and libnmsg lowers it
+	 * again to what the pool can run. -dd reports what it ended up as.
+	 */
+	if (c->zmin < 0 || c->zmin > NMSGTOOL_ZWORKERS_MAX(nmsgtool_ncpu()))
+		usage("--zmin must be 0 or a thread count no greater than "
+		      "the available cores");
+
 	if (c->vname == NULL && c->mname != NULL)
 		c->vname = "base";
 

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -409,6 +409,14 @@ process_args(nmsgtool_ctx *c) {
 		add_pres_output(c, "-");
 	}
 
+	/*
+	 * Size the compressor pool now that every input exists. Must follow
+	 * the implicit output above, and must precede daemonize(): the pool's
+	 * threads are started on first write, which happens in whichever
+	 * process ends up doing the writing.
+	 */
+	setup_nmsg_output_workers(c);
+
 	/* daemonize if necessary */
 	if (c->daemon) {
 		if (!daemonize()) {

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -125,21 +125,27 @@ process_args(nmsgtool_ctx *c) {
 	if (c->mtu == 0)
 		c->mtu = NMSG_WBUFSZ_JUMBO;
 
-	if (c->zasync < -1 || c->zasync > NMSGTOOL_ZWORKERS_MAX(nmsgtool_ncpu()))
+	if (c->zasync < -1 || c->zasync > NMSGTOOL_ZWORKERS_MAX(my_ncpu()))
 		usage("--zasync must be -1 (choose), 0 (off), "
 		      "or a thread count no greater than the available cores");
+
+	/* A container per message; a pool would spend a thread on each. */
+	if (c->zasync != 0 && c->unbuffered)
+		usage("--zasync cannot be used with --unbuffered");
 
 	if (c->zcull < 0)
 		usage("--zcull must be 0 (never cull) or a number of seconds");
 
+	if (c->zmin < 0)
+		usage("--zmin must be 0 or a number of compressor threads");
+
 	/*
-	 * Only checked for sanity here: the ceiling --zmin is a floor under is
-	 * not settled until setup_nmsg_output_workers(), and libnmsg lowers it
-	 * again to what the pool can run. -dd reports what it ended up as.
+	 * Only checked against an explicit ceiling. Under --zasync -1 the
+	 * ceiling is not settled until setup_nmsg_output_workers(), and libnmsg
+	 * lowers the floor again to what the pool can run, reporting it at -dd.
 	 */
-	if (c->zmin < 0 || c->zmin > NMSGTOOL_ZWORKERS_MAX(nmsgtool_ncpu()))
-		usage("--zmin must be 0 or a thread count no greater than "
-		      "the available cores");
+	if (c->zasync > 0 && c->zmin > c->zasync)
+		usage("--zmin cannot exceed --zasync");
 
 	if (c->vname == NULL && c->mname != NULL)
 		c->vname = "base";

--- a/src/process_args.c
+++ b/src/process_args.c
@@ -127,7 +127,7 @@ process_args(nmsgtool_ctx *c) {
 
 	if (c->zasync < -1 || c->zasync > NMSGTOOL_ZWORKERS_MAX(nmsgtool_ncpu()))
 		usage("--zasync must be -1 (choose), 0 (off), "
-		      "or a thread count no greater than twice the available cores");
+		      "or a thread count no greater than the available cores");
 
 	if (c->vname == NULL && c->mname != NULL)
 		c->vname = "base";
@@ -414,10 +414,9 @@ process_args(nmsgtool_ctx *c) {
 	}
 
 	/*
-	 * Size the compressor pool now that every input exists. Must follow
-	 * the implicit output above, and must precede daemonize(): the pool's
-	 * threads are started on first write, which happens in whichever
-	 * process ends up doing the writing.
+	 * Size the pool now that every input exists. Must follow the implicit
+	 * output above and precede daemonize(): pool threads start on first
+	 * write, in whichever process does the writing.
 	 */
 	setup_nmsg_output_workers(c);
 

--- a/tests/test-zpool-cull.c
+++ b/tests/test-zpool-cull.c
@@ -246,30 +246,34 @@ static void
 test_cull_to_empty(const char *path)
 {
 	nmsg_output_t output = open_output(path, 4, 0, CULL_SECS);
-	unsigned live, peak;
+	unsigned live;
 	uint64_t culled;
 
+	/* Polled, not read once: the worker arms its deadline as it finishes. */
 	write_burst(output, BURST, 0);
-	counts(output, &live, &peak, &culled);
-	if (live != 1)
-		fail_count("worker not started", 1, live);
+	wait_for_live(output, 1);
 
 	wait_for_live(output, 0);
 
-	counts(output, &live, &peak, &culled);
+	counts(output, &live, NULL, &culled);
 	if (culled != 1)
 		fail_count("culls recorded", 1, (unsigned) culled);
 
+	/*
+	 * Two bursts: a culled worker's record is not free again until the
+	 * committer reaps it, which happens on the next commit. Where the
+	 * ceiling is 1 -- a single-core builder -- that commit is the first
+	 * burst's, so the pool cannot grow until the second.
+	 */
 	write_burst(output, BURST, BURST);
-	counts(output, &live, &peak, &culled);
-	if (live != 1)
-		fail_count("pool did not grow again", 1, live);
+	write_burst(output, BURST, 2 * BURST);
+	wait_for_live(output, 1);
 
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");
 
-	if (count_payloads(path) != 2 * BURST)
-		fail_count("payloads written", 2 * BURST, count_payloads(path));
+	if (count_payloads(path) != 3 * BURST)
+		fail_count("payloads written", 3 * BURST, count_payloads(path));
 }
 
 /* The floor is left alone, however long the pool stays quiet. */
@@ -319,21 +323,28 @@ test_cull_disabled(const char *path)
 }
 
 /*
- * A floor above the ceiling has nothing to cull, and must be lowered to it
- * rather than quietly disable the policy.
+ * A floor above the ceiling leaves nothing to cull, and the pool has to keep
+ * working rather than wedge or cull anyway.
+ *
+ * Not a test of async_min_workers_for()'s clamp, which cannot be one: nlive
+ * never exceeds the ceiling, so `nlive > min_workers` is false whether the
+ * floor was lowered or left at 8. The clamp's only effect is its -dd line.
  */
 static void
 test_floor_above_ceiling(const char *path)
 {
 	nmsg_output_t output = open_output(path, 1, 8, CULL_SECS);
 	unsigned live;
+	uint64_t culled;
 
 	write_burst(output, BURST, 0);
 	nap_ms(SETTLE_SECS * 1000);
 
-	counts(output, &live, NULL, NULL);
+	counts(output, &live, NULL, &culled);
 	if (live != 1)
 		fail_count("clamped floor not held", 1, live);
+	if (culled != 0)
+		fail_count("culls under a clamped floor", 0, (unsigned) culled);
 
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");

--- a/tests/test-zpool-cull.c
+++ b/tests/test-zpool-cull.c
@@ -26,6 +26,7 @@
 
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <errno.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,9 +42,25 @@
 /* Long enough that a CULL_SECS deadline has certainly passed. */
 #define SETTLE_SECS	3
 
+/* Payloads per burst. One container per burst is what the counts below rely on. */
+#define BURST		100
+
+#if BURST * 64 > BUFSZ
+#error "BURST no longer fits one container"
+#endif
+
+/* Polling for a cull that has to happen, rather than guessing how long it takes. */
+#define POLL_STEP_MS	50
+#define POLL_MAX_MS	30000
+
 static nmsg_msgmod_t mod;
 
-/* automake has no per-test timeout, so a wedged pool would hang forever. */
+/*
+ * automake has no per-test timeout, so a wedged pool would hang forever. Set
+ * well above the runtime: under valgrind or a loaded builder this test is
+ * slower by an order of magnitude, and a watchdog that fires then is
+ * indistinguishable from the deadlock it is meant to catch.
+ */
 static void
 on_alarm(int sig __attribute__((unused)))
 {
@@ -53,6 +70,33 @@ on_alarm(int sig __attribute__((unused)))
 		/* Nothing useful to do; we are on our way out regardless. */
 	}
 	_exit(1);
+}
+
+/* nanosleep(), not sleep(): mixing sleep() with alarm() is unspecified. */
+static void
+nap_ms(unsigned ms)
+{
+	struct timespec ts;
+
+	ts.tv_sec = ms / 1000;
+	ts.tv_nsec = (long) (ms % 1000) * 1000000;
+
+	while (nanosleep(&ts, &ts) != 0 && errno == EINTR)
+		;
+}
+
+/* Unlinked however the test ends, so a failure does not litter the tmp dir. */
+static const char *tmp_paths[1];
+
+static void
+unlink_tmp(void)
+{
+	unsigned i;
+
+	for (i = 0; i < sizeof(tmp_paths) / sizeof(tmp_paths[0]); i++) {
+		if (tmp_paths[i] != NULL)
+			unlink(tmp_paths[i]);
+	}
 }
 
 static void
@@ -74,13 +118,16 @@ make_message(unsigned i)
 {
 	char payload[48];
 	nmsg_message_t msg;
-	size_t len;
+	int len;
 
 	msg = nmsg_message_init(mod);
 	if (msg == NULL)
 		fail("nmsg_message_init() failed");
 
 	len = snprintf(payload, sizeof(payload), "payload %u", i);
+	if (len < 0 || (size_t) len >= sizeof(payload))
+		fail("snprintf() failed");
+
 	if (nmsg_message_set_field(msg, "payload", 0,
 				   (const uint8_t *) payload, len) != nmsg_res_success)
 		fail("nmsg_message_set_field() failed");
@@ -104,13 +151,19 @@ count_payloads(const char *path)
 	if (input == NULL)
 		fail("nmsg_input_open_file() failed");
 
-	while (nmsg_input_read(input, &msg) == nmsg_res_success) {
+	for (;;) {
+		nmsg_res res = nmsg_input_read(input, &msg);
+
+		if (res == nmsg_res_eof)
+			break;
+		if (res != nmsg_res_success)
+			fail("nmsg_input_read() failed");
+
 		nmsg_message_destroy(&msg);
 		n += 1;
 	}
 
-	nmsg_input_close(&input);
-	close(fd);
+	nmsg_input_close(&input);	/* Closes fd; autoclose is the default. */
 
 	return (n);
 }
@@ -166,10 +219,28 @@ counts(nmsg_output_t output, unsigned *live, unsigned *peak, uint64_t *culled)
 	_output_async_counts(pool, live, peak, culled);
 }
 
+/* Wait for the pool to reach 'want' live compressors, or give up and say so. */
+static void
+wait_for_live(nmsg_output_t output, unsigned want)
+{
+	unsigned live, waited;
+
+	for (waited = 0; waited < POLL_MAX_MS; waited += POLL_STEP_MS) {
+		counts(output, &live, NULL, NULL);
+		if (live == want)
+			return;
+		nap_ms(POLL_STEP_MS);
+	}
+
+	counts(output, &live, NULL, NULL);
+	if (live != want)
+		fail_count("pool did not settle", want, live);
+}
+
 /*
  * A worker starts, goes quiet and gives its place back; the pool then grows
- * again from empty. Reaching zero is what exercises reusing a culled worker's
- * record, which means joining the thread that left it.
+ * again from empty. Reaching zero is what exercises the committer reaping a
+ * culled worker before its record can be spawned into again.
  */
 static void
 test_cull_to_empty(const char *path)
@@ -178,21 +249,18 @@ test_cull_to_empty(const char *path)
 	unsigned live, peak;
 	uint64_t culled;
 
-	write_burst(output, 100, 0);
+	write_burst(output, BURST, 0);
 	counts(output, &live, &peak, &culled);
 	if (live != 1)
 		fail_count("worker not started", 1, live);
 
-	sleep(SETTLE_SECS);
+	wait_for_live(output, 0);
 
 	counts(output, &live, &peak, &culled);
-	if (live != 0)
-		fail_count("pool did not empty", 0, live);
 	if (culled != 1)
 		fail_count("culls recorded", 1, (unsigned) culled);
 
-	/* Growing again has to reuse the record the culled worker left. */
-	write_burst(output, 100, 100);
+	write_burst(output, BURST, BURST);
 	counts(output, &live, &peak, &culled);
 	if (live != 1)
 		fail_count("pool did not grow again", 1, live);
@@ -200,8 +268,8 @@ test_cull_to_empty(const char *path)
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");
 
-	if (count_payloads(path) != 200)
-		fail_count("payloads written", 200, count_payloads(path));
+	if (count_payloads(path) != 2 * BURST)
+		fail_count("payloads written", 2 * BURST, count_payloads(path));
 }
 
 /* The floor is left alone, however long the pool stays quiet. */
@@ -212,8 +280,8 @@ test_floor(const char *path)
 	unsigned live;
 	uint64_t culled;
 
-	write_burst(output, 100, 0);
-	sleep(SETTLE_SECS);
+	write_burst(output, BURST, 0);
+	nap_ms(SETTLE_SECS * 1000);
 
 	counts(output, &live, NULL, &culled);
 	if (live != 1)
@@ -233,12 +301,12 @@ test_cull_disabled(const char *path)
 	unsigned live, peak;
 	uint64_t culled;
 
-	write_burst(output, 100, 0);
+	write_burst(output, BURST, 0);
 	counts(output, &live, &peak, &culled);
 	if (live != peak)
 		fail_count("workers lost before settling", peak, live);
 
-	sleep(SETTLE_SECS);
+	nap_ms(SETTLE_SECS * 1000);
 
 	counts(output, &live, &peak, &culled);
 	if (live != peak)
@@ -260,8 +328,8 @@ test_floor_above_ceiling(const char *path)
 	nmsg_output_t output = open_output(path, 1, 8, CULL_SECS);
 	unsigned live;
 
-	write_burst(output, 100, 0);
-	sleep(SETTLE_SECS);
+	write_burst(output, BURST, 0);
+	nap_ms(SETTLE_SECS * 1000);
 
 	counts(output, &live, NULL, NULL);
 	if (live != 1)
@@ -282,8 +350,8 @@ test_traffic_across_culls(const char *path)
 	unsigned round, live;
 
 	for (round = 0; round < 3; round++) {
-		write_burst(output, 100, round * 100);
-		sleep(SETTLE_SECS);
+		write_burst(output, BURST, round * BURST);
+		wait_for_live(output, 0);
 	}
 
 	counts(output, &live, NULL, NULL);
@@ -293,16 +361,20 @@ test_traffic_across_culls(const char *path)
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");
 
-	if (count_payloads(path) != 300)
-		fail_count("payloads written", 300, count_payloads(path));
+	if (count_payloads(path) != 3 * BURST)
+		fail_count("payloads written", 3 * BURST, count_payloads(path));
 }
 
-int main(void) {
-	char path[] = "/tmp/nmsg-zpool-cull.XXXXXX";
+int
+main(void)
+{
+	/* static: unlink_tmp() runs from atexit(), after this frame is gone. */
+	static char path[] = "/tmp/nmsg-zpool-cull.XXXXXX";
 	int fd;
 
-	signal(SIGALRM, on_alarm);
-	alarm(120);
+	if (signal(SIGALRM, on_alarm) == SIG_ERR)
+		fail("signal() failed");
+	alarm(600);
 
 	if (nmsg_init() != nmsg_res_success)
 		fail("nmsg_init() failed");
@@ -316,14 +388,14 @@ int main(void) {
 	if (fd < 0)
 		fail("mkstemp() failed");
 	close(fd);
+	tmp_paths[0] = path;
+	atexit(unlink_tmp);
 
 	test_cull_to_empty(path);
 	test_floor(path);
 	test_cull_disabled(path);
 	test_floor_above_ceiling(path);
 	test_traffic_across_culls(path);
-
-	unlink(path);
 
 	return (0);
 }

--- a/tests/test-zpool-cull.c
+++ b/tests/test-zpool-cull.c
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) 2026 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Compressors have to give their place back once they go idle, and the pool has
+ * to grow again afterwards. Linked against libnmsg's own objects, since the
+ * live worker count is not something the public headers expose.
+ *
+ * Only the first spawn is deterministic: a producer that finds no idle worker
+ * starts one, so a single write guarantees exactly one. Growing past that needs
+ * production to outrun compression, so nothing here asserts on it.
+ */
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "nmsg.h"
+#include "private.h"
+
+#define BUFSZ		NMSG_WBUFSZ_JUMBO
+#define CULL_SECS	1
+
+/* Long enough that a CULL_SECS deadline has certainly passed. */
+#define SETTLE_SECS	3
+
+static nmsg_msgmod_t mod;
+
+/* automake has no per-test timeout, so a wedged pool would hang forever. */
+static void
+on_alarm(int sig __attribute__((unused)))
+{
+	static const char msg[] = "test-zpool-cull: timed out\n";
+
+	if (write(STDERR_FILENO, msg, sizeof(msg) - 1) != sizeof(msg) - 1) {
+		/* Nothing useful to do; we are on our way out regardless. */
+	}
+	_exit(1);
+}
+
+static void
+fail(const char *what)
+{
+	fprintf(stderr, "test-zpool-cull: %s\n", what);
+	exit(1);
+}
+
+static void
+fail_count(const char *what, unsigned want, unsigned got)
+{
+	fprintf(stderr, "test-zpool-cull: %s: wanted %u, got %u\n", what, want, got);
+	exit(1);
+}
+
+static nmsg_message_t
+make_message(unsigned i)
+{
+	char payload[48];
+	nmsg_message_t msg;
+	size_t len;
+
+	msg = nmsg_message_init(mod);
+	if (msg == NULL)
+		fail("nmsg_message_init() failed");
+
+	len = snprintf(payload, sizeof(payload), "payload %u", i);
+	if (nmsg_message_set_field(msg, "payload", 0,
+				   (const uint8_t *) payload, len) != nmsg_res_success)
+		fail("nmsg_message_set_field() failed");
+
+	return (msg);
+}
+
+static unsigned
+count_payloads(const char *path)
+{
+	nmsg_input_t input;
+	nmsg_message_t msg;
+	unsigned n = 0;
+	int fd;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		fail("open() for reading failed");
+
+	input = nmsg_input_open_file(fd);
+	if (input == NULL)
+		fail("nmsg_input_open_file() failed");
+
+	while (nmsg_input_read(input, &msg) == nmsg_res_success) {
+		nmsg_message_destroy(&msg);
+		n += 1;
+	}
+
+	nmsg_input_close(&input);
+	close(fd);
+
+	return (n);
+}
+
+static nmsg_output_t
+open_output(const char *path, unsigned workers, unsigned zmin, unsigned zcull)
+{
+	nmsg_output_t output;
+	int fd;
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0)
+		fail("open() for writing failed");
+
+	output = nmsg_output_open_file(fd, BUFSZ);
+	if (output == NULL)
+		fail("nmsg_output_open_file() failed");
+
+	nmsg_output_set_buffered(output, true);
+	nmsg_output_set_zlibout(output, true);
+	nmsg_output_set_zlib_cull(output, zmin, zcull);
+	nmsg_output_set_zlib_workers(output, workers);
+
+	return (output);
+}
+
+/* Write 'n' payloads and seal what they filled, so the pool sees a container. */
+static void
+write_burst(nmsg_output_t output, unsigned n, unsigned tag)
+{
+	unsigned i;
+
+	for (i = 0; i < n; i++) {
+		nmsg_message_t msg = make_message(tag + i);
+
+		if (nmsg_output_write(output, msg) != nmsg_res_success)
+			fail("nmsg_output_write() failed");
+		nmsg_message_destroy(&msg);
+	}
+
+	if (nmsg_output_flush(output) != nmsg_res_success)
+		fail("nmsg_output_flush() failed");
+}
+
+static void
+counts(nmsg_output_t output, unsigned *live, unsigned *peak, uint64_t *culled)
+{
+	struct nmsg_ostr_async *pool = output->stream->so_pool;
+
+	if (pool == NULL)
+		fail("output has no compressor pool");
+
+	_output_async_counts(pool, live, peak, culled);
+}
+
+/*
+ * A worker starts, goes quiet and gives its place back; the pool then grows
+ * again from empty. Reaching zero is what exercises reusing a culled worker's
+ * record, which means joining the thread that left it.
+ */
+static void
+test_cull_to_empty(const char *path)
+{
+	nmsg_output_t output = open_output(path, 4, 0, CULL_SECS);
+	unsigned live, peak;
+	uint64_t culled;
+
+	write_burst(output, 100, 0);
+	counts(output, &live, &peak, &culled);
+	if (live != 1)
+		fail_count("worker not started", 1, live);
+
+	sleep(SETTLE_SECS);
+
+	counts(output, &live, &peak, &culled);
+	if (live != 0)
+		fail_count("pool did not empty", 0, live);
+	if (culled != 1)
+		fail_count("culls recorded", 1, (unsigned) culled);
+
+	/* Growing again has to reuse the record the culled worker left. */
+	write_burst(output, 100, 100);
+	counts(output, &live, &peak, &culled);
+	if (live != 1)
+		fail_count("pool did not grow again", 1, live);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+
+	if (count_payloads(path) != 200)
+		fail_count("payloads written", 200, count_payloads(path));
+}
+
+/* The floor is left alone, however long the pool stays quiet. */
+static void
+test_floor(const char *path)
+{
+	nmsg_output_t output = open_output(path, 4, 1, CULL_SECS);
+	unsigned live;
+	uint64_t culled;
+
+	write_burst(output, 100, 0);
+	sleep(SETTLE_SECS);
+
+	counts(output, &live, NULL, &culled);
+	if (live != 1)
+		fail_count("floor not held", 1, live);
+	if (culled != 0)
+		fail_count("culls below the floor", 0, (unsigned) culled);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+}
+
+/* Culling off leaves the pool at its high water mark. */
+static void
+test_cull_disabled(const char *path)
+{
+	nmsg_output_t output = open_output(path, 4, 0, 0);
+	unsigned live, peak;
+	uint64_t culled;
+
+	write_burst(output, 100, 0);
+	counts(output, &live, &peak, &culled);
+	if (live != peak)
+		fail_count("workers lost before settling", peak, live);
+
+	sleep(SETTLE_SECS);
+
+	counts(output, &live, &peak, &culled);
+	if (live != peak)
+		fail_count("culled with culling disabled", peak, live);
+	if (culled != 0)
+		fail_count("culls with culling disabled", 0, (unsigned) culled);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+}
+
+/*
+ * A floor above the ceiling has nothing to cull, and must be lowered to it
+ * rather than quietly disable the policy.
+ */
+static void
+test_floor_above_ceiling(const char *path)
+{
+	nmsg_output_t output = open_output(path, 1, 8, CULL_SECS);
+	unsigned live;
+
+	write_burst(output, 100, 0);
+	sleep(SETTLE_SECS);
+
+	counts(output, &live, NULL, NULL);
+	if (live != 1)
+		fail_count("clamped floor not held", 1, live);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+}
+
+/*
+ * Work keeps flowing across culls: containers written while the pool is
+ * shrinking and regrowing all have to arrive, in order.
+ */
+static void
+test_traffic_across_culls(const char *path)
+{
+	nmsg_output_t output = open_output(path, 4, 0, CULL_SECS);
+	unsigned round, live;
+
+	for (round = 0; round < 3; round++) {
+		write_burst(output, 100, round * 100);
+		sleep(SETTLE_SECS);
+	}
+
+	counts(output, &live, NULL, NULL);
+	if (live != 0)
+		fail_count("pool did not settle", 0, live);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+
+	if (count_payloads(path) != 300)
+		fail_count("payloads written", 300, count_payloads(path));
+}
+
+int main(void) {
+	char path[] = "/tmp/nmsg-zpool-cull.XXXXXX";
+	int fd;
+
+	signal(SIGALRM, on_alarm);
+	alarm(120);
+
+	if (nmsg_init() != nmsg_res_success)
+		fail("nmsg_init() failed");
+
+	mod = nmsg_msgmod_lookup_byname("base", "encode");
+	if (mod == NULL)
+		fail("no base:encode message type");
+
+	/* mkstemp() only to get a unique name; the writers reopen by path. */
+	fd = mkstemp(path);
+	if (fd < 0)
+		fail("mkstemp() failed");
+	close(fd);
+
+	test_cull_to_empty(path);
+	test_floor(path);
+	test_cull_disabled(path);
+	test_floor_above_ceiling(path);
+	test_traffic_across_culls(path);
+
+	unlink(path);
+
+	return (0);
+}

--- a/tests/test-zpool-mt.c
+++ b/tests/test-zpool-mt.c
@@ -38,6 +38,7 @@
 #include <unistd.h>
 
 #include "nmsg.h"
+#include "private.h"
 
 #define NUM_THREADS	4
 #define PER_THREAD	5000
@@ -184,7 +185,7 @@ static void
 run(const char *path, unsigned workers)
 {
 	struct writer writers[NUM_THREADS];
-	unsigned i, total;
+	unsigned i, total, peak = 0;
 	int fd;
 
 	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
@@ -197,7 +198,8 @@ run(const char *path, unsigned workers)
 
 	nmsg_output_set_buffered(output, true);
 	nmsg_output_set_zlibout(output, true);
-	nmsg_output_set_zlib_workers(output, workers);
+	if (nmsg_output_set_zlib_workers(output, workers) != nmsg_res_success)
+		fail("nmsg_output_set_zlib_workers() failed");
 
 	for (i = 0; i < NUM_THREADS; i++) {
 		writers[i].id = i;
@@ -209,6 +211,17 @@ run(const char *path, unsigned workers)
 	for (i = 0; i < NUM_THREADS; i++)
 		if (pthread_join(writers[i].thr, NULL) != 0)
 			fail("pthread_join() failed");
+
+	/*
+	 * Read before the close, which takes the pool down. Without it the
+	 * ordering check below would still pass with no pool at all -- the
+	 * reordering a pool prevents is a race that need not occur.
+	 */
+	if (output->stream->so_pool == NULL)
+		fail("output has no compressor pool");
+	_output_async_counts(output->stream->so_pool, NULL, &peak, NULL);
+	if (peak == 0)
+		fail("no compressor thread ever ran");
 
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");

--- a/tests/test-zpool-mt.c
+++ b/tests/test-zpool-mt.c
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2026 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * With several threads writing one output, the pool guarantees 
+ * containers reach the file in the order they were
+ * sealed. A thread's own payloads must therefore appear in the file in the
+ * order that thread wrote them.
+ *
+ * This is a per-thread claim, not a global one. Which thread wins a given
+ * container is a race, so nothing is asserted about how threads interleave --
+ * only that no thread's payloads are reordered among themselves.
+ *
+ * Without a pool, container_submit() writes on the calling thread and two
+ * threads race for w_lock in send_buffer(), so containers can reach the file
+ * out of order. The check below therefore applies to the pooled runs only.
+ */
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "nmsg.h"
+
+#define NUM_THREADS	4
+#define PER_THREAD	5000
+#define BUFSZ		NMSG_WBUFSZ_JUMBO
+
+static nmsg_msgmod_t mod;
+static nmsg_output_t output;
+
+struct writer {
+	pthread_t	thr;
+	unsigned	id;
+};
+
+static void
+on_alarm(int sig __attribute__((unused)))
+{
+	static const char msg[] = "test-zpool-mt: timed out\n";
+
+	if (write(STDERR_FILENO, msg, sizeof(msg) - 1) != sizeof(msg) - 1) {
+		/* On our way out regardless. */
+	}
+	_exit(1);
+}
+
+static void
+fail(const char *what)
+{
+	fprintf(stderr, "test-zpool-mt: %s\n", what);
+	exit(1);
+}
+
+static void *
+writer_thread(void *arg)
+{
+	struct writer *w = (struct writer *) arg;
+	unsigned i;
+
+	for (i = 0; i < PER_THREAD; i++) {
+		char payload[48];
+		nmsg_message_t msg;
+		size_t len;
+
+		msg = nmsg_message_init(mod);
+		if (msg == NULL)
+			fail("nmsg_message_init() failed");
+
+		len = snprintf(payload, sizeof(payload), "%u:%u", w->id, i);
+		if (nmsg_message_set_field(msg, "payload", 0,
+					   (const uint8_t *) payload,
+					   len) != nmsg_res_success)
+			fail("nmsg_message_set_field() failed");
+
+		if (nmsg_output_write(output, msg) != nmsg_res_success)
+			fail("nmsg_output_write() failed");
+		nmsg_message_destroy(&msg);
+	}
+
+	return (NULL);
+}
+
+/*
+ * Read the file back and check that each thread's counters only ever increase.
+ * Returns the total number of payloads seen.
+ */
+static unsigned
+verify_order(const char *path)
+{
+	unsigned last[NUM_THREADS];
+	unsigned total = 0, i;
+	nmsg_input_t input;
+	nmsg_message_t msg;
+	int fd;
+
+	for (i = 0; i < NUM_THREADS; i++)
+		last[i] = 0;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		fail("open() for reading failed");
+
+	input = nmsg_input_open_file(fd);
+	if (input == NULL)
+		fail("nmsg_input_open_file() failed");
+
+	while (nmsg_input_read(input, &msg) == nmsg_res_success) {
+		unsigned tid, seq;
+		void *data;
+		size_t len;
+		char buf[64];
+
+		if (nmsg_message_get_field(msg, "payload", 0, &data,
+					   &len) != nmsg_res_success)
+			fail("nmsg_message_get_field() failed");
+
+		if (len >= sizeof(buf))
+			fail("payload larger than expected");
+		memcpy(buf, data, len);
+		buf[len] = '\0';
+
+		if (sscanf(buf, "%u:%u", &tid, &seq) != 2)
+			fail("payload did not parse");
+		if (tid >= NUM_THREADS)
+			fail("payload carried an unknown thread id");
+
+		/*
+		 * Counters start at 0, so 'last' holds the next value expected
+		 * rather than the previous one seen.
+		 */
+		if (seq != last[tid]) {
+			fprintf(stderr, "test-zpool-mt: thread %u payload %u "
+				"arrived where %u was expected\n",
+				tid, seq, last[tid]);
+			exit(1);
+		}
+		last[tid] = seq + 1;
+
+		nmsg_message_destroy(&msg);
+		total += 1;
+	}
+
+	nmsg_input_close(&input);
+	close(fd);
+
+	return (total);
+}
+
+static void
+run(const char *path, unsigned workers)
+{
+	struct writer writers[NUM_THREADS];
+	unsigned i, total;
+	int fd;
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0)
+		fail("open() for writing failed");
+
+	output = nmsg_output_open_file(fd, BUFSZ);
+	if (output == NULL)
+		fail("nmsg_output_open_file() failed");
+
+	nmsg_output_set_buffered(output, true);
+	nmsg_output_set_zlibout(output, true);
+	nmsg_output_set_zlib_workers(output, workers);
+
+	for (i = 0; i < NUM_THREADS; i++) {
+		writers[i].id = i;
+		if (pthread_create(&writers[i].thr, NULL, writer_thread,
+				   &writers[i]) != 0)
+			fail("pthread_create() failed");
+	}
+
+	for (i = 0; i < NUM_THREADS; i++)
+		pthread_join(writers[i].thr, NULL);
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+
+	total = verify_order(path);
+	if (total != NUM_THREADS * PER_THREAD) {
+		fprintf(stderr, "test-zpool-mt: read %u payloads, expected %u\n",
+			total, NUM_THREADS * PER_THREAD);
+		exit(1);
+	}
+}
+
+int main(void) {
+	char path[] = "/tmp/nmsg-zpool-mt.XXXXXX";
+	int fd;
+
+	signal(SIGALRM, on_alarm);
+	alarm(60);
+
+	if (nmsg_init() != nmsg_res_success)
+		fail("nmsg_init() failed");
+
+	mod = nmsg_msgmod_lookup_byname("base", "encode");
+	if (mod == NULL)
+		fail("no base:encode message type");
+
+	fd = mkstemp(path);
+	if (fd < 0)
+		fail("mkstemp() failed");
+	close(fd);
+
+	run(path, 1);
+	run(path, 4);
+
+	unlink(path);
+
+	return (0);
+}

--- a/tests/test-zpool-mt.c
+++ b/tests/test-zpool-mt.c
@@ -15,7 +15,7 @@
  */
 
 /*
- * With several threads writing one output, the pool guarantees 
+ * With several threads writing one output, the pool guarantees
  * containers reach the file in the order they were
  * sealed. A thread's own payloads must therefore appear in the file in the
  * order that thread wrote them.
@@ -62,6 +62,20 @@ on_alarm(int sig __attribute__((unused)))
 	_exit(1);
 }
 
+/* Unlinked however the test ends, so a failure does not litter the tmp dir. */
+static const char *tmp_paths[1];
+
+static void
+unlink_tmp(void)
+{
+	unsigned i;
+
+	for (i = 0; i < sizeof(tmp_paths) / sizeof(tmp_paths[0]); i++) {
+		if (tmp_paths[i] != NULL)
+			unlink(tmp_paths[i]);
+	}
+}
+
 static void
 fail(const char *what)
 {
@@ -78,13 +92,16 @@ writer_thread(void *arg)
 	for (i = 0; i < PER_THREAD; i++) {
 		char payload[48];
 		nmsg_message_t msg;
-		size_t len;
+		int len;
 
 		msg = nmsg_message_init(mod);
 		if (msg == NULL)
 			fail("nmsg_message_init() failed");
 
 		len = snprintf(payload, sizeof(payload), "%u:%u", w->id, i);
+		if (len < 0 || (size_t) len >= sizeof(payload))
+			fail("snprintf() failed");
+
 		if (nmsg_message_set_field(msg, "payload", 0,
 					   (const uint8_t *) payload,
 					   len) != nmsg_res_success)
@@ -158,8 +175,7 @@ verify_order(const char *path)
 		total += 1;
 	}
 
-	nmsg_input_close(&input);
-	close(fd);
+	nmsg_input_close(&input);	/* Closes fd; autoclose is the default. */
 
 	return (total);
 }
@@ -191,7 +207,8 @@ run(const char *path, unsigned workers)
 	}
 
 	for (i = 0; i < NUM_THREADS; i++)
-		pthread_join(writers[i].thr, NULL);
+		if (pthread_join(writers[i].thr, NULL) != 0)
+			fail("pthread_join() failed");
 
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");
@@ -204,12 +221,16 @@ run(const char *path, unsigned workers)
 	}
 }
 
-int main(void) {
-	char path[] = "/tmp/nmsg-zpool-mt.XXXXXX";
+int
+main(void)
+{
+	/* static: unlink_tmp() runs from atexit(), after this frame is gone. */
+	static char path[] = "/tmp/nmsg-zpool-mt.XXXXXX";
 	int fd;
 
-	signal(SIGALRM, on_alarm);
-	alarm(60);
+	if (signal(SIGALRM, on_alarm) == SIG_ERR)
+		fail("signal() failed");
+	alarm(600);
 
 	if (nmsg_init() != nmsg_res_success)
 		fail("nmsg_init() failed");
@@ -222,11 +243,11 @@ int main(void) {
 	if (fd < 0)
 		fail("mkstemp() failed");
 	close(fd);
+	tmp_paths[0] = path;
+	atexit(unlink_tmp);
 
 	run(path, 1);
 	run(path, 4);
-
-	unlink(path);
 
 	return (0);
 }

--- a/tests/test-zpool-order.c
+++ b/tests/test-zpool-order.c
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2026 DomainTools LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * The compressor pool must not change what gets written, only who compresses
+ * it. One producer writes the same payloads with a range of worker ceilings;
+ * every resulting file has to be byte for byte identical.
+ *
+ * A small bufsz is what makes this worth running: it puts many more containers
+ * in the file than a 1 MiB one would, so the slot ring wraps repeatedly and
+ * producers exercise the path where every worker is busy.
+ */
+
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "nmsg.h"
+
+#define NUM_PAYLOADS	4000
+#define BUFSZ		NMSG_WBUFSZ_JUMBO
+
+/* Flush and check the file part-way through, at this payload. */
+#define CHECKPOINT_AT	1500
+
+/* Enable the pool at this payload in the late-enable run. */
+#define LATE_ENABLE_AT	700
+
+static nmsg_msgmod_t mod;
+
+/*
+ * A wedged pool would otherwise hang the test suite forever: automake has no
+ * per-test timeout, so the test has to impose its own.
+ */
+static void
+on_alarm(int sig __attribute__((unused)))
+{
+	static const char msg[] = "test-zpool-order: timed out\n";
+
+	if (write(STDERR_FILENO, msg, sizeof(msg) - 1) != sizeof(msg) - 1) {
+		/* Nothing useful to do; we are on our way out regardless. */
+	}
+	_exit(1);
+}
+
+static void
+fail(const char *what)
+{
+	fprintf(stderr, "test-zpool-order: %s\n", what);
+	exit(1);
+}
+
+/*
+ * Payloads are deliberately short. A payload larger than bufsz would take the
+ * fragmenting path, whose fragment id is drawn from the RNG, and the output
+ * would then differ between two identical runs for reasons that have nothing
+ * to do with the pool.
+ */
+static nmsg_message_t
+make_message(unsigned i)
+{
+	char payload[48];
+	nmsg_message_t msg;
+	struct timespec ts;
+	size_t len;
+
+	msg = nmsg_message_init(mod);
+	if (msg == NULL)
+		fail("nmsg_message_init() failed");
+
+	len = snprintf(payload, sizeof(payload), "payload %u", i);
+	if (len >= BUFSZ / 2)
+		fail("payload too large; would fragment");
+
+	if (nmsg_message_set_field(msg, "payload", 0,
+				   (const uint8_t *) payload, len) != nmsg_res_success)
+		fail("nmsg_message_set_field() failed");
+
+	/* Fixed, so two runs cannot differ on the timestamp. */
+	ts.tv_sec = 1000000000 + i;
+	ts.tv_nsec = 0;
+	nmsg_message_set_time(msg, &ts);
+
+	return (msg);
+}
+
+/* Payloads readable from a path right now. */
+static unsigned
+count_payloads(const char *path)
+{
+	nmsg_input_t input;
+	nmsg_message_t msg;
+	unsigned n = 0;
+	int fd;
+
+	fd = open(path, O_RDONLY);
+	if (fd < 0)
+		fail("open() for reading failed");
+
+	input = nmsg_input_open_file(fd);
+	if (input == NULL)
+		fail("nmsg_input_open_file() failed");
+
+	while (nmsg_input_read(input, &msg) == nmsg_res_success) {
+		nmsg_message_destroy(&msg);
+		n += 1;
+	}
+
+	nmsg_input_close(&input);
+	close(fd);
+
+	return (n);
+}
+
+/*
+ * Write the corpus to 'path'.
+ *
+ * workers is the ceiling handed to nmsg_output_set_zlib_workers(). late_enable
+ * defers that call until the stream is already part-written, which is only safe
+ * because the pool seeds itself from the stream's ticket counter. rate throttles
+ * the writer so the committer falls behind and producers have to wait on a slot.
+ */
+static void
+write_corpus(const char *path, unsigned workers, bool late_enable, nmsg_rate_t rate)
+{
+	nmsg_output_t output;
+	unsigned i;
+	int fd;
+
+	fd = open(path, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+	if (fd < 0)
+		fail("open() for writing failed");
+
+	output = nmsg_output_open_file(fd, BUFSZ);
+	if (output == NULL)
+		fail("nmsg_output_open_file() failed");
+
+	nmsg_output_set_buffered(output, true);
+	nmsg_output_set_zlibout(output, true);
+	if (rate != NULL)
+		nmsg_output_set_rate(output, rate);
+	if (!late_enable)
+		nmsg_output_set_zlib_workers(output, workers);
+
+	for (i = 0; i < NUM_PAYLOADS; i++) {
+		nmsg_message_t msg = make_message(i);
+
+		if (nmsg_output_write(output, msg) != nmsg_res_success)
+			fail("nmsg_output_write() failed");
+		nmsg_message_destroy(&msg);
+
+		if (i == LATE_ENABLE_AT) {
+			if (nmsg_output_flush(output) != nmsg_res_success)
+				fail("nmsg_output_flush() failed");
+			if (late_enable)
+				nmsg_output_set_zlib_workers(output, workers);
+		}
+
+		/*
+		 * A flush must leave everything written so far on disk, which
+		 * is the contract every file rotation depends on. Checked while
+		 * the output is still open, so it is the flush being tested and
+		 * not the close.
+		 */
+		if (i == CHECKPOINT_AT) {
+			unsigned seen;
+
+			if (nmsg_output_flush(output) != nmsg_res_success)
+				fail("nmsg_output_flush() failed");
+
+			seen = count_payloads(path);
+			if (seen != i + 1) {
+				fprintf(stderr, "test-zpool-order: flush left "
+					"%u of %u payloads on disk\n", seen, i + 1);
+				exit(1);
+			}
+		}
+	}
+
+	if (nmsg_output_close(&output) != nmsg_res_success)
+		fail("nmsg_output_close() failed");
+}
+
+static void
+compare(const char *ref, const char *path, const char *what)
+{
+	FILE *fa, *fb;
+	int ca, cb;
+	long off = 0;
+
+	fa = fopen(ref, "rb");
+	fb = fopen(path, "rb");
+	if (fa == NULL || fb == NULL)
+		fail("fopen() for comparison failed");
+
+	do {
+		ca = getc(fa);
+		cb = getc(fb);
+		if (ca != cb) {
+			fprintf(stderr, "test-zpool-order: %s differs from the "
+				"inline output at byte %ld\n", what, off);
+			exit(1);
+		}
+		off += 1;
+	} while (ca != EOF);
+
+	fclose(fa);
+	fclose(fb);
+}
+
+int main(void) {
+	static const unsigned counts[] = { 1, 4, 8 };
+	char ref[] = "/tmp/nmsg-zpool-ref.XXXXXX";
+	char out[] = "/tmp/nmsg-zpool-out.XXXXXX";
+	nmsg_rate_t rate;
+	unsigned i;
+	int fd;
+
+	signal(SIGALRM, on_alarm);
+	alarm(30);
+
+	if (nmsg_init() != nmsg_res_success)
+		fail("nmsg_init() failed");
+
+	mod = nmsg_msgmod_lookup_byname("base", "encode");
+	if (mod == NULL)
+		fail("no base:encode message type");
+
+	/* mkstemp() only to get unique names; the writers reopen by path. */
+	fd = mkstemp(ref);
+	if (fd < 0)
+		fail("mkstemp() failed");
+	close(fd);
+	fd = mkstemp(out);
+	if (fd < 0)
+		fail("mkstemp() failed");
+	close(fd);
+
+	/* No pool: the reference every other run has to match. */
+	write_corpus(ref, 0, false, NULL);
+
+	if (count_payloads(ref) != NUM_PAYLOADS)
+		fail("reference output is missing payloads");
+
+	for (i = 0; i < sizeof(counts) / sizeof(counts[0]); i++) {
+		char what[64];
+
+		snprintf(what, sizeof(what), "output with %u worker(s)", counts[i]);
+		write_corpus(out, counts[i], false, NULL);
+		compare(ref, out, what);
+	}
+
+	/* Pool enabled once the stream is already part-written. */
+	write_corpus(out, 4, true, NULL);
+	compare(ref, out, "output with the pool enabled mid-stream");
+
+	/*
+	 * Throttled, so the committer lags and the ring fills. This is the only
+	 * run that reaches the slot wait in container_submit().
+	 */
+	rate = nmsg_rate_init(200, 1);
+	if (rate == NULL)
+		fail("nmsg_rate_init() failed");
+	write_corpus(out, 4, false, rate);
+	compare(ref, out, "rate-limited output");
+	nmsg_rate_destroy(&rate);
+
+	unlink(ref);
+	unlink(out);
+
+	return (0);
+}

--- a/tests/test-zpool-order.c
+++ b/tests/test-zpool-order.c
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include "nmsg.h"
+#include "private.h"
 
 #define NUM_PAYLOADS	4000
 #define BUFSZ		NMSG_WBUFSZ_JUMBO
@@ -61,6 +62,20 @@ on_alarm(int sig __attribute__((unused)))
 	_exit(1);
 }
 
+/* Unlinked however the test ends, so a failure does not litter the tmp dir. */
+static const char *tmp_paths[2];
+
+static void
+unlink_tmp(void)
+{
+	unsigned i;
+
+	for (i = 0; i < sizeof(tmp_paths) / sizeof(tmp_paths[0]); i++) {
+		if (tmp_paths[i] != NULL)
+			unlink(tmp_paths[i]);
+	}
+}
+
 static void
 fail(const char *what)
 {
@@ -81,14 +96,16 @@ make_message(unsigned i)
 	nmsg_message_t msg;
 	struct timespec ts;
 	size_t len;
+	int written;
 
 	msg = nmsg_message_init(mod);
 	if (msg == NULL)
 		fail("nmsg_message_init() failed");
 
-	len = snprintf(payload, sizeof(payload), "payload %u", i);
-	if (len >= BUFSZ / 2)
-		fail("payload too large; would fragment");
+	written = snprintf(payload, sizeof(payload), "payload %u", i);
+	if (written < 0 || (size_t) written >= sizeof(payload))
+		fail("snprintf() failed");
+	len = (size_t) written;
 
 	if (nmsg_message_set_field(msg, "payload", 0,
 				   (const uint8_t *) payload, len) != nmsg_res_success)
@@ -119,13 +136,19 @@ count_payloads(const char *path)
 	if (input == NULL)
 		fail("nmsg_input_open_file() failed");
 
-	while (nmsg_input_read(input, &msg) == nmsg_res_success) {
+	for (;;) {
+		nmsg_res res = nmsg_input_read(input, &msg);
+
+		if (res == nmsg_res_eof)
+			break;
+		if (res != nmsg_res_success)
+			fail("nmsg_input_read() failed");
+
 		nmsg_message_destroy(&msg);
 		n += 1;
 	}
 
-	nmsg_input_close(&input);
-	close(fd);
+	nmsg_input_close(&input);	/* Closes fd; autoclose is the default. */
 
 	return (n);
 }
@@ -195,6 +218,21 @@ write_corpus(const char *path, unsigned workers, bool late_enable, nmsg_rate_t r
 		}
 	}
 
+	/*
+	 * Read before the close, which takes the pool down. Without this every
+	 * assertion below would still hold if the pool had silently failed to
+	 * start and everything had been compressed inline.
+	 */
+	if (workers > 0) {
+		unsigned peak = 0;
+
+		if (output->stream->so_pool == NULL)
+			fail("output has no compressor pool");
+		_output_async_counts(output->stream->so_pool, NULL, &peak, NULL);
+		if (peak == 0)
+			fail("no compressor thread ever ran");
+	}
+
 	if (nmsg_output_close(&output) != nmsg_res_success)
 		fail("nmsg_output_close() failed");
 }
@@ -226,20 +264,24 @@ compare(const char *ref, const char *path, const char *what)
 	fclose(fb);
 }
 
-int main(void) {
+int
+main(void)
+{
 	/*
 	 * 16 asks for a bigger reorder buffer than the rest; libnmsg clamps it
 	 * to what the machine allows, which exercises the clamp either way.
 	 */
 	static const unsigned counts[] = { 1, 4, 8, 16 };
-	char ref[] = "/tmp/nmsg-zpool-ref.XXXXXX";
-	char out[] = "/tmp/nmsg-zpool-out.XXXXXX";
+	/* static: unlink_tmp() runs from atexit(), after this frame is gone. */
+	static char ref[] = "/tmp/nmsg-zpool-ref.XXXXXX";
+	static char out[] = "/tmp/nmsg-zpool-out.XXXXXX";
 	nmsg_rate_t rate;
 	unsigned i;
 	int fd;
 
-	signal(SIGALRM, on_alarm);
-	alarm(30);
+	if (signal(SIGALRM, on_alarm) == SIG_ERR)
+		fail("signal() failed");
+	alarm(600);
 
 	if (nmsg_init() != nmsg_res_success)
 		fail("nmsg_init() failed");
@@ -253,10 +295,15 @@ int main(void) {
 	if (fd < 0)
 		fail("mkstemp() failed");
 	close(fd);
+	tmp_paths[0] = ref;
+
 	fd = mkstemp(out);
 	if (fd < 0)
 		fail("mkstemp() failed");
 	close(fd);
+	tmp_paths[1] = out;
+
+	atexit(unlink_tmp);
 
 	/* No pool: the reference every other run has to match. */
 	write_corpus(ref, 0, false, NULL);
@@ -286,9 +333,6 @@ int main(void) {
 	write_corpus(out, 4, false, rate);
 	compare(ref, out, "rate-limited output");
 	nmsg_rate_destroy(&rate);
-
-	unlink(ref);
-	unlink(out);
 
 	return (0);
 }

--- a/tests/test-zpool-order.c
+++ b/tests/test-zpool-order.c
@@ -20,8 +20,9 @@
  * every resulting file has to be byte for byte identical.
  *
  * A small bufsz is what makes this worth running: it puts many more containers
- * in the file than a 1 MiB one would, so the slot ring wraps repeatedly and
- * producers exercise the path where every worker is busy.
+ * in the file than a 1 MiB one would, so the reorder buffer wraps repeatedly
+ * and producers exercise the path where every worker is busy. The worker counts
+ * below span both buffer sizes, since the depth is derived from them.
  */
 
 #include <sys/stat.h>
@@ -226,7 +227,11 @@ compare(const char *ref, const char *path, const char *what)
 }
 
 int main(void) {
-	static const unsigned counts[] = { 1, 4, 8 };
+	/*
+	 * 16 asks for a bigger reorder buffer than the rest; libnmsg clamps it
+	 * to what the machine allows, which exercises the clamp either way.
+	 */
+	static const unsigned counts[] = { 1, 4, 8, 16 };
 	char ref[] = "/tmp/nmsg-zpool-ref.XXXXXX";
 	char out[] = "/tmp/nmsg-zpool-out.XXXXXX";
 	nmsg_rate_t rate;
@@ -272,8 +277,8 @@ int main(void) {
 	compare(ref, out, "output with the pool enabled mid-stream");
 
 	/*
-	 * Throttled, so the committer lags and the ring fills. This is the only
-	 * run that reaches the slot wait in container_submit().
+	 * Throttled, so the committer lags and the reorder buffer fills. This is
+	 * the only run that reaches the slot wait in _output_async_submit().
 	 */
 	rate = nmsg_rate_init(200, 1);
 	if (rate == NULL)


### PR DESCRIPTION
## Change
`nmsgtool -z` compresses on the reader thread. While zlib runs, nothing drains the
socket. A single reader tops out before the kernel receive queue overflows and payloads are lost. 
`--zasync` moves compression onto worker threads
and puts the writes back in order behind one committer thread.

## Using it
```
--zasync n      up to n compressor threads (-1 chooses, 0 off — the default)
--zcull secs    give up a compressor idle this long (300; 0 never)
--zmin n        never cull below n compressors (1; 0 lets the pool empty)
```

## Replace zlib with zlib-ng
```
default:              libz.so.1 => /usr/lib/x86_64-linux-gnu/libz.so.1
LD_LIBRARY_PATH=<ng>: libz.so.1 => .../zlib-ng-233/lib/libz.so.1
```

[Related Confluence Page](https://domaintools.atlassian.net/wiki/x/SwBhRwE)